### PR TITLE
Provide a way to mark android devices optional

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -207,8 +207,15 @@ def get_instances_with_configs(configs):
             raise Error(
                 "Required value 'serial' is missing in AndroidDevice config %s."
                 % c)
-        ad = AndroidDevice(serial)
-        ad.load_config(c)
+        is_required = c.pop("required", True)
+        try:
+            ad = AndroidDevice(serial)
+            ad.load_config(c)
+        except:
+            if not is_required:
+                logging.warning("Failed to initialize Android device %s", serial)
+                continue
+            raise
         results.append(ad)
     return results
 

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -33,10 +33,15 @@ from mobly.controllers.android_device_lib import sl4a_client
 MOBLY_CONTROLLER_CONFIG_NAME = "AndroidDevice"
 
 ANDROID_DEVICE_PICK_ALL_TOKEN = "*"
+
 # Key name for adb logcat extra params in config file.
 ANDROID_DEVICE_ADB_LOGCAT_PARAM_KEY = "adb_logcat_param"
 ANDROID_DEVICE_EMPTY_CONFIG_MSG = "Configuration is empty, abort!"
 ANDROID_DEVICE_NOT_LIST_CONFIG_MSG = "Configuration should be a list, abort!"
+
+# Keys for attributes in configs that alternate device behavior
+KEY_SKIP_SL4A = "skip_sl4a"
+KEY_DEVICE_REQUIRED = "required"
 
 
 class Error(signals.ControllerError):
@@ -123,11 +128,16 @@ def _start_services_on_ads(ads):
     for ad in ads:
         running_ads.append(ad)
         try:
-            ad.start_services(skip_sl4a=getattr(ad, "skip_sl4a", False))
-        except:
-            ad.log.exception("Failed to start some services, abort!")
-            destroy(running_ads)
-            raise
+            ad.start_services(skip_sl4a=getattr(ad, KEY_SKIP_SL4A, False))
+        except Exception as e:
+            is_required = getattr(ad, KEY_DEVICE_REQUIRED, True)
+            if is_required:
+                ad.log.exception("Failed to start some services, abort!")
+                destroy(running_ads)
+                raise
+            else:
+                logging.warning("Failed to start some service on %s: %s",
+                                ad.serial, e)
 
 
 def _parse_device_list(device_list_str, key):
@@ -207,15 +217,16 @@ def get_instances_with_configs(configs):
             raise Error(
                 "Required value 'serial' is missing in AndroidDevice config %s."
                 % c)
-        is_required = c.pop("required", True)
+        is_required = c.get(KEY_DEVICE_REQUIRED, True)
         try:
             ad = AndroidDevice(serial)
             ad.load_config(c)
-        except:
-            if not is_required:
-                logging.warning("Failed to initialize Android device %s", serial)
-                continue
-            raise
+        except Exception as e:
+            if is_required:
+                raise
+            logging.warning("Failed to initialize optional device %s: %s",
+                            serial, e)
+            continue
         results.append(ad)
     return results
 

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -136,8 +136,8 @@ def _start_services_on_ads(ads):
                 destroy(running_ads)
                 raise
             else:
-                logging.warning("Failed to start some service on %s: %s",
-                                ad.serial, e)
+                logging.warning(("Skipping device %s because some service "
+                                 "failed to start: %s"), ad.serial, e)
 
 
 def _parse_device_list(device_list_str, key):
@@ -224,8 +224,7 @@ def get_instances_with_configs(configs):
         except Exception as e:
             if is_required:
                 raise
-            logging.warning("Failed to initialize optional device %s: %s",
-                            serial, e)
+            logging.warning("Skipping device %s due to error: %s", serial, e)
             continue
         results.append(ad)
     return results


### PR DESCRIPTION
Sometimes users want to continue the test even when some Android devices in a test bed are not operable.
So here we provide an option to allow the test to execute even if some Android controller objects failed to instantiate.