### PR TITLE
Update test error report/handling.

### DIFF
--- a/mobly/records.py
+++ b/mobly/records.py
@@ -44,7 +44,7 @@ class TestResultEnums(object):
     TEST_RESULT_PASS = "PASS"
     TEST_RESULT_FAIL = "FAIL"
     TEST_RESULT_SKIP = "SKIP"
-    TEST_RESULT_UNKNOWN = "UNKNOWN"
+    TEST_RESULT_ERROR = "ERROR"
 
 
 class TestResultRecord(object):
@@ -90,7 +90,7 @@ class TestResultRecord(object):
         self.end_time = utils.get_current_epoch_time()
         self.result = result
         if self.extra_errors:
-            self.result = TestResultEnums.TEST_RESULT_UNKNOWN
+            self.result = TestResultEnums.TEST_RESULT_ERROR
         if isinstance(e, signals.TestSignal):
             self.details = e.details
             self.extras = e.extras
@@ -125,17 +125,17 @@ class TestResultRecord(object):
         """
         self._test_end(TestResultEnums.TEST_RESULT_SKIP, e)
 
-    def test_unknown(self, e=None):
-        """To mark the test as unknown in this record.
+    def test_error(self, e=None):
+        """To mark the test as error in this record.
 
         Args:
             e: An exception object.
         """
-        self._test_end(TestResultEnums.TEST_RESULT_UNKNOWN, e)
+        self._test_end(TestResultEnums.TEST_RESULT_ERROR, e)
 
     def add_error(self, tag, e):
         """Add extra error happened during a test mark the test result as
-        UNKNOWN.
+        ERROR.
 
         If an error is added the test record, the record's result is equivalent
         to the case where an uncaught exception happened.
@@ -144,7 +144,7 @@ class TestResultRecord(object):
             tag: A string describing where this error came from, e.g. 'on_pass'.
             e: An exception object.
         """
-        self.result = TestResultEnums.TEST_RESULT_UNKNOWN
+        self.result = TestResultEnums.TEST_RESULT_ERROR
         self.extra_errors[tag] = str(e)
 
     def __str__(self):
@@ -205,7 +205,7 @@ class TestResult(object):
         self.executed: A list of records for tests that were actually executed.
         self.passed: A list of records for tests passed.
         self.skipped: A list of records for tests skipped.
-        self.unknown: A list of records for tests with unknown result token.
+        self.error: A list of records for tests with error result token.
     """
 
     def __init__(self):
@@ -214,7 +214,7 @@ class TestResult(object):
         self.executed = []
         self.passed = []
         self.skipped = []
-        self.unknown = []
+        self.error = []
         self.controller_info = {}
 
     def __add__(self, r):
@@ -262,7 +262,7 @@ class TestResult(object):
         elif record.result == TestResultEnums.TEST_RESULT_PASS:
             self.passed.append(record)
         else:
-            self.unknown.append(record)
+            self.error.append(record)
 
     def add_controller_info(self, name, info):
         try:
@@ -287,7 +287,7 @@ class TestResult(object):
     @property
     def is_all_pass(self):
         """True if no tests failed or threw errors, False otherwise."""
-        num_of_failures = len(self.failed) + len(self.unknown)
+        num_of_failures = len(self.failed) + len(self.error)
         if num_of_failures == 0:
             return True
         return False
@@ -347,5 +347,5 @@ class TestResult(object):
         d["Passed"] = len(self.passed)
         d["Failed"] = len(self.failed)
         d["Skipped"] = len(self.skipped)
-        d["Unknown"] = len(self.unknown)
+        d["Error"] = len(self.error)
         return d

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -160,8 +160,8 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, "setup_class")
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 1, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 0")
+        expected_summary = ("Error 0, Executed 1, Failed 1, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
         call_check.assert_called_once_with("haha")
 
@@ -174,12 +174,12 @@ class BaseTestTest(unittest.TestCase):
                 never_call()
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run(test_names=["test_something"])
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_setup_test_fail_by_test_signal(self):
@@ -195,8 +195,8 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 1, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 0")
+        expected_summary = ("Error 0, Executed 1, Failed 1, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_setup_test_fail_by_return_False(self):
@@ -225,12 +225,12 @@ class BaseTestTest(unittest.TestCase):
                 pass
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertIsNone(actual_record.details)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_teardown_test_raise_exception(self):
@@ -241,14 +241,14 @@ class BaseTestTest(unittest.TestCase):
                 pass
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertIsNone(actual_record.details)
         self.assertIsNone(actual_record.extras)
         expected_extra_error = {"teardown_test": MSG_EXPECTED_EXCEPTION}
         self.assertEqual(actual_record.extra_errors, expected_extra_error)
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_teardown_test_executed_if_test_pass(self):
@@ -265,8 +265,8 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertIsNone(actual_record.details)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 0, Passed 1, Requested 1, "
-                            "Skipped 0, Unknown 0")
+        expected_summary = ("Error 0, Executed 1, Failed 0, Passed 1, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_teardown_test_executed_if_setup_test_fails(self):
@@ -280,13 +280,13 @@ class BaseTestTest(unittest.TestCase):
                 pass
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         my_mock.assert_called_once_with("teardown_test")
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_teardown_test_executed_if_test_fails(self):
@@ -298,33 +298,33 @@ class BaseTestTest(unittest.TestCase):
                 raise Exception(MSG_EXPECTED_EXCEPTION)
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         my_mock.assert_called_once_with("teardown_test")
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
-    def test_on_exception_executed_if_teardown_test_fails(self):
+    def test_on_fail_executed_if_teardown_test_fails(self):
         my_mock = mock.MagicMock()
         class MockBaseTest(base_test.BaseTestClass):
-            def on_exception(self, test_name, begin_time):
-                my_mock("on_exception")
+            def on_fail(self, test_name, begin_time):
+                my_mock("on_fail")
             def teardown_test(self):
                 raise Exception(MSG_EXPECTED_EXCEPTION)
             def test_something(self):
                 pass
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        my_mock.assert_called_once_with("on_exception")
-        actual_record = bt_cls.results.unknown[0]
+        my_mock.assert_called_once_with("on_fail")
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertIsNone(actual_record.details)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_on_fail_executed_if_test_fails(self):
@@ -341,8 +341,8 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 1, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 0")
+        expected_summary = ("Error 0, Executed 1, Failed 1, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_on_fail_executed_if_test_setup_fails_by_exception(self):
@@ -357,12 +357,12 @@ class BaseTestTest(unittest.TestCase):
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
         my_mock.assert_called_once_with("on_fail")
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_on_fail_executed_if_test_setup_fails_by_return_False(self):
@@ -393,13 +393,13 @@ class BaseTestTest(unittest.TestCase):
                 asserts.assert_true(False, MSG_EXPECTED_EXCEPTION)
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertIn('_on_fail', actual_record.extra_errors)
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_failure_in_procedure_functions_is_recorded(self):
@@ -411,14 +411,14 @@ class BaseTestTest(unittest.TestCase):
                 asserts.explicit_pass(MSG_EXPECTED_EXCEPTION)
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         expected_extra_error = {'_on_pass': expected_msg}
         self.assertEqual(actual_record.extra_errors, expected_extra_error)
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_both_teardown_and_test_body_raise_exceptions(self):
@@ -429,18 +429,18 @@ class BaseTestTest(unittest.TestCase):
                 raise Exception("Test Body Exception.")
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, "Test Body Exception.")
         self.assertIsNone(actual_record.extras)
         self.assertEqual(actual_record.extra_errors["teardown_test"],
                          "Details=This is an expected exception., Extras=None")
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_explicit_pass_but_teardown_test_raises_an_exception(self):
-        """Test record result should be marked as UNKNOWN as opposed to PASS.
+        """Test record result should be marked as ERROR as opposed to PASS.
         """
         class MockBaseTest(base_test.BaseTestClass):
             def teardown_test(self):
@@ -449,14 +449,14 @@ class BaseTestTest(unittest.TestCase):
                 asserts.explicit_pass("Test Passed!")
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, "Test Passed!")
         self.assertIsNone(actual_record.extras)
         self.assertEqual(actual_record.extra_errors["teardown_test"],
                          "Details=This is an expected exception., Extras=None")
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_on_pass_raise_exception(self):
@@ -467,14 +467,14 @@ class BaseTestTest(unittest.TestCase):
                 asserts.explicit_pass(MSG_EXPECTED_EXCEPTION, extras=MOCK_EXTRA)
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertEqual(actual_record.extras, MOCK_EXTRA)
         self.assertEqual(actual_record.extra_errors,
                          {'_on_pass': MSG_EXPECTED_EXCEPTION})
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_on_fail_raise_exception(self):
@@ -485,15 +485,15 @@ class BaseTestTest(unittest.TestCase):
                 asserts.fail(MSG_EXPECTED_EXCEPTION, extras=MOCK_EXTRA)
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(bt_cls.results.failed, [])
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertEqual(actual_record.extras, MOCK_EXTRA)
         self.assertEqual(actual_record.extra_errors,
                          {'_on_fail': MSG_EXPECTED_EXCEPTION})
-        expected_summary = ("Executed 1, Failed 0, Passed 0, Requested 1, "
-                            "Skipped 0, Unknown 1")
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+                            "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
     def test_abort_class(self):
@@ -512,8 +512,8 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(bt_cls.results.failed[0].details,
                          MSG_EXPECTED_EXCEPTION)
         self.assertEqual(bt_cls.results.summary_str(),
-                         ("Executed 2, Failed 1, Passed 1, Requested 3, "
-                          "Skipped 0, Unknown 0"))
+                         ("Error 0, Executed 2, Failed 1, Passed 1, "
+                          "Requested 3, Skipped 0"))
 
     def test_uncaught_exception(self):
         class MockBaseTest(base_test.BaseTestClass):
@@ -522,7 +522,7 @@ class BaseTestTest(unittest.TestCase):
                 never_call()
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run(test_names=["test_func"])
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, "test_func")
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
@@ -618,7 +618,7 @@ class BaseTestTest(unittest.TestCase):
                     raise AttributeError(MSG_UNEXPECTED_EXCEPTION)
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, "test_func")
         self.assertEqual(actual_record.details, MSG_UNEXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
@@ -681,7 +681,7 @@ class BaseTestTest(unittest.TestCase):
                     raise AttributeError(MSG_UNEXPECTED_EXCEPTION)
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.unknown[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, "test_func")
         self.assertEqual(actual_record.details, MSG_UNEXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -234,7 +234,7 @@ class RecordsTest(unittest.TestCase):
         record1.test_fail(s)
         record2 = records.TestResultRecord(self.tn)
         record2.test_begin()
-        record2.test_unknown(s)
+        record2.test_error(s)
         tr = records.TestResult()
         tr.add_record(record1)
         tr.add_record(record2)


### PR DESCRIPTION
Use on_fail for both test failure and uncaught exceptions. So tests
    don't have to call the same logic twice to cover all not-pass test
    status.

    Rename test result 'UNKNOWN' to 'ERROR" to represent uncaught error
    occured in test for clariy.