### PR TITLE
Dropping code paths for importing test class files in test_runner.

### DIFF
--- a/mobly/config_parser.py
+++ b/mobly/config_parser.py
@@ -25,10 +25,6 @@ from mobly import utils
 # An environment variable defining the base location for Mobly logs.
 _ENV_MOBLY_LOGPATH = 'MOBLY_LOGPATH'
 
-# An environment variable defining the test search paths for Mobly.
-_ENV_MOBLY_TESTPATHS = 'MOBLY_TESTPATHS'
-_PATH_SEPARATOR = ':'
-
 
 class MoblyConfigError(Exception):
     """Raised when there is a problem in test configuration file."""
@@ -190,12 +186,6 @@ def load_test_config_file(test_config_path, tb_filters=None):
         print('Using environment log path: %s' %
               (os.environ[_ENV_MOBLY_LOGPATH]))
         configs[keys.Config.key_log_path.value] = os.environ[_ENV_MOBLY_LOGPATH]
-    if (not keys.Config.key_test_paths.value in configs and
-            _ENV_MOBLY_TESTPATHS in os.environ):
-        print('Using environment test paths: %s' %
-              (os.environ[_ENV_MOBLY_TESTPATHS]))
-        configs[keys.Config.key_test_paths.value] = os.environ[
-            _ENV_MOBLY_TESTPATHS].split(_PATH_SEPARATOR)
 
     _validate_test_config(configs)
     _validate_testbed_configs(configs[keys.Config.key_testbed.value])
@@ -203,7 +193,6 @@ def load_test_config_file(test_config_path, tb_filters=None):
     configs[k_log_path] = utils.abs_path(configs[k_log_path])
     config_path, _ = os.path.split(utils.abs_path(test_config_path))
     configs[keys.Config.key_config_path] = config_path
-    tps = configs[keys.Config.key_test_paths.value]
     # Unpack testbeds into separate json objects.
     beds = configs.pop(keys.Config.key_testbed.value)
     config_jsons = []

--- a/mobly/keys.py
+++ b/mobly/keys.py
@@ -30,7 +30,6 @@ class Config(enum.Enum):
     key_testbed = "testbed"
     key_testbed_name = "name"
     key_config_path = "configpath"
-    key_test_paths = "testpaths"
     key_port = "Port"
     key_address = "Address"
     # Internal keys, used internally, not exposed to user's config files.
@@ -42,7 +41,7 @@ class Config(enum.Enum):
 
     # A list of keys whose values in configs should not be passed to test
     # classes without unpacking first.
-    reserved_keys = (key_testbed, key_log_path, key_test_paths)
+    reserved_keys = (key_testbed, key_log_path)
 
 
 def get_name_by_value(value):

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -25,6 +25,7 @@ from mobly import test_runner
 
 from tests.lib import mock_android_device
 from tests.lib import mock_controller
+from tests.lib import IntegrationTest
 
 
 class TestRunnerTest(unittest.TestCase):
@@ -134,11 +135,11 @@ class TestRunnerTest(unittest.TestCase):
         mock_test_config[tb_key][mock_ctrlr_config_name] = my_config
         tr = test_runner.TestRunner(mock_test_config, [('IntegrationTest',
                                                         None)])
-        tr.run()
+        tr.run([IntegrationTest.IntegrationTest])
         self.assertFalse(tr.controller_registry)
         self.assertFalse(tr.controller_destructors)
         self.assertTrue(mock_test_config[tb_key][mock_ctrlr_config_name][0])
-        tr.run()
+        tr.run([IntegrationTest.IntegrationTest])
         tr.stop()
         self.assertFalse(tr.controller_registry)
         self.assertFalse(tr.controller_destructors)
@@ -179,7 +180,7 @@ class TestRunnerTest(unittest.TestCase):
         tr = test_runner.TestRunner(mock_test_config,
                                     [('IntegrationTest', None),
                                      ('IntegrationTest', None)])
-        tr.run()
+        tr.run([IntegrationTest.IntegrationTest])
         tr.stop()
         self.assertFalse(tr.controller_registry)
         self.assertFalse(tr.controller_destructors)

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -28,6 +28,12 @@ from tests.lib import mock_controller
 from tests.lib import IntegrationTest
 
 
+class Integration2Test(IntegrationTest.IntegrationTest):
+    """Same as the IntegrationTest class, created this so we have two
+    'different' test classes to use in unit tests.
+    """
+
+
 class TestRunnerTest(unittest.TestCase):
     """This test class has unit tests for the implementation of everything
     under mobly.test_runner.
@@ -178,9 +184,10 @@ class TestRunnerTest(unittest.TestCase):
              "skip_sl4a": True}
         ]
         tr = test_runner.TestRunner(mock_test_config,
-                                    [('IntegrationTest', None),
+                                    [('Integration2Test', None),
                                      ('IntegrationTest', None)])
-        tr.run([IntegrationTest.IntegrationTest])
+        tr.run([IntegrationTest.IntegrationTest,
+                Integration2Test])
         tr.stop()
         self.assertFalse(tr.controller_registry)
         self.assertFalse(tr.controller_destructors)


### PR DESCRIPTION
This includes:
* Remove mobly.test_runner.TestRunner.import_test_modules
* Remove the need for key 'testpaths'
* Refactor code to accommodate the removals. (cleaner code)

fixes #21 
fixes #5 