### PR TITLE
Rename sl4a_client to sl4a_shell.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def main():
         license='Apache2.0',
         packages=setuptools.find_packages(),
         include_package_data=False,
-        scripts=['tools/sl4a_client.py'],
+        scripts=['tools/sl4a_shell.py'],
         tests_require=['pytest'],
         install_requires=install_requires,
         cmdclass={'test': PyTest},

--- a/tools/sl4a_shell.py
+++ b/tools/sl4a_shell.py
@@ -29,7 +29,7 @@ actions. For more information see the Mobly codelab:
 https://github.com/google/mobly#event-dispatcher
 
 Usage:
-$ sl4a_client
+$ sl4a_shell
 >>> s.getBuildID()
 u'N2F52'
 """


### PR DESCRIPTION
This avoids confusion with the sl4a_client lib.