### PR TITLE
Improve snippet client management.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -40,6 +40,9 @@ ANDROID_DEVICE_ADB_LOGCAT_PARAM_KEY = "adb_logcat_param"
 ANDROID_DEVICE_EMPTY_CONFIG_MSG = "Configuration is empty, abort!"
 ANDROID_DEVICE_NOT_LIST_CONFIG_MSG = "Configuration should be a list, abort!"
 
+SNIPPET_KEY_CLIENT = 'client'
+SNIPPET_KEY_PACKAGE = 'name'
+
 # Keys for attributes in configs that alternate device behavior
 KEY_SKIP_SL4A = "skip_sl4a"
 KEY_DEVICE_REQUIRED = "required"
@@ -47,6 +50,10 @@ KEY_DEVICE_REQUIRED = "required"
 
 class Error(signals.ControllerError):
     pass
+
+
+class SnippetError(signals.ControllerError):
+    """Raised when somethig wrong with snippet happens."""
 
 
 class DoesNotExistError(Error):
@@ -366,7 +373,8 @@ class AndroidDevice(object):
         self.fastboot = fastboot.FastbootProxy(serial)
         if not self.is_bootloader and self.is_rootable:
             self.root_adb()
-        self._snippet_clients = []
+        # A dict for tracking snippet clients
+        self._snippet_clients = {}
 
     def set_logger_prefix_tag(self, tag):
         """Set a tag for the log line prefix of this instance.
@@ -413,9 +421,11 @@ class AndroidDevice(object):
         if self._adb_logcat_process:
             self.stop_adb_logcat()
         self._terminate_sl4a()
-        for client in self._snippet_clients:
+        for name in list(self._snippet_clients.keys()):
+            client = self._snippet_clients[name][SNIPPET_KEY_CLIENT]
             self._terminate_jsonrpc_client(client)
-        self._snippet_clients = []
+            delattr(self, name)
+        self._snippet_clients = {}
 
     @property
     def build_info(self):
@@ -492,9 +502,8 @@ class AndroidDevice(object):
         """
         for k, v in config.items():
             if hasattr(self, k):
-                raise Error(
-                    "Attempting to set existing attribute %s on %s" %
-                    (k, self.serial))
+                raise Error("Attempting to set existing attribute %s on %s" %
+                            (k, self.serial))
             setattr(self, k, v)
 
     def root_adb(self):
@@ -509,18 +518,38 @@ class AndroidDevice(object):
     def load_snippet(self, name, package):
         """Starts the snippet apk with the given package name and connects.
 
-        Args:
-          name: The attribute name to which to attach the snippet server.
-            e.g. name='maps' will attach the snippet server to ad.maps.
-          package: The package name defined in AndroidManifest.xml of the
-            snippet apk.
-
         Examples:
             >>> ad = AndroidDevice()
             >>> ad.load_snippet(
                     name='maps', package='com.google.maps.snippets')
             >>> ad.maps.activateZoom('3')
+
+        Args:
+            name: The attribute name to which to attach the snippet server.
+                  e.g. name='maps' will attach the snippet server to ad.maps.
+            package: The package name defined in AndroidManifest.xml of the
+                     snippet apk.
+
+        Raises:
+            SnippetError is raised if illegal load operations are attempted.
         """
+        # Should not load snippet with the same attribute more than once.
+        if name in self._snippet_clients:
+            raise SnippetError(
+                ('Attribute "%s" is already registered with '
+                 'package "%s", it cannot be used again.') % (
+                     name, self._snippet_clients[name][SNIPPET_KEY_PACKAGE]))
+        # Should not load snippet with an existing attribute.
+        if hasattr(self, name):
+            raise SnippetError(
+                'Attribute "%s" already exists, please use a different name.' %
+                name)
+        # Should not load the same snippet package more than once.
+        for client_name, client_info in self._snippet_clients.items():
+            if package == client_info[SNIPPET_KEY_PACKAGE]:
+                raise SnippetError(
+                    'Snippet package "%s" has already been loaded under name "%s".'
+                    % (package, client_name))
         host_port = utils.get_available_host_port()
         # TODO(adorokhine): Don't assume that a free host-side port is free on
         # the device as well. Both sides should allocate a unique port.
@@ -528,7 +557,10 @@ class AndroidDevice(object):
         client = snippet_client.SnippetClient(
             package=package, port=host_port, adb_proxy=self.adb)
         self._start_jsonrpc_client(client, host_port, device_port)
-        self._snippet_clients.append(client)
+        self._snippet_clients[name] = {
+            SNIPPET_KEY_CLIENT: client,
+            SNIPPET_KEY_PACKAGE: package
+        }
         setattr(self, name, client)
 
     def _start_sl4a(self):
@@ -548,7 +580,8 @@ class AndroidDevice(object):
         # Start an EventDispatcher for the current sl4a session
         event_client = sl4a_client.Sl4aClient(self.adb)
         event_client.connect(
-            port=host_port, uid=self.sl4a.uid,
+            port=host_port,
+            uid=self.sl4a.uid,
             cmd=jsonrpc_client_base.JsonRpcCommand.CONTINUE)
         self.ed = event_dispatcher.EventDispatcher(event_client)
         self.ed.start()
@@ -577,7 +610,8 @@ class AndroidDevice(object):
         self.adb.forward("--remove tcp:%d" % client.port)
 
     def _is_timestamp_in_range(self, target, begin_time, end_time):
-        low = mobly_logger.logline_timestamp_comparator(begin_time, target) <= 0
+        low = mobly_logger.logline_timestamp_comparator(begin_time,
+                                                        target) <= 0
         high = mobly_logger.logline_timestamp_comparator(end_time, target) >= 0
         return low and high
 
@@ -636,8 +670,8 @@ class AndroidDevice(object):
         """
         if self._adb_logcat_process:
             raise Error(
-              'Android device %s already has an adb logcat thread going on. '
-              'Cannot start another one.' % self.serial)
+                'Android device %s already has an adb logcat thread going on. '
+                'Cannot start another one.' % self.serial)
         # Disable adb log spam filter for rootable. Have to stop and clear
         # settings first because 'start' doesn't support --clear option before
         # Android N.
@@ -697,7 +731,7 @@ class AndroidDevice(object):
             out = self.adb.shell("bugreportz").decode("utf-8")
             if not out.startswith("OK"):
                 raise Error("Failed to take bugreport on %s: %s" %
-                                         (self.serial, out))
+                            (self.serial, out))
             br_out_path = out.split(':')[1].strip()
             self.adb.pull("%s %s" % (br_out_path, full_out_path))
         else:
@@ -796,6 +830,7 @@ class AndroidDeviceLoggerAdapter(logging.LoggerAdapter):
         Then each log line added by my_log will have a prefix
         "[AndroidDevice|<tag>]"
     """
+
     def process(self, msg, kwargs):
         msg = "[AndroidDevice|%s] %s" % (self.extra["tag"], msg)
         return (msg, kwargs)

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -418,8 +418,7 @@ class AndroidDevice(object):
         if self._adb_logcat_process:
             self.stop_adb_logcat()
         self._terminate_sl4a()
-        for name in list(self._snippet_clients.keys()):
-            client = self._snippet_clients[name]
+        for name, client in self._snippet_clients.items():
             self._terminate_jsonrpc_client(client)
             delattr(self, name)
         self._snippet_clients = {}

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -370,7 +370,8 @@ class AndroidDevice(object):
         self.fastboot = fastboot.FastbootProxy(serial)
         if not self.is_bootloader and self.is_rootable:
             self.root_adb()
-        # A dict for tracking snippet clients
+        # A dict for tracking snippet clients. Keys are clients' attribute
+        # names, values are the clients: {<attr name string>: <client object>}.
         self._snippet_clients = {}
 
     def set_logger_prefix_tag(self, tag):

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -535,7 +535,7 @@ class AndroidDevice(object):
             raise SnippetError(
                 ('Attribute "%s" is already registered with '
                  'package "%s", it cannot be used again.') % (
-                     name, self._snippet_clients[name].app_name))
+                     name, self._snippet_clients[name].package))
         # Should not load snippet with an existing attribute.
         if hasattr(self, name):
             raise SnippetError(
@@ -543,7 +543,7 @@ class AndroidDevice(object):
                 name)
         # Should not load the same snippet package more than once.
         for client_name, client in self._snippet_clients.items():
-            if package == client.app_name:
+            if package == client.package:
                 raise SnippetError(
                     'Snippet package "%s" has already been loaded under name "%s".'
                     % (package, client_name))

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -40,9 +40,6 @@ ANDROID_DEVICE_ADB_LOGCAT_PARAM_KEY = "adb_logcat_param"
 ANDROID_DEVICE_EMPTY_CONFIG_MSG = "Configuration is empty, abort!"
 ANDROID_DEVICE_NOT_LIST_CONFIG_MSG = "Configuration should be a list, abort!"
 
-SNIPPET_KEY_CLIENT = 'client'
-SNIPPET_KEY_PACKAGE = 'name'
-
 # Keys for attributes in configs that alternate device behavior
 KEY_SKIP_SL4A = "skip_sl4a"
 KEY_DEVICE_REQUIRED = "required"
@@ -422,7 +419,7 @@ class AndroidDevice(object):
             self.stop_adb_logcat()
         self._terminate_sl4a()
         for name in list(self._snippet_clients.keys()):
-            client = self._snippet_clients[name][SNIPPET_KEY_CLIENT]
+            client = self._snippet_clients[name]
             self._terminate_jsonrpc_client(client)
             delattr(self, name)
         self._snippet_clients = {}
@@ -538,15 +535,15 @@ class AndroidDevice(object):
             raise SnippetError(
                 ('Attribute "%s" is already registered with '
                  'package "%s", it cannot be used again.') % (
-                     name, self._snippet_clients[name][SNIPPET_KEY_PACKAGE]))
+                     name, self._snippet_clients[name].app_name))
         # Should not load snippet with an existing attribute.
         if hasattr(self, name):
             raise SnippetError(
                 'Attribute "%s" already exists, please use a different name.' %
                 name)
         # Should not load the same snippet package more than once.
-        for client_name, client_info in self._snippet_clients.items():
-            if package == client_info[SNIPPET_KEY_PACKAGE]:
+        for client_name, client in self._snippet_clients.items():
+            if package == client.app_name:
                 raise SnippetError(
                     'Snippet package "%s" has already been loaded under name "%s".'
                     % (package, client_name))
@@ -557,10 +554,7 @@ class AndroidDevice(object):
         client = snippet_client.SnippetClient(
             package=package, port=host_port, adb_proxy=self.adb)
         self._start_jsonrpc_client(client, host_port, device_port)
-        self._snippet_clients[name] = {
-            SNIPPET_KEY_CLIENT: client,
-            SNIPPET_KEY_PACKAGE: package
-        }
+        self._snippet_clients[name] = client
         setattr(self, name, client)
 
     def _start_sl4a(self):

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -50,6 +50,10 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         self._package = package
         self._port = port
 
+    @property
+    def package(self):
+        return self._package
+
     def _do_start_app(self):
         """Overrides superclass."""
         cmd = _LAUNCH_CMD.format(self._port, self._package)
@@ -62,7 +66,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         logging.info('Stopping snippet apk with: %s', cmd)
         out = self._adb.shell(_STOP_CMD.format(self._package)).decode('utf-8')
         if 'OK (0 tests)' not in out:
-            raise Error('Failed to stop existing apk. Unexpected output: ' +
+            raise Error('Failed to stop existing apk. Unexpected output: %s' %
                         out)
 
     def _is_app_installed(self):

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -42,6 +42,10 @@ MOCK_ADB_LOGCAT_BEGIN_TIME = "02-29 14:02:20.123"
 MOCK_ADB_LOGCAT_END_TIME = "02-29 14:02:22.000"
 MOCK_SNIPPET_PACKAGE_NAME = "com.my.snippet"
 
+# A mock SnippetClient used for testing snippet management logic.
+MockSnippetClient = mock.MagicMock()
+MockSnippetClient.app_name = MOCK_SNIPPET_PACKAGE_NAME
+
 
 class AndroidDeviceTest(unittest.TestCase):
     """This test class has unit tests for the implementation of everything
@@ -357,7 +361,8 @@ class AndroidDeviceTest(unittest.TestCase):
                 return_value=mock_android_device.MockAdbProxy(1))
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
                 return_value=mock_android_device.MockFastbootProxy(1))
-    @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
+    @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient',
+                return_value=MockSnippetClient)
     @mock.patch('mobly.utils.get_available_host_port')
     def test_AndroidDevice_load_snippet_dup_package(
         self, MockGetPort, MockSnippetClient, MockFastboot, MockAdbProxy):
@@ -373,7 +378,8 @@ class AndroidDeviceTest(unittest.TestCase):
                 return_value=mock_android_device.MockAdbProxy(1))
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
                 return_value=mock_android_device.MockFastbootProxy(1))
-    @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
+    @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient',
+                return_value=MockSnippetClient)
     @mock.patch('mobly.utils.get_available_host_port')
     def test_AndroidDevice_load_snippet_dup_snippet_name(
         self, MockGetPort, MockSnippetClient, MockFastboot, MockAdbProxy):

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -346,8 +346,9 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
                 return_value=mock_android_device.MockFastbootProxy(1))
     @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
-    def test_AndroidDevice_load_snippet(self, MockSnippetClient, MockFastboot,
-                                        MockAdbProxy):
+    @mock.patch('mobly.utils.get_available_host_port')
+    def test_AndroidDevice_load_snippet(
+        self, MockGetPort, MockSnippetClient, MockFastboot, MockAdbProxy):
         ad = android_device.AndroidDevice(serial=1)
         ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME)
         self.assertTrue(hasattr(ad, 'snippet'))
@@ -357,8 +358,9 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
                 return_value=mock_android_device.MockFastbootProxy(1))
     @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
-    def test_AndroidDevice_load_snippet_dup_package(self, MockSnippetClient,
-                                                    MockFastboot, MockAdbProxy):
+    @mock.patch('mobly.utils.get_available_host_port')
+    def test_AndroidDevice_load_snippet_dup_package(
+        self, MockGetPort, MockSnippetClient, MockFastboot, MockAdbProxy):
         ad = android_device.AndroidDevice(serial=1)
         ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME)
         expected_msg = ('Snippet package "%s" has already been loaded under '
@@ -372,8 +374,9 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
                 return_value=mock_android_device.MockFastbootProxy(1))
     @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
+    @mock.patch('mobly.utils.get_available_host_port')
     def test_AndroidDevice_load_snippet_dup_snippet_name(
-        self, MockSnippetClient, MockFastboot, MockAdbProxy):
+        self, MockGetPort, MockSnippetClient, MockFastboot, MockAdbProxy):
         ad = android_device.AndroidDevice(serial=1)
         ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME)
         expected_msg = ('Attribute "%s" is already registered with package '
@@ -388,8 +391,9 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
                 return_value=mock_android_device.MockFastbootProxy(1))
     @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
+    @mock.patch('mobly.utils.get_available_host_port')
     def test_AndroidDevice_load_snippet_dup_attribute_name(
-        self, MockSnippetClient, MockFastboot, MockAdbProxy):
+        self, MockGetPort, MockSnippetClient, MockFastboot, MockAdbProxy):
         ad = android_device.AndroidDevice(serial=1)
         expected_msg = ('Attribute "%s" already exists, please use a different'
                         ' name') % 'adb'
@@ -402,7 +406,8 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
                 return_value=mock_android_device.MockFastbootProxy(1))
     @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
-    def test_AndroidDevice_snippet_cleanup(self, MockSnippetClient,
+    @mock.patch('mobly.utils.get_available_host_port')
+    def test_AndroidDevice_snippet_cleanup(self, MockGetPort, MockSnippetClient,
                                            MockFastboot, MockAdbProxy):
         ad = android_device.AndroidDevice(serial=1)
         ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME)

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -40,6 +40,7 @@ MOCK_ADB_LOGCAT = ("02-29 14:02:19.123  4454  Nothing\n"
 # Mock start and end time of the adb cat.
 MOCK_ADB_LOGCAT_BEGIN_TIME = "02-29 14:02:20.123"
 MOCK_ADB_LOGCAT_END_TIME = "02-29 14:02:22.000"
+MOCK_SNIPPET_PACKAGE_NAME = "com.my.snippet"
 
 
 class AndroidDeviceTest(unittest.TestCase):
@@ -339,6 +340,74 @@ class AndroidDeviceTest(unittest.TestCase):
         self.assertEqual(actual_cat, ''.join(MOCK_ADB_LOGCAT_CAT_RESULT))
         # Stops adb logcat.
         ad.stop_adb_logcat()
+
+    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
+                return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+                return_value=mock_android_device.MockFastbootProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
+    def test_AndroidDevice_load_snippet(self, MockSnippetClient, MockFastboot,
+                                        MockAdbProxy):
+        ad = android_device.AndroidDevice(serial=1)
+        ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME)
+        self.assertTrue(hasattr(ad, 'snippet'))
+
+    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
+                return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+                return_value=mock_android_device.MockFastbootProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
+    def test_AndroidDevice_load_snippet_dup_package(self, MockSnippetClient,
+                                                    MockFastboot, MockAdbProxy):
+        ad = android_device.AndroidDevice(serial=1)
+        ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME)
+        expected_msg = ('Snippet package "%s" has already been loaded under '
+                        'name "snippet".') % MOCK_SNIPPET_PACKAGE_NAME
+        with self.assertRaisesRegexp(android_device.SnippetError,
+                                     expected_msg):
+            ad.load_snippet('snippet2', MOCK_SNIPPET_PACKAGE_NAME)
+
+    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
+                return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+                return_value=mock_android_device.MockFastbootProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
+    def test_AndroidDevice_load_snippet_dup_snippet_name(
+        self, MockSnippetClient, MockFastboot, MockAdbProxy):
+        ad = android_device.AndroidDevice(serial=1)
+        ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME)
+        expected_msg = ('Attribute "%s" is already registered with package '
+                        '"%s", it cannot be used again.') % (
+                        'snippet', MOCK_SNIPPET_PACKAGE_NAME)
+        with self.assertRaisesRegexp(android_device.SnippetError,
+                                     expected_msg):
+            ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME + 'haha')
+
+    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
+                return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+                return_value=mock_android_device.MockFastbootProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
+    def test_AndroidDevice_load_snippet_dup_attribute_name(
+        self, MockSnippetClient, MockFastboot, MockAdbProxy):
+        ad = android_device.AndroidDevice(serial=1)
+        expected_msg = ('Attribute "%s" already exists, please use a different'
+                        ' name') % 'adb'
+        with self.assertRaisesRegexp(android_device.SnippetError,
+                                     expected_msg):
+            ad.load_snippet('adb', MOCK_SNIPPET_PACKAGE_NAME)
+
+    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
+                return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+                return_value=mock_android_device.MockFastbootProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.snippet_client.SnippetClient')
+    def test_AndroidDevice_snippet_cleanup(self, MockSnippetClient,
+                                           MockFastboot, MockAdbProxy):
+        ad = android_device.AndroidDevice(serial=1)
+        ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME)
+        ad.stop_services()
+        self.assertFalse(hasattr(ad, 'snippet'))
 
 
 if __name__ == "__main__":

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -44,7 +44,7 @@ MOCK_SNIPPET_PACKAGE_NAME = "com.my.snippet"
 
 # A mock SnippetClient used for testing snippet management logic.
 MockSnippetClient = mock.MagicMock()
-MockSnippetClient.app_name = MOCK_SNIPPET_PACKAGE_NAME
+MockSnippetClient.package = MOCK_SNIPPET_PACKAGE_NAME
 
 
 class AndroidDeviceTest(unittest.TestCase):


### PR DESCRIPTION
* Better handling of attempts to load snippet with duplicate info.
* Remove client attributes in stop_services.
* Add unit tests
fixes #55 
fixes #56 