### PR TITLE
Fix a bug in AndroidDevice.reboot

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -132,7 +132,7 @@ def _start_services_on_ads(ads):
     for ad in ads:
         running_ads.append(ad)
         try:
-            ad.start_services(getattr(ad, KEY_SKIP_SL4A, False))
+            ad.start_services(skip_sl4a=getattr(ad, KEY_SKIP_SL4A, False))
         except Exception as e:
             is_required = getattr(ad, KEY_DEVICE_REQUIRED, True)
             if is_required:
@@ -810,7 +810,7 @@ class AndroidDevice(object):
         self.wait_for_boot_completion()
         if self.is_rootable:
             self.root_adb()
-        self.start_services(getattr(self, KEY_SKIP_SL4A, False))
+        self.start_services(skip_sl4a=getattr(self, KEY_SKIP_SL4A, False))
 
 
 class AndroidDeviceLoggerAdapter(logging.LoggerAdapter):

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -132,7 +132,7 @@ def _start_services_on_ads(ads):
     for ad in ads:
         running_ads.append(ad)
         try:
-            ad.start_services(skip_sl4a=getattr(ad, KEY_SKIP_SL4A, False))
+            ad.start_services()
         except Exception as e:
             is_required = getattr(ad, KEY_DEVICE_REQUIRED, True)
             if is_required:
@@ -394,7 +394,7 @@ class AndroidDevice(object):
 
     # TODO(angli): This function shall be refactored to accommodate all services
     # and not have hard coded switch for SL4A when b/29157104 is done.
-    def start_services(self, skip_sl4a=False):
+    def start_services(self, skip_sl4a=None):
         """Starts long running services on the android device.
 
         1. Start adb logcat capture.
@@ -408,6 +408,8 @@ class AndroidDevice(object):
         except:
             self.log.exception("Failed to start adb logcat!")
             raise
+        if skip_sl4a is None:
+            skip_sl4a=getattr(ad, KEY_SKIP_SL4A, False)
         if not skip_sl4a:
             self._start_sl4a()
 

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -132,7 +132,7 @@ def _start_services_on_ads(ads):
     for ad in ads:
         running_ads.append(ad)
         try:
-            ad.start_services()
+            ad.start_services(getattr(ad, KEY_SKIP_SL4A, False))
         except Exception as e:
             is_required = getattr(ad, KEY_DEVICE_REQUIRED, True)
             if is_required:
@@ -394,7 +394,7 @@ class AndroidDevice(object):
 
     # TODO(angli): This function shall be refactored to accommodate all services
     # and not have hard coded switch for SL4A when b/29157104 is done.
-    def start_services(self, skip_sl4a=None):
+    def start_services(self, skip_sl4a=False):
         """Starts long running services on the android device.
 
         1. Start adb logcat capture.
@@ -408,8 +408,6 @@ class AndroidDevice(object):
         except:
             self.log.exception("Failed to start adb logcat!")
             raise
-        if skip_sl4a is None:
-            skip_sl4a=getattr(ad, KEY_SKIP_SL4A, False)
         if not skip_sl4a:
             self._start_sl4a()
 
@@ -812,7 +810,7 @@ class AndroidDevice(object):
         self.wait_for_boot_completion()
         if self.is_rootable:
             self.root_adb()
-        self.start_services()
+        self.start_services(getattr(self, KEY_SKIP_SL4A, False))
 
 
 class AndroidDeviceLoggerAdapter(logging.LoggerAdapter):


### PR DESCRIPTION
AndroidDevice.reboot tries to start sl4a even if skip_sl4a is set to True.