### PR TITLE
Refresh adb connection at the end of AndroidDevice controller cleanup.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -98,6 +98,10 @@ def destroy(ads):
     for ad in ads:
         try:
             ad.stop_services()
+            # Refresh the adb connection to this device so we don't have any
+            # adb processes/ports started by the test lingering on after test
+            # stops. It also recovers unresponsive devices in some cases.
+            ad.adb.reconnect()
         except:
             ad.log.exception("Failed to clean up properly.")
 


### PR DESCRIPTION
fixes #71 