### PR TITLE
Rework snippet and sl4a startup process.

### DIFF
--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -94,20 +94,24 @@ class JsonRpcClientBase(object):
 
     Attributes:
         host_port: (int) The host port of this RPC client.
-        device_port: (int) The device port of this RPC client. Must be set by
-          the superclass.
-        uid: (int) The uid of this session.
+        device_port: (int) The device port of this RPC client.
         app_name: (str) The user-visible name of the app being communicated
-          with. Must be set by the superclass.
+                  with.
+        uid: (int) The uid of this session.
     """
 
-    def __init__(self, host_port, adb_proxy):
+    def __init__(self, host_port, device_port, app_name, adb_proxy):
         """
         Args:
-            port: (int) the host-side port this server will listen on
-            adb_proxy: adb.AdbProxy, The adb proxy to use to start the app
+            host_port: (int) The host port of this RPC client.
+            device_port: (int) The device port of this RPC client.
+            app_name: (str) The user-visible name of the app being communicated
+                      with.
+            adb_proxy: (adb.AdbProxy) The adb proxy to use to start the app.
         """
         self.host_port = host_port
+        self.device_port = device_port
+        self.app_name = app_name
         self.uid = None
         self._adb = adb_proxy
         self._client = None  # prevent close errors on connect failure
@@ -156,7 +160,7 @@ class JsonRpcClientBase(object):
 
         Args:
             wait_time: float, The time to wait for the app to come up before
-                raising an error.
+                       raising an error.
 
         Raises:
             AppStartError: When the app was not able to be started.

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -275,7 +275,7 @@ class JsonRpcClientBase(object):
           running = True
         finally:
           self.close()
-          # This 'return' squashes exceptions fron connect()
+          # This 'return' squashes exceptions from connect()
           return running
 
     def __getattr__(self, name):

--- a/mobly/controllers/android_device_lib/sl4a_client.py
+++ b/mobly/controllers/android_device_lib/sl4a_client.py
@@ -27,10 +27,21 @@ _LAUNCH_CMD = (
 
 
 class Sl4aClient(jsonrpc_client_base.JsonRpcClientBase):
+    """A client for interacting with SL4A using Mobly Snippet Lib.
+
+    See superclass documentation for a list of public attributes.
+    """
+
     def __init__(self, host_port, adb_proxy):
-        super(Sl4aClient, self).__init__(host_port, adb_proxy)
-        self.app_name = 'SL4A'
-        self.device_port = DEVICE_SIDE_PORT
+        """Initializes an Sl4aClient.
+
+        Args:
+            host_port: (int) The host port of this RPC client.
+            adb_proxy: (adb.AdbProxy) The adb proxy to use to start the app.
+        """
+        super(Sl4aClient, self).__init__(
+            host_port=host_port, device_port=DEVICE_SIDE_PORT, app_name='SL4A',
+            adb_proxy=adb_proxy)
 
     def _do_start_app(self):
         """Overrides superclass."""

--- a/mobly/controllers/android_device_lib/sl4a_client.py
+++ b/mobly/controllers/android_device_lib/sl4a_client.py
@@ -27,13 +27,14 @@ _LAUNCH_CMD = (
 
 
 class Sl4aClient(jsonrpc_client_base.JsonRpcClientBase):
-    def __init__(self, adb_proxy):
-        super(Sl4aClient, self).__init__(adb_proxy)
+    def __init__(self, host_port, adb_proxy):
+        super(Sl4aClient, self).__init__(host_port, adb_proxy)
         self.app_name = 'SL4A'
+        self.device_port = DEVICE_SIDE_PORT
 
     def _do_start_app(self):
         """Overrides superclass."""
-        self._adb.shell(_LAUNCH_CMD.format(DEVICE_SIDE_PORT))
+        self._adb.shell(_LAUNCH_CMD.format(self.device_port))
 
     def stop_app(self):
         """Overrides superclass."""
@@ -44,19 +45,6 @@ class Sl4aClient(jsonrpc_client_base.JsonRpcClientBase):
         try:
             out = self._adb.shell("pm path com.googlecode.android_scripting"
                                   ).decode('utf-8').strip()
-            return bool(out)
-        except adb.AdbError as e:
-            if (e.ret_code == 1) and (not e.stdout) and (not e.stderr):
-                return False
-            raise
-
-    def _is_app_running(self):
-        """Overrides superclass."""
-        # Grep for process with a preceding S which means it is truly started.
-        try:
-            out = self._adb.shell(
-                'ps | grep "S com.googlecode.android_scripting"').decode(
-                    'utf-8').strip()
             return bool(out)
         except adb.AdbError as e:
             if (e.ret_code == 1) and (not e.stdout) and (not e.stderr):

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -44,7 +44,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
                      defined.
             host_port: (int) The port at which to start the snippet client. Note
                        that the same port will currently be used for both the
-                      device and host side of the connection.
+                       device and host side of the connection.
             adb_proxy: (adb.AdbProxy) The adb proxy to use to start the app.
         """
         # TODO(adorokhine): Don't assume that a free host-side port is free on

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 """JSON RPC interface to Mobly Snippet Lib."""
 import logging
-import socket
 
 from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import jsonrpc_client_base
@@ -32,42 +31,40 @@ class Error(Exception):
 
 
 class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
-    def __init__(self, package, port, adb_proxy):
+    def __init__(self, package, host_port, adb_proxy):
         """Initialzies a SnippetClient.
   
         Args:
           package: (str) The package name of the apk where the snippets are
             defined.
-          port: (int) The port at which to start the snippet client. Note that
-            the same port will currently be used for both the device and host
-            side of the connection.
+          host_port: (int) The port at which to start the snippet client. Note
+            that the same port will currently be used for both the device and
+            host side of the connection.
             TODO(adorokhine): allocate a distinct free port for both sides of
             the connection; it is not safe in general to reuse the same one.
           adb_proxy: (adb.AdbProxy) The adb proxy to use to start the app.
         """
-        super(SnippetClient, self).__init__(adb_proxy)
+        super(SnippetClient, self).__init__(host_port, adb_proxy)
         self.app_name = package
-        self._package = package
-        self._port = port
-
-    @property
-    def package(self):
-        return self._package
+        # TODO(adorokhine): Don't assume that a free host-side port is free on
+        # the device as well. Both sides should allocate a unique port.
+        self.device_port = host_port
+        self.package = package
 
     def _do_start_app(self):
         """Overrides superclass."""
-        cmd = _LAUNCH_CMD.format(self._port, self._package)
+        cmd = _LAUNCH_CMD.format(self.device_port, self.package)
         # Use info here so people know exactly what's happening here, which is
         # helpful since they need to create their own instrumentations and
         # manifest.
         logging.info('Launching snippet apk with: %s', cmd)
-        self._adb.shell(_LAUNCH_CMD.format(self._port, self._package))
+        self._adb.shell(cmd)
 
     def stop_app(self):
         """Overrides superclass."""
-        cmd = _STOP_CMD.format(self._package)
+        cmd = _STOP_CMD.format(self.package)
         logging.info('Stopping snippet apk with: %s', cmd)
-        out = self._adb.shell(_STOP_CMD.format(self._package)).decode('utf-8')
+        out = self._adb.shell(_STOP_CMD.format(self.package)).decode('utf-8')
         if 'OK (0 tests)' not in out:
             raise Error('Failed to stop existing apk. Unexpected output: %s' %
                         out)
@@ -77,22 +74,9 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         try:
             out = self._adb.shell(
                 'pm list instrumentation | grep ^instrumentation:%s/' %
-                self._package).decode('utf-8')
+                self.package).decode('utf-8')
             return bool(out)
         except adb.AdbError as e:
             if (e.ret_code == 1) and (not e.stdout) and (not e.stderr):
                 return False
             raise
-
-    def _is_app_running(self):
-        """Overrides superclass."""
-        # While instrumentation is running, 'ps' only shows the package of the
-        # main apk. However, the main apk might be running for other reasons.
-        # Instead of grepping the process tree, this is implemented by seeing if
-        # our destination port is alive.
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            result = sock.connect_ex(('127.0.0.1', self._port))
-            return result == 0
-        finally:
-            sock.close()

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -31,24 +31,27 @@ class Error(Exception):
 
 
 class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
+    """A client for interacting with snippet APKs using Mobly Snippet Lib.
+
+    See superclass documentation for a list of public attributes.
+    """
+
     def __init__(self, package, host_port, adb_proxy):
-        """Initialzies a SnippetClient.
+        """Initializes a SnippetClient.
   
         Args:
-          package: (str) The package name of the apk where the snippets are
-            defined.
-          host_port: (int) The port at which to start the snippet client. Note
-            that the same port will currently be used for both the device and
-            host side of the connection.
-            TODO(adorokhine): allocate a distinct free port for both sides of
-            the connection; it is not safe in general to reuse the same one.
-          adb_proxy: (adb.AdbProxy) The adb proxy to use to start the app.
+            package: (str) The package name of the apk where the snippets are
+                     defined.
+            host_port: (int) The port at which to start the snippet client. Note
+                       that the same port will currently be used for both the
+                      device and host side of the connection.
+            adb_proxy: (adb.AdbProxy) The adb proxy to use to start the app.
         """
-        super(SnippetClient, self).__init__(host_port, adb_proxy)
-        self.app_name = package
         # TODO(adorokhine): Don't assume that a free host-side port is free on
         # the device as well. Both sides should allocate a unique port.
-        self.device_port = host_port
+        super(SnippetClient, self).__init__(
+            host_port=host_port, device_port=host_port, app_name=package,
+            adb_proxy=adb_proxy)
         self.package = package
 
     def _do_start_app(self):

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
@@ -46,7 +46,7 @@ class MockSocketFile(object):
 
 class FakeRpcClient(jsonrpc_client_base.JsonRpcClientBase):
     def __init__(self):
-      super(FakeRpcClient, self).__init__(adb_proxy=None)
+      super(FakeRpcClient, self).__init__(host_port=80, adb_proxy=None)
 
 
 class JsonRpcClientBaseTest(unittest.TestCase):
@@ -78,7 +78,7 @@ class JsonRpcClientBaseTest(unittest.TestCase):
         mock_create_connection.side_effect = IOError()
         with self.assertRaises(IOError):
             client = FakeRpcClient()
-            client.connect(port=80)
+            client.connect()
 
     @mock.patch('socket.create_connection')
     def test_connect_timeout(self, mock_create_connection):
@@ -90,7 +90,7 @@ class JsonRpcClientBaseTest(unittest.TestCase):
         mock_create_connection.side_effect = socket.timeout
         with self.assertRaises(socket.timeout):
             client = FakeRpcClient()
-            client.connect(port=80)
+            client.connect()
 
     @mock.patch('socket.create_connection')
     def test_handshake_error(self, mock_create_connection):
@@ -104,7 +104,7 @@ class JsonRpcClientBaseTest(unittest.TestCase):
         mock_create_connection.return_value = fake_conn
         with self.assertRaises(jsonrpc_client_base.ProtocolError):
             client = FakeRpcClient()
-            client.connect(port=80)
+            client.connect()
 
     @mock.patch('socket.create_connection')
     def test_connect_handshake(self, mock_create_connection):
@@ -118,7 +118,7 @@ class JsonRpcClientBaseTest(unittest.TestCase):
         mock_create_connection.return_value = fake_conn
 
         client = FakeRpcClient()
-        client.connect(port=80)
+        client.connect()
 
         self.assertEqual(client.uid, 1)
 
@@ -135,7 +135,7 @@ class JsonRpcClientBaseTest(unittest.TestCase):
         mock_create_connection.return_value = fake_conn
 
         client = FakeRpcClient()
-        client.connect(port=80)
+        client.connect()
 
         self.assertEqual(client.uid, jsonrpc_client_base.UNKNOWN_UID)
 
@@ -149,7 +149,7 @@ class JsonRpcClientBaseTest(unittest.TestCase):
         fake_file = self.setup_mock_socket_file(mock_create_connection)
 
         client = FakeRpcClient()
-        client.connect(port=80)
+        client.connect()
 
         fake_file.resp = None
 
@@ -169,7 +169,7 @@ class JsonRpcClientBaseTest(unittest.TestCase):
         fake_file = self.setup_mock_socket_file(mock_create_connection)
 
         client = FakeRpcClient()
-        client.connect(port=80)
+        client.connect()
 
         fake_file.resp = MOCK_RESP_WITH_ERROR
 
@@ -186,7 +186,7 @@ class JsonRpcClientBaseTest(unittest.TestCase):
         fake_file = self.setup_mock_socket_file(mock_create_connection)
 
         client = FakeRpcClient()
-        client.connect(port=80)
+        client.connect()
 
         fake_file.resp = (MOCK_RESP_TEMPLATE % 52).encode('utf8')
 
@@ -205,7 +205,7 @@ class JsonRpcClientBaseTest(unittest.TestCase):
         fake_file = self.setup_mock_socket_file(mock_create_connection)
 
         client = FakeRpcClient()
-        client.connect(port=80)
+        client.connect()
 
         fake_file.resp = None
 
@@ -224,7 +224,7 @@ class JsonRpcClientBaseTest(unittest.TestCase):
         fake_file = self.setup_mock_socket_file(mock_create_connection)
 
         client = FakeRpcClient()
-        client.connect(port=80)
+        client.connect()
 
         result = client.some_rpc(1, 2, 3)
         self.assertEquals(result, 123)
@@ -243,7 +243,7 @@ class JsonRpcClientBaseTest(unittest.TestCase):
         fake_file = self.setup_mock_socket_file(mock_create_connection)
 
         client = FakeRpcClient()
-        client.connect(port=80)
+        client.connect()
 
         for i in range(0, 10):
             fake_file.resp = (MOCK_RESP_TEMPLATE % i).encode('utf-8')

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
@@ -46,7 +46,9 @@ class MockSocketFile(object):
 
 class FakeRpcClient(jsonrpc_client_base.JsonRpcClientBase):
     def __init__(self):
-      super(FakeRpcClient, self).__init__(host_port=80, adb_proxy=None)
+        super(FakeRpcClient, self).__init__(
+            host_port=80, device_port=90, app_name='FakeRpcClient',
+            adb_proxy=None)
 
 
 class JsonRpcClientBaseTest(unittest.TestCase):

--- a/tools/snippet_shell.py
+++ b/tools/snippet_shell.py
@@ -28,7 +28,6 @@ from __future__ import print_function
 
 import argparse
 import logging
-import sys
 
 from mobly.controllers.android_device_lib import jsonrpc_shell_base
 


### PR DESCRIPTION
_is_app_running() didn't work before because the socket was 'live' as soon
as it was bound through adb, even though nothing had started on the other
end. This led to race conditions between the snippet app starting and the
client connecting.

I couldn't find a way to make sure something was alive on the other end
other than actually sending data through the socket and getting a response,
so I've changed the is_app_running() process to actually call connect().
Tested with both snippet and sl4a.

Fixes #88.