### PR TITLE
Bug fixes in SnippetClient.check_app_installed

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -99,7 +99,6 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         if target_name != self.package:
             out = self._adb_grep_wrapper(
                 'pm list package | grep ^package:%s$' % target_name)
-            print(out)
             if not out:
                 raise jsonrpc_client_base.AppStartError(
                     'Instrumentation target %s is not installed on %s' %

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -80,7 +80,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         """Overrides superclass."""
         # Check that the Mobly Snippet app is installed.
         if not self._adb_grep_wrapper(
-                'pm list package | grep "^package:%s[^M]\?$"' % self.package):
+                'pm list package | grep "^package:%s\\r\?$"' % self.package):
             raise jsonrpc_client_base.AppStartError(
                 '%s is not installed on %s' % (self.package, self._serial))
         # Check that the app is instrumented.
@@ -91,7 +91,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
             raise jsonrpc_client_base.AppStartError(
                 '%s is installed on %s, but it is not instrumented.' %
                 (self.package, self._serial))
-        match = re.search(r'^instrumentation:(.*)\/(.*) \(target=(.*)\)[^M]?$',
+        match = re.search(r'^instrumentation:(.*)\/(.*) \(target=(.*)\)\r?$',
                           out)
         target_name = match.group(3)
         # Check that the instrumentation target is installed if it's not the

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -80,13 +80,13 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         """Overrides superclass."""
         # Check that the Mobly Snippet app is installed.
         if not self._adb_grep_wrapper(
-                'pm list package | tr -d "\\r" | grep "^package:%s$"' %
+                r'pm list package | tr -d "\r" | grep "^package:%s$"' %
                 self.package):
             raise jsonrpc_client_base.AppStartError(
                 '%s is not installed on %s' % (self.package, self._serial))
         # Check that the app is instrumented.
         out = self._adb_grep_wrapper(
-            'pm list instrumentation | tr -d "\\r" | grep ^instrumentation:%s/%s'
+            r'pm list instrumentation | tr -d "\r" | grep ^instrumentation:%s/%s'
             % (self.package, _INSTRUMENTATION_RUNNER_PACKAGE))
         if not out:
             raise jsonrpc_client_base.AppStartError(
@@ -99,7 +99,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         # same as the snippet package.
         if target_name != self.package:
             out = self._adb_grep_wrapper(
-                'pm list package | tr -d "\\r" | grep ^package:%s$' %
+                r'pm list package | tr -d "\r" | grep ^package:%s$' %
                 target_name)
             if not out:
                 raise jsonrpc_client_base.AppStartError(

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -80,25 +80,27 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         """Overrides superclass."""
         # Check that the Mobly Snippet app is installed.
         if not self._adb_grep_wrapper(
-                'pm list package | grep "^package:%s\\r\?$"' % self.package):
+                'pm list package | tr -d "\\r" | grep "^package:%s$"' %
+                self.package):
             raise jsonrpc_client_base.AppStartError(
                 '%s is not installed on %s' % (self.package, self._serial))
         # Check that the app is instrumented.
         out = self._adb_grep_wrapper(
-            'pm list instrumentation | grep ^instrumentation:%s/%s' %
-            (self.package, _INSTRUMENTATION_RUNNER_PACKAGE))
+            'pm list instrumentation | tr -d "\\r" | grep ^instrumentation:%s/%s'
+            % (self.package, _INSTRUMENTATION_RUNNER_PACKAGE))
         if not out:
             raise jsonrpc_client_base.AppStartError(
                 '%s is installed on %s, but it is not instrumented.' %
                 (self.package, self._serial))
-        match = re.search(r'^instrumentation:(.*)\/(.*) \(target=(.*)\)\r?$',
+        match = re.search(r'^instrumentation:(.*)\/(.*) \(target=(.*)\)$',
                           out)
         target_name = match.group(3)
         # Check that the instrumentation target is installed if it's not the
         # same as the snippet package.
         if target_name != self.package:
             out = self._adb_grep_wrapper(
-                'pm list package | grep ^package:%s$' % target_name)
+                'pm list package | tr -d "\\r" | grep ^package:%s$' %
+                target_name)
             if not out:
                 raise jsonrpc_client_base.AppStartError(
                     'Instrumentation target %s is not installed on %s' %

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -42,16 +42,16 @@ class MockAdbProxy(object):
                 return b''
             if self.target_not_installed and MOCK_MISSING_PACKAGE_NAME in params:
                 return b''
-            return bytes('package:%s\\r' % MOCK_PACKAGE_NAME, 'utf-8')
+            return bytes(r'package:%s\r' % MOCK_PACKAGE_NAME, 'utf-8')
         elif 'pm list instrumentation' in params:
             if self.apk_not_instrumented:
                 return b''
             if self.target_not_installed:
-                return bytes('instrumentation:{p}\\r/{r} (target={mp})'.format(
+                return bytes(r'instrumentation:{p}\r/{r} (target={mp})'.format(
                     p=MOCK_PACKAGE_NAME,
                     r=snippet_client._INSTRUMENTATION_RUNNER_PACKAGE,
                     mp=MOCK_MISSING_PACKAGE_NAME), 'utf-8')
-            return bytes('instrumentation:{p}\\r/{r} (target={p})'.format(
+            return bytes(r'instrumentation:{p}\r/{r} (target={p})'.format(
                 p=MOCK_PACKAGE_NAME,
                 r=snippet_client._INSTRUMENTATION_RUNNER_PACKAGE), 'utf-8')
 

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3.4
+#
+# Copyright 2016 Google Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from builtins import str
+from builtins import bytes
+
+import json
+import mock
+import socket
+import unittest
+
+from mobly.controllers.android_device_lib import jsonrpc_client_base
+from mobly.controllers.android_device_lib import snippet_client
+from tests.lib import mock_android_device
+
+MOCK_PACKAGE_NAME = 'some.package.name'
+MOCK_MISSING_PACKAGE_NAME = 'not.installed'
+JSONRPC_BASE_PACKAGE = 'mobly.controllers.android_device_lib.jsonrpc_client_base.JsonRpcClientBase'
+
+class MockAdbProxy(object):
+    def __init__(self, **kwargs):
+        self.apk_not_installed = kwargs.get('apk_not_installed', False)
+        self.apk_not_instrumented = kwargs.get('apk_not_instrumented', False)
+        self.target_not_installed = kwargs.get('target_not_installed', False)
+
+    def shell(self, params):
+        if 'pm list package' in params:
+            if self.apk_not_installed:
+                return b''
+            if self.target_not_installed and MOCK_MISSING_PACKAGE_NAME in params:
+                return b''
+            return bytes('package:%s^M' % MOCK_PACKAGE_NAME, 'utf-8')
+        elif 'pm list instrumentation' in params:
+            if self.apk_not_instrumented:
+                return b''
+            if self.target_not_installed:
+                return bytes('instrumentation:{p}^M/{r} (target={mp})'.format(
+                    p=MOCK_PACKAGE_NAME,
+                    r=snippet_client._INSTRUMENTATION_RUNNER_PACKAGE,
+                    mp=MOCK_MISSING_PACKAGE_NAME), 'utf-8')
+            return bytes('instrumentation:{p}^M/{r} (target={p})'.format(
+                p=MOCK_PACKAGE_NAME,
+                r=snippet_client._INSTRUMENTATION_RUNNER_PACKAGE), 'utf-8')
+
+    def __getattr__(self, name):
+        """All calls to the none-existent functions in adb proxy would
+        simply return the adb command string.
+        """
+
+        def adb_call(*args):
+            arg_str = ' '.join(str(elem) for elem in args)
+            return arg_str
+
+        return adb_call
+
+
+class JsonRpcClientBaseTest(unittest.TestCase):
+    """Unit tests for mobly.controllers.android_device_lib.snippet_client.
+    """
+
+    @mock.patch('socket.create_connection')
+    @mock.patch(JSONRPC_BASE_PACKAGE)
+    def test_check_app_installed_normal(self, mock_create_connection,
+                                        mock_client_base):
+        sc = snippet_client.SnippetClient(MOCK_PACKAGE_NAME, 42,
+                                          MockAdbProxy())
+        sc.check_app_installed()
+
+    @mock.patch('socket.create_connection')
+    @mock.patch(JSONRPC_BASE_PACKAGE)
+    def test_check_app_installed_fail_app_not_installed(
+            self, mock_create_connection, mock_client_base):
+        sc = snippet_client.SnippetClient(
+            MOCK_PACKAGE_NAME, 42, MockAdbProxy(apk_not_installed=True))
+        expected_msg = '%s is not installed on .*' % MOCK_PACKAGE_NAME
+        with self.assertRaisesRegexp(jsonrpc_client_base.AppStartError,
+                                     expected_msg):
+            sc.check_app_installed()
+
+    @mock.patch('socket.create_connection')
+    @mock.patch(JSONRPC_BASE_PACKAGE)
+    def test_check_app_installed_fail_not_instrumented(
+            self, mock_create_connection, mock_client_base):
+        sc = snippet_client.SnippetClient(
+            MOCK_PACKAGE_NAME, 42, MockAdbProxy(apk_not_instrumented=True))
+        expected_msg = '%s is installed on .*, but it is not instrumented.' % MOCK_PACKAGE_NAME
+        with self.assertRaisesRegexp(jsonrpc_client_base.AppStartError,
+                                     expected_msg):
+            sc.check_app_installed()
+
+    @mock.patch('socket.create_connection')
+    @mock.patch(JSONRPC_BASE_PACKAGE)
+    def test_check_app_installed_fail_target_not_installed(
+            self, mock_create_connection, mock_client_base):
+        sc = snippet_client.SnippetClient(
+            MOCK_PACKAGE_NAME, 42, MockAdbProxy(target_not_installed=True))
+        expected_msg = 'Instrumentation target %s is not installed on .*' % MOCK_MISSING_PACKAGE_NAME
+        with self.assertRaisesRegexp(jsonrpc_client_base.AppStartError,
+                                     expected_msg):
+            sc.check_app_installed()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3.4
 #
-# Copyright 2016 Google Inc.
+# Copyright 2017 Google Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,16 +42,16 @@ class MockAdbProxy(object):
                 return b''
             if self.target_not_installed and MOCK_MISSING_PACKAGE_NAME in params:
                 return b''
-            return bytes('package:%s^M' % MOCK_PACKAGE_NAME, 'utf-8')
+            return bytes('package:%s\\r' % MOCK_PACKAGE_NAME, 'utf-8')
         elif 'pm list instrumentation' in params:
             if self.apk_not_instrumented:
                 return b''
             if self.target_not_installed:
-                return bytes('instrumentation:{p}^M/{r} (target={mp})'.format(
+                return bytes('instrumentation:{p}\\r/{r} (target={mp})'.format(
                     p=MOCK_PACKAGE_NAME,
                     r=snippet_client._INSTRUMENTATION_RUNNER_PACKAGE,
                     mp=MOCK_MISSING_PACKAGE_NAME), 'utf-8')
-            return bytes('instrumentation:{p}^M/{r} (target={p})'.format(
+            return bytes('instrumentation:{p}\\r/{r} (target={p})'.format(
                 p=MOCK_PACKAGE_NAME,
                 r=snippet_client._INSTRUMENTATION_RUNNER_PACKAGE), 'utf-8')
 


### PR DESCRIPTION
Fix an issue where the function fails due to trailing `^M` in adb output.
Also add unit tests for the function.