### PR TITLE
Improve debugging info emitted by AndroidDevice.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -395,7 +395,7 @@ class AndroidDevice(object):
         """Setter for the debug tag.
 
         By default, the tag is the serial of the device, but sometimes it may
-        be more descriptive to use a different tag of the user's choise. 
+        be more descriptive to use a different tag of the user's choice.
 
         Changing debug tag changes part of the prefix of debug info emitted by
         this object, like log lines and the message of DeviceError.

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -379,7 +379,7 @@ class AndroidDevice(object):
         self._snippet_clients = {}
 
     def __repr__(self):
-        return "AndroidDevice(%s)" % self.serial
+        return "<AndroidDevice|%s>" % self.debug_tag
 
     @property
     def debug_tag(self):

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -35,6 +35,7 @@ from mobly.controllers.android_device_lib import snippet_client
 MOBLY_CONTROLLER_CONFIG_NAME = 'AndroidDevice'
 
 ANDROID_DEVICE_PICK_ALL_TOKEN = '*'
+_LOG_TAG_TEMPLATE = '[AndroidDevice|%s] %s'
 
 # Key name for adb logcat extra params in config file.
 ANDROID_DEVICE_ADB_LOGCAT_PARAM_KEY = 'adb_logcat_param'
@@ -49,12 +50,25 @@ class Error(signals.ControllerError):
     pass
 
 
-class SnippetError(signals.ControllerError):
-    """Raised when somethig wrong with snippet happens."""
+def _generate_error_class(device_id):
+    """Generate an exception class specific to a device object.
 
+    The class's msg will be prefixed with a tag that's consistent with that used
+    by the device's logger.
 
-class DoesNotExistError(Error):
-    """Raised when something that does not exist is referenced."""
+    Arg:
+        device_id: A string that is an ID for the device.
+    """
+
+    class DeviceError(Error):
+        def __init__(self, msg):
+            self.device_id = device_id
+            self.msg = msg
+
+        def __str__(self):
+            return _LOG_TAG_TEMPLATE % (self.device_id, self.msg)
+
+    return DeviceError
 
 
 def create(configs):
@@ -83,8 +97,8 @@ def create(configs):
 
     for ad in ads:
         if ad.serial not in connected_ads:
-            raise DoesNotExistError('Android device %s is specified in config'
-                                    ' but is not attached.' % ad.serial)
+            raise ad.Error('Android device is specified in config but is not '
+                           'attached.')
     _start_services_on_ads(ads)
     return ads
 
@@ -140,8 +154,8 @@ def _start_services_on_ads(ads):
                 destroy(running_ads)
                 raise
             else:
-                logging.warning('Skipping device %s because some service '
-                                'failed to start: %s', ad.serial, e)
+                ad.log.exception('Skipping this optional device because some '
+                                 'services failed to start: %s', e)
 
 
 def _parse_device_list(device_list_str, key):
@@ -228,7 +242,7 @@ def get_instances_with_configs(configs):
         except Exception as e:
             if is_required:
                 raise
-            logging.warning('Skipping device %s due to error: %s', serial, e)
+            ad.log.warning('Skipping this device due to error: %s', e)
             continue
         results.append(ad)
     return results
@@ -344,13 +358,15 @@ class AndroidDevice(object):
                   android device should be stored.
         log: A logger adapted from root logger with an added prefix specific
              to an AndroidDevice instance. The default prefix is
-             [AndroidDevice|<serial>]. Use self.set_logger_prefix_tag to use
-             a different tag in the prefix.
+             [AndroidDevice|<serial>]. Use self.set_prefix_tag to use a
+             different tag in the prefix.
         adb_logcat_file_path: A string that's the full path to the adb logcat
                               file collected, if any.
         adb: An AdbProxy object used for interacting with the device via adb.
         fastboot: A FastbootProxy object used for interacting with the device
                   via fastboot.
+        Error: A DeviceError class whose message contains specific info of a
+               device object.
     """
 
     def __init__(self, serial=''):
@@ -360,6 +376,7 @@ class AndroidDevice(object):
         self.log_path = os.path.join(log_path_base, 'AndroidDevice%s' % serial)
         self.log = AndroidDeviceLoggerAdapter(logging.getLogger(),
                                               {'tag': self.serial})
+        self.Error = _generate_error_class(self.log.extra['tag'])
         self.sl4a = None
         self.ed = None
         self._adb_logcat_process = None
@@ -372,23 +389,25 @@ class AndroidDevice(object):
         # names, values are the clients: {<attr name string>: <client object>}.
         self._snippet_clients = {}
 
-    def set_logger_prefix_tag(self, tag):
-        """Set a tag for the log line prefix of this instance.
+    def set_debug_tag(self, tag):
+        """Set a tag to be the prefix of debugging messages emitted by this
+        device object, like log lines and the message of DeviceError.
 
-        By default, the tag is the serial of the device, but sometimes having
-        the serial number in the log line doesn't help much with debugging. It
-        could be more helpful if users can mark the role of the device instead.
+        By default, the tag is the serial of the device, but sometimes it may
+        be more descriptive to use a different tag of the user's choose.
 
-        For example, instead of marking the serial number:
-            'INFO [AndroidDevice|abcdefg12345] One pending call ringing.'
-
-        marking the role of the device here is  more useful here:
-            'INFO [AndroidDevice|Caller] One pending call ringing.'
+        Example:
+            By default, the device's serial number is used:
+                'INFO [AndroidDevice|abcdefg12345] One pending call ringing.'
+            By calling `ad.set_prefix_tag('Caller')`, the user can customize the
+            tag:
+                'INFO [AndroidDevice|Caller] One pending call ringing.'
 
         Args:
             tag: A string that is the tag to use.
         """
         self.log.extra['tag'] = tag
+        self.Error = _generate_error_class(tag)
 
     def start_services(self):
         """Starts long running services on the android device, like adb logcat
@@ -542,8 +561,8 @@ class AndroidDevice(object):
         """
         for k, v in config.items():
             if hasattr(self, k):
-                raise Error('Attempting to set existing attribute %s on %s' %
-                            (k, self.serial))
+                raise self.Error(
+                    'Attribute %s already exists, cannot set again.')
             setattr(self, k, v)
 
     def root_adb(self):
@@ -575,18 +594,18 @@ class AndroidDevice(object):
         """
         # Should not load snippet with the same attribute more than once.
         if name in self._snippet_clients:
-            raise SnippetError(
+            raise self.Error(
                 'Attribute "%s" is already registered with package "%s", it '
                 'cannot be used again.' %
                 (name, self._snippet_clients[name].package))
         # Should not load snippet with an existing attribute.
         if hasattr(self, name):
-            raise SnippetError('Attribute "%s" already exists, please use a '
-                               'different name.' % name)
+            raise self.Error('Attribute "%s" already exists, please use a '
+                             'different name.' % name)
         # Should not load the same snippet package more than once.
         for client_name, client in self._snippet_clients.items():
             if package == client.package:
-                raise SnippetError(
+                raise self.Error(
                     'Snippet package "%s" has already been loaded under name'
                     ' "%s".' % (package, client_name))
         host_port = utils.get_available_host_port()
@@ -660,9 +679,8 @@ class AndroidDevice(object):
                 period.
         """
         if not self.adb_logcat_file_path:
-            raise Error(
-                'Attempting to cat adb log when none has been collected on '
-                'Android device %s.' % self.serial)
+            raise self.Error(
+                'Attempting to cat adb log when none has been collected.')
         end_time = mobly_logger.get_log_line_timestamp()
         self.log.debug('Extracting adb log from logcat.')
         adb_excerpt_path = os.path.join(self.log_path, 'AdbLogExcerpts')
@@ -704,8 +722,8 @@ class AndroidDevice(object):
         save the logcat in a file.
         """
         if self._adb_logcat_process:
-            raise Error('Android device %s already has an adb logcat thread '
-                        'going on. Cannot start another one.' % self.serial)
+            raise self.Error(
+                'Logcat thread is already running, cannot start another one.')
         # Disable adb log spam filter for rootable. Have to stop and clear
         # settings first because 'start' doesn't support --clear option before
         # Android N.
@@ -728,9 +746,7 @@ class AndroidDevice(object):
         """Stops the adb logcat collection subprocess.
         """
         if not self._adb_logcat_process:
-            raise Error(
-                'Android device %s does not have an ongoing adb logcat '
-                'collection.' % self.serial)
+            raise self.Error('No ongoing adb logcat collection found.')
         utils.stop_standing_subprocess(self._adb_logcat_process)
         self._adb_logcat_process = None
 
@@ -764,8 +780,7 @@ class AndroidDevice(object):
         if new_br:
             out = self.adb.shell('bugreportz').decode('utf-8')
             if not out.startswith('OK'):
-                raise Error('Failed to take bugreport on %s: %s' %
-                            (self.serial, out))
+                raise self.Error('Failed to take bugreport: %s' % out)
             br_out_path = out.split(':')[1].strip()
             self.adb.pull('%s %s' % (br_out_path, full_out_path))
         else:
@@ -826,7 +841,7 @@ class AndroidDevice(object):
                 # process, which is normal. Ignoring these errors.
                 pass
             time.sleep(5)
-        raise Error('Device %s booting process timed out.' % self.serial)
+        raise self.Error('Booting process timed out.')
 
     def _get_active_snippet_info(self):
         """Collects information on currently active snippet clients.
@@ -878,5 +893,5 @@ class AndroidDeviceLoggerAdapter(logging.LoggerAdapter):
     """
 
     def process(self, msg, kwargs):
-        msg = '[AndroidDevice|%s] %s' % (self.extra['tag'], msg)
+        msg = _LOG_TAG_TEMPLATE % (self.extra['tag'], msg)
         return (msg, kwargs)

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -52,11 +52,9 @@ class Error(signals.ControllerError):
 
 class DeviceError(Error):
     """Raised for errors from within an AndroidDevice object."""
-    def __init__(self, *args):
-        if isinstance(args[0], AndroidDevice):
-            new_args = list(args[1:])
-            new_args[0] = _LOG_TAG_TEMPLATE % (args[0].debug_tag, args[1])
-        super(DeviceError, self).__init__(*new_args)
+    def __init__(self, ad, msg):
+        new_msg = _LOG_TAG_TEMPLATE % (repr(ad), msg)
+        super(DeviceError, self).__init__(new_msg)
 
 
 class SnippetError(DeviceError):
@@ -89,8 +87,8 @@ def create(configs):
 
     for ad in ads:
         if ad.serial not in connected_ads:
-            raise ad._error('Android device is specified in config but is not '
-                            'attached.')
+            raise DeviceError(ad, 'Android device is specified in config but '
+                              ' is not attached.')
     _start_services_on_ads(ads)
     return ads
 
@@ -683,7 +681,7 @@ class AndroidDevice(object):
                 period.
         """
         if not self.adb_logcat_file_path:
-            raise DeviceError(self, 
+            raise DeviceError(self,
                 'Attempting to cat adb log when none has been collected.')
         end_time = mobly_logger.get_log_line_timestamp()
         self.log.debug('Extracting adb log from logcat.')

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -59,7 +59,6 @@ def _generate_error_class(device_id):
     Arg:
         device_id: A string that is an ID for the device.
     """
-
     class DeviceError(Error):
         def __init__(self, msg):
             self.device_id = device_id
@@ -67,7 +66,6 @@ def _generate_error_class(device_id):
 
         def __str__(self):
             return _LOG_TAG_TEMPLATE % (self.device_id, self.msg)
-
     return DeviceError
 
 
@@ -239,10 +237,10 @@ def get_instances_with_configs(configs):
         try:
             ad = AndroidDevice(serial)
             ad.load_config(c)
-        except Exception as e:
+        except Exception:
             if is_required:
                 raise
-            ad.log.warning('Skipping this device due to error: %s', e)
+            ad.log.warning('Skipping this optional device due to error.')
             continue
         results.append(ad)
     return results
@@ -358,7 +356,7 @@ class AndroidDevice(object):
                   android device should be stored.
         log: A logger adapted from root logger with an added prefix specific
              to an AndroidDevice instance. The default prefix is
-             [AndroidDevice|<serial>]. Use self.set_prefix_tag to use a
+             [AndroidDevice|<serial>]. Use self.set_debug_tag to use a
              different tag in the prefix.
         adb_logcat_file_path: A string that's the full path to the adb logcat
                               file collected, if any.

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -405,8 +405,7 @@ class AndroidDevice(object):
         Example:
             By default, the device's serial number is used:
                 'INFO [AndroidDevice|abcdefg12345] One pending call ringing.'
-            By calling `ad.set_debug_tag('Caller')`, the user can customize the
-            tag:
+            The tag can be customized with `ad.debug_tag = 'Caller'`:
                 'INFO [AndroidDevice|Caller] One pending call ringing.'
         """
         self._debug_tag = tag

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -357,8 +357,6 @@ class AndroidDevice(object):
         adb: An AdbProxy object used for interacting with the device via adb.
         fastboot: A FastbootProxy object used for interacting with the device
                   via fastboot.
-        SnippetError: A SnippetError class whose message contains specific info
-                      of a device object.
     """
 
     def __init__(self, serial=''):

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -185,10 +185,10 @@ class JsonRpcClientBase(object):
         for _ in range(wait_time):
             time.sleep(1)
             if self._is_app_running():
+                self.log.debug('Successfully started %s', self.app_name)
                 return
         raise AppStartError('%s failed to start on %s.' %
                             (self.app_name, self._adb.serial))
-        self.log.debug('Successfully started %s', self.app_name)
 
     def connect(self, uid=UNKNOWN_UID, cmd=JsonRpcCommand.INIT):
         """Opens a connection to a JSON RPC server.

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -39,6 +39,7 @@ Response:
 from builtins import str
 
 import json
+import logging
 import socket
 import threading
 import time
@@ -102,7 +103,12 @@ class JsonRpcClientBase(object):
         uid: (int) The uid of this session.
     """
 
-    def __init__(self, host_port, device_port, app_name, adb_proxy):
+    def __init__(self,
+                 host_port,
+                 device_port,
+                 app_name,
+                 adb_proxy,
+                 log=logging.getLogger()):
         """
         Args:
             host_port: (int) The host port of this RPC client.
@@ -121,6 +127,7 @@ class JsonRpcClientBase(object):
         self._counter = None
         self._lock = threading.Lock()
         self._event_client = None
+        self._log = log
 
     def __del__(self):
         self.close()
@@ -181,6 +188,7 @@ class JsonRpcClientBase(object):
                 return
         raise AppStartError('%s failed to start on %s.' %
                             (self.app_name, self._adb.serial))
+        self.log.debug('Successfully started %s', self.app_name)
 
     def connect(self, uid=UNKNOWN_UID, cmd=JsonRpcCommand.INIT):
         """Opens a connection to a JSON RPC server.

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -54,7 +54,8 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
             host_port=host_port,
             device_port=host_port,
             app_name=package,
-            adb_proxy=adb_proxy)
+            adb_proxy=adb_proxy,
+            log=log)
         self.package = package
         self._serial = self._adb.getprop('ro.boot.serialno')
         self.log = log

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -418,6 +418,24 @@ class AndroidDeviceTest(unittest.TestCase):
         ad.stop_services()
         self.assertFalse(hasattr(ad, 'snippet'))
 
+    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy', return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+                return_value=mock_android_device.MockFastbootProxy(1))
+    def test_AndroidDevice_debug_tag(self, MockFastboot, MockAdbProxy):
+        mock_serial = 1
+        ad = android_device.AndroidDevice(serial=mock_serial)
+        self.assertEqual(ad.debug_tag, 1)
+        try:
+            raise ad._error("Something")
+        except android_device.Error as e:
+            self.assertEqual("[AndroidDevice|1] Something", str(e))
+        # Verify that debug tag's setter updates the debug prefix correctly.
+        ad.debug_tag = "Mememe"
+        try:
+            raise ad._error("Something")
+        except android_device.Error as e:
+            self.assertEqual("[AndroidDevice|Mememe] Something", str(e))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -206,7 +206,7 @@ class AndroidDeviceTest(unittest.TestCase):
         """
         mock_serial = 1
         ad = android_device.AndroidDevice(serial=mock_serial)
-        expected_msg = "Failed to take bugreport on 1: OMG I died!"
+        expected_msg = ".* Failed to take bugreport."
         with self.assertRaisesRegexp(android_device.Error,
                                      expected_msg):
             ad.take_bug_report("test_something", "sometime")
@@ -244,8 +244,7 @@ class AndroidDeviceTest(unittest.TestCase):
         """
         mock_serial = 1
         ad = android_device.AndroidDevice(serial=mock_serial)
-        expected_msg = ("Android device .* does not have an ongoing adb logcat"
-                        " collection.")
+        expected_msg = ".* No ongoing adb logcat collection found."
         # Expect error if stop is called before start.
         with self.assertRaisesRegexp(android_device.Error,
                                      expected_msg):
@@ -261,8 +260,8 @@ class AndroidDeviceTest(unittest.TestCase):
         start_proc_mock.assert_called_with(adb_cmd % (ad.serial,
                                                       expected_log_path))
         self.assertEqual(ad.adb_logcat_file_path, expected_log_path)
-        expected_msg = ("Android device .* already has an adb logcat thread "
-                        "going on. Cannot start another one.")
+        expected_msg = ('Logcat thread is already running, cannot start another'
+                        ' one.')
         # Expect error if start is called back to back.
         with self.assertRaisesRegexp(android_device.Error,
                                      expected_msg):
@@ -289,8 +288,7 @@ class AndroidDeviceTest(unittest.TestCase):
         mock_serial = 1
         ad = android_device.AndroidDevice(serial=mock_serial)
         ad.adb_logcat_param = "-b radio"
-        expected_msg = ("Android device .* does not have an ongoing adb logcat"
-                        " collection.")
+        expected_msg = '.* No ongoing adb logcat collection found.'
         # Expect error if stop is called before start.
         with self.assertRaisesRegexp(android_device.Error,
                                      expected_msg):
@@ -324,8 +322,8 @@ class AndroidDeviceTest(unittest.TestCase):
         mock_serial = 1
         ad = android_device.AndroidDevice(serial=mock_serial)
         # Expect error if attempted to cat adb log before starting adb logcat.
-        expected_msg = ("Attempting to cat adb log when none has been "
-                        "collected on Android device .*")
+        expected_msg = (".* Attempting to cat adb log when none"
+                        " has been collected.")
         with self.assertRaisesRegexp(android_device.Error,
                                      expected_msg):
             ad.cat_adb_log("some_test", MOCK_ADB_LOGCAT_BEGIN_TIME)
@@ -370,7 +368,7 @@ class AndroidDeviceTest(unittest.TestCase):
         ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME)
         expected_msg = ('Snippet package "%s" has already been loaded under '
                         'name "snippet".') % MOCK_SNIPPET_PACKAGE_NAME
-        with self.assertRaisesRegexp(android_device.SnippetError,
+        with self.assertRaisesRegexp(android_device.Error,
                                      expected_msg):
             ad.load_snippet('snippet2', MOCK_SNIPPET_PACKAGE_NAME)
 
@@ -388,7 +386,7 @@ class AndroidDeviceTest(unittest.TestCase):
         expected_msg = ('Attribute "%s" is already registered with package '
                         '"%s", it cannot be used again.') % (
                         'snippet', MOCK_SNIPPET_PACKAGE_NAME)
-        with self.assertRaisesRegexp(android_device.SnippetError,
+        with self.assertRaisesRegexp(android_device.Error,
                                      expected_msg):
             ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME + 'haha')
 
@@ -403,7 +401,7 @@ class AndroidDeviceTest(unittest.TestCase):
         ad = android_device.AndroidDevice(serial=1)
         expected_msg = ('Attribute "%s" already exists, please use a different'
                         ' name') % 'adb'
-        with self.assertRaisesRegexp(android_device.SnippetError,
+        with self.assertRaisesRegexp(android_device.Error,
                                      expected_msg):
             ad.load_snippet('adb', MOCK_SNIPPET_PACKAGE_NAME)
 

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -426,15 +426,20 @@ class AndroidDeviceTest(unittest.TestCase):
         ad = android_device.AndroidDevice(serial=mock_serial)
         self.assertEqual(ad.debug_tag, 1)
         try:
-            raise ad._error("Something")
-        except android_device.Error as e:
-            self.assertEqual("[AndroidDevice|1] Something", str(e))
+            raise android_device.DeviceError(ad, 'Something')
+        except android_device.DeviceError as e:
+            self.assertEqual('[AndroidDevice|1] Something', str(e))
         # Verify that debug tag's setter updates the debug prefix correctly.
-        ad.debug_tag = "Mememe"
+        ad.debug_tag = 'Mememe'
         try:
-            raise ad._error("Something")
-        except android_device.Error as e:
-            self.assertEqual("[AndroidDevice|Mememe] Something", str(e))
+            raise android_device.DeviceError(ad, 'Something')
+        except android_device.DeviceError as e:
+            self.assertEqual('[AndroidDevice|Mememe] Something', str(e))
+        # Verify that repr is changed correctly.
+        try:
+            raise Exception(ad, 'Something')
+        except Exception as e:
+            self.assertEqual("(<AndroidDevice|Mememe>, 'Something')", str(e))
 
 
 if __name__ == "__main__":

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -418,7 +418,8 @@ class AndroidDeviceTest(unittest.TestCase):
         ad.stop_services()
         self.assertFalse(hasattr(ad, 'snippet'))
 
-    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy', return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
+                return_value=mock_android_device.MockAdbProxy(1))
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
                 return_value=mock_android_device.MockFastbootProxy(1))
     def test_AndroidDevice_debug_tag(self, MockFastboot, MockAdbProxy):

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -429,13 +429,13 @@ class AndroidDeviceTest(unittest.TestCase):
         try:
             raise android_device.DeviceError(ad, 'Something')
         except android_device.DeviceError as e:
-            self.assertEqual('[AndroidDevice|1] Something', str(e))
+            self.assertEqual('<AndroidDevice|1> Something', str(e))
         # Verify that debug tag's setter updates the debug prefix correctly.
         ad.debug_tag = 'Mememe'
         try:
             raise android_device.DeviceError(ad, 'Something')
         except android_device.DeviceError as e:
-            self.assertEqual('[AndroidDevice|Mememe] Something', str(e))
+            self.assertEqual('<AndroidDevice|Mememe> Something', str(e))
         # Verify that repr is changed correctly.
         try:
             raise Exception(ad, 'Something')


### PR DESCRIPTION
* Add prefix tag to the msg of exceptions thrown from each device
  object.
* Users can also throw these device-specific exceptions.
* Clean up and improve existing error messages and log lines.

fixes #105 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/107)
<!-- Reviewable:end -->
