### PR TITLE
Always remove adb port forwarding for a Rpc client

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -438,7 +438,10 @@ class AndroidDevice(object):
         service_info['snippet_info'] = self._get_active_snippet_info()
         service_info['use_sl4a'] = self.sl4a is not None
         if self._adb_logcat_process:
-            self.stop_adb_logcat()
+            try:
+                self.stop_adb_logcat()
+            except:
+                self.log.exception('Failed to stop adb logcat.')
         self._terminate_sl4a()
         for name, client in self._snippet_clients.items():
             self._terminate_jsonrpc_client(client)
@@ -672,7 +675,7 @@ class AndroidDevice(object):
             client.close()
             client.stop_app()
         except:
-            self.log.exception('Failed to stop Rpc client for %s',
+            self.log.exception('Failed to stop Rpc client for %s.',
                                client.app_name)
         finally:
             # Always clean up the adb port
@@ -761,6 +764,9 @@ class AndroidDevice(object):
 
     def stop_adb_logcat(self):
         """Stops the adb logcat collection subprocess.
+
+        Raises:
+            DeviceError: raised if there's no adb logcat collection going on.
         """
         if not self._adb_logcat_process:
             raise DeviceError(self, 'No ongoing adb logcat collection found.')


### PR DESCRIPTION
Fix a bug where adb forwarded ports are not cleaned up if rpc client fails to shutdown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/155)
<!-- Reviewable:end -->
