### PR TITLE
Use the device shell for grepping, instead of the host shell.

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -77,7 +77,7 @@ class AdbProxy(object):
         indicator of cmd execution status.
 
         Args:
-            cmd: string or list: command to execute.
+            cmd: string or list, command to execute.
             shell: Whether to pass the command to the shell for interpretation.
 
         Returns:
@@ -140,6 +140,15 @@ class AdbProxy(object):
     def __getattr__(self, name):
         def adb_call(args=None):
             """Wrapper for an ADB call.
+
+            ADB calls can be done with or without the host shell.
+
+            Example of usage:
+              ad.adb.shell('logcat | grep foo')  # runs in local shell
+              ad.adb.shell(['logcat | grep foo'])  # runs in device shell
+              ad.adb.shell('ln -s a b')  # runs in local shell
+              ad.adb.shell(['ln -s a b'])  # runs in device shell
+              ad.adb.shell(['ln', '-s', 'a', 'b'])  # runs in device shell
 
             Args:
                 args: string (for shell) or list (no shell); command to execute.

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -245,7 +245,7 @@ class JsonRpcClientBase(object):
             otherwise.
         """
         try:
-            return self._adb.shell(adb_shell_cmd).decode('utf-8')
+            return self._adb.shell([adb_shell_cmd]).decode('utf-8').rstrip()
         except adb.AdbError as e:
             if (e.ret_code == 1) and (not e.stdout) and (not e.stderr):
                 return False

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -17,18 +17,16 @@
 from builtins import str
 from builtins import bytes
 
-import json
 import mock
-import socket
 import unittest
 
 from mobly.controllers.android_device_lib import jsonrpc_client_base
 from mobly.controllers.android_device_lib import snippet_client
-from tests.lib import mock_android_device
 
 MOCK_PACKAGE_NAME = 'some.package.name'
 MOCK_MISSING_PACKAGE_NAME = 'not.installed'
 JSONRPC_BASE_PACKAGE = 'mobly.controllers.android_device_lib.jsonrpc_client_base.JsonRpcClientBase'
+
 
 class MockAdbProxy(object):
     def __init__(self, **kwargs):
@@ -37,13 +35,14 @@ class MockAdbProxy(object):
         self.target_not_installed = kwargs.get('target_not_installed', False)
 
     def shell(self, params):
-        if 'pm list package' in params:
+        if 'pm list package' in params[0]:
             if self.apk_not_installed:
                 return b''
-            if self.target_not_installed and MOCK_MISSING_PACKAGE_NAME in params:
+            if (self.target_not_installed and
+                MOCK_MISSING_PACKAGE_NAME in params[0]):
                 return b''
             return bytes(r'package:%s\r' % MOCK_PACKAGE_NAME, 'utf-8')
-        elif 'pm list instrumentation' in params:
+        elif 'pm list instrumentation' in params[0]:
             if self.apk_not_instrumented:
                 return b''
             if self.target_not_installed:


### PR DESCRIPTION
Under Windows the host shell does not have 'grep'.

Requires allowing the use of shell=False evaluation in the adb proxy,
because shells have different quoting rules that cause problems with
the quoting in the grep commands. For example, the Windows shell does
not support single quotes. Luckily, executing commands without shell is
safer and more cross-platform anyway).

Issue #131.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/157)
<!-- Reviewable:end -->
