### PR TITLE
Avoid using the shell for adb commands wherever possible.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -807,6 +807,8 @@ class AndroidDevice(object):
             br_out_path = out.split(':')[1].strip()
             self.adb.pull([br_out_path, full_out_path])
         else:
+            # shell=True as this command redirects the stdout to a local file
+            # using shell redirection.
             self.adb.bugreport(' > %s' % full_out_path, shell=True)
         self.log.info('Bugreport for %s taken at %s.', test_name,
                       full_out_path)

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -805,9 +805,9 @@ class AndroidDevice(object):
             if not out.startswith('OK'):
                 raise DeviceError(self, 'Failed to take bugreport: %s' % out)
             br_out_path = out.split(':')[1].strip()
-            self.adb.pull('%s %s' % (br_out_path, full_out_path))
+            self.adb.pull([br_out_path, full_out_path])
         else:
-            self.adb.bugreport(' > %s' % full_out_path)
+            self.adb.bugreport(' > %s' % full_out_path, shell=True)
         self.log.info('Bugreport for %s taken at %s.', test_name,
                       full_out_path)
 

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -65,6 +65,19 @@ class AdbProxy(object):
     >> adb = AdbProxy(<serial>)
     >> adb.start_server()
     >> adb.devices() # will return the console output of "adb devices".
+
+    By default, command args are expected to be an iterable which is passed
+    directly to subprocess.Popen():
+    >> adb.shell(['echo', 'a', 'b'])
+
+    This way of launching commands is recommended by the subprocess
+    documentation to avoid shell injection vulnerabilities and avoid having to
+    deal with multiple layers of shell quoting and different shell environments
+    between different OSes.
+
+    If you really want to run the command through the system shell, this is
+    possible by supplying shell=True, but try to avoid this if possible:
+    >> adb.shell('cat /foo > /tmp/file', shell=True)
     """
 
     def __init__(self, serial=''):
@@ -76,8 +89,8 @@ class AdbProxy(object):
         Args:
             args: string or list, program arguments.
                 See subprocess.Popen() documentation.
-            shell: bool, whether to run this command through the system shell.
-                See subprocess.Popen() documentation.
+            shell: bool, True to run this command through the system shell,
+                False to invoke it directly. See subprocess.Popen() docs.
 
         Returns:
             The output of the adb command run if exit code is 0.
@@ -144,8 +157,8 @@ class AdbProxy(object):
             Args:
                 args: string or list, arguments to the adb command.
                     See subprocess.Proc() documentation.
-                shell: bool, whether to run cmd through the system shell.
-                    See subprocess.Proc() documentation.
+                shell: bool, True to run this command through the system shell,
+                    False to invoke it directly. See subprocess.Proc() docs.
 
             Returns:
                 The output of the adb command run if exit code is 0.

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -87,7 +87,7 @@ class AdbProxy(object):
         """Executes adb commands.
 
         Args:
-            args: string or list, program arguments.
+            args: string or list of strings, program arguments.
                 See subprocess.Popen() documentation.
             shell: bool, True to run this command through the system shell,
                 False to invoke it directly. See subprocess.Popen() docs.
@@ -155,7 +155,7 @@ class AdbProxy(object):
             """Wrapper for an ADB command.
 
             Args:
-                args: string or list, arguments to the adb command.
+                args: string or list of strings, arguments to the adb command.
                     See subprocess.Proc() documentation.
                 shell: bool, True to run this command through the system shell,
                     False to invoke it directly. See subprocess.Proc() docs.

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -238,14 +238,14 @@ class JsonRpcClientBase(object):
         This surpresses AdbError if the grep fails to find anything.
 
         Args:
-            adb_shell_cmd: A string that is an adb shell cmd with grep.
+            adb_shell_cmd: string, a grep command to execute on the device.
 
         Returns:
             The stdout of the grep result if the grep found something, False
             otherwise.
         """
         try:
-            return self._adb.shell(adb_shell_cmd).decode('utf-8')
+            return self._adb.shell(adb_shell_cmd).decode('utf-8').rstrip()
         except adb.AdbError as e:
             if (e.ret_code == 1) and (not e.stdout) and (not e.stderr):
                 return False

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -22,6 +22,10 @@ import mock
 import os
 
 
+class Error(Exception):
+    pass
+
+
 def get_mock_ads(num):
     """Generates a list of mock AndroidDevice objects.
 
@@ -88,12 +92,14 @@ class MockAdbProxy(object):
         elif params == "sys.boot_completed":
             return "1"
 
-    def bugreport(self, params):
-        expected = os.path.join(logging.log_path,
-                                "AndroidDevice%s" % self.serial, "BugReports",
-                                "test_something,sometime,%s" % (self.serial))
-        assert expected in params, "Expected '%s', got '%s'." % (expected,
-                                                                 params)
+    def bugreport(self, args, shell=False):
+        expected = os.path.join(
+            logging.log_path,
+            'AndroidDevice%s' % self.serial,
+            'BugReports',
+            'test_something,sometime,%s' % self.serial)
+        if expected not in args:
+            raise Error('"Expected "%s", got "%s"' % (expected, args))
 
     def __getattr__(self, name):
         """All calls to the none-existent functions in adb proxy would


### PR DESCRIPTION
Per the 'subprocess' documentation, running commands through the shell is
brittle (because the command has to handle shell interpolation/quoting
rules which might also vary between shells) and dangerous (because it makes
shell injection vulnerabilities possible).

Running commands through the shell is still possible by exposing the
'shell' argument of subprocess to callers.

Issue #131.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/162)
<!-- Reviewable:end -->
