### PR TITLE
Deflake unit tests by giving stop_standing_subprocess more time to run.

### DIFF
--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -29,11 +29,11 @@ class UtilsTest(unittest.TestCase):
     def test_start_standing_subproc(self):
         with self.assertRaisesRegexp(utils.Error,
                                      "Process .* has terminated"):
-            utils.start_standing_subprocess("sleep 0", check_health_delay=0.1)
+            utils.start_standing_subprocess("sleep 0", check_health_delay=0.5)
 
     def test_stop_standing_subproc(self):
         p = utils.start_standing_subprocess("sleep 0")
-        time.sleep(0.1)
+        time.sleep(0.5)
         with self.assertRaisesRegexp(utils.Error,
                                      "Process .* has terminated"):
             utils.stop_standing_subprocess(p)


### PR DESCRIPTION
On very slow or overloaded machines, or when root partition is on a
remote filesystem,fetching the 'sleep' binary and starting it up can
take more than 100ms. This causes unit test flakes because the
'sleep' command is still setting up when we expect it to be gone
already.

Fixes #97.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/165)
<!-- Reviewable:end -->
