### PR TITLE
Don't use system shell for starting standing subprocesses by default.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -759,7 +759,8 @@ class AndroidDevice(object):
             extra_params = '-b all'
         cmd = 'adb -s %s logcat -v threadtime %s >> %s' % (
             self.serial, extra_params, logcat_file_path)
-        self._adb_logcat_process = utils.start_standing_subprocess(cmd)
+        self._adb_logcat_process = utils.start_standing_subprocess(
+            cmd, shell=True)
         self.adb_logcat_file_path = logcat_file_path
 
     def stop_adb_logcat(self):

--- a/mobly/controllers/iperf_server.py
+++ b/mobly/controllers/iperf_server.py
@@ -141,7 +141,7 @@ class IPerfServer():
                                                          len(self.log_files))
         full_out_path = os.path.join(self.log_path, out_file_name)
         cmd = "{} {} > {}".format(self.iperf_str, extra_args, full_out_path)
-        self.iperf_process = utils.start_standing_subprocess(cmd)
+        self.iperf_process = utils.start_standing_subprocess(cmd, shell=True)
         self.log_files.append(full_out_path)
         self.started = True
 

--- a/mobly/controllers/iperf_server.py
+++ b/mobly/controllers/iperf_server.py
@@ -140,7 +140,7 @@ class IPerfServer():
         out_file_name = "IPerfServer,{},{}{}.log".format(self.port, tag,
                                                          len(self.log_files))
         full_out_path = os.path.join(self.log_path, out_file_name)
-        cmd = "{} {} > {}".format(self.iperf_str, extra_args, full_out_path)
+        cmd = '%s %s > %s' % (self.iperf_str, extra_args, full_out_path)
         self.iperf_process = utils.start_standing_subprocess(cmd, shell=True)
         self.log_files.append(full_out_path)
         self.started = True

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -296,13 +296,14 @@ def _assert_subprocess_running(proc):
                              " stdout: %s" % (proc.pid, ret, err, out))
 
 
-def start_standing_subprocess(cmd, check_health_delay=0):
+def start_standing_subprocess(cmd, check_health_delay=0, shell=False):
     """Starts a long-running subprocess.
 
     This is not a blocking call and the subprocess started by it should be
     explicitly terminated with stop_standing_subprocess.
 
-    For short-running commands, you should use exe_cmd, which blocks.
+    For short-running commands, you should use subprocess.check_call, which
+    blocks.
 
     You can specify a health check after the subprocess is started to make sure
     it did not stop prematurely.
@@ -312,16 +313,19 @@ def start_standing_subprocess(cmd, check_health_delay=0):
         check_health_delay: float, the number of seconds to wait after the
                             subprocess starts to check its health. Default is 0,
                             which means no check.
+        shell: bool, True to run this command through the system shell,
+            False to invoke it directly. See subprocess.Proc() docs.
 
     Returns:
-        The subprocess that got started.
+        The subprocess that was started.
     """
+    logging.debug('Start standing subprocess with cmd: %s', cmd)
     proc = subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        shell=True)
+        shell=shell)
     logging.debug('Start standing subprocess with cmd: %s', cmd)
     # Leaving stdin open causes problems for input, e.g. breaking the
     # code.inspect() shell (http://stackoverflow.com/a/25512460/1612937), so

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -283,8 +283,8 @@ class AndroidDeviceTest(unittest.TestCase):
                                          "adblog,fakemodel,%s.txt" % ad.serial)
         creat_dir_mock.assert_called_with(os.path.dirname(expected_log_path))
         adb_cmd = 'adb -s %s logcat -v threadtime -b all >> %s'
-        start_proc_mock.assert_called_with(adb_cmd % (ad.serial,
-                                                      expected_log_path))
+        start_proc_mock.assert_called_with(
+              adb_cmd % (ad.serial, expected_log_path), shell=True)
         self.assertEqual(ad.adb_logcat_file_path, expected_log_path)
         expected_msg = ('Logcat thread is already running, cannot start another'
                         ' one.')
@@ -327,8 +327,8 @@ class AndroidDeviceTest(unittest.TestCase):
                                          "adblog,fakemodel,%s.txt" % ad.serial)
         creat_dir_mock.assert_called_with(os.path.dirname(expected_log_path))
         adb_cmd = 'adb -s %s logcat -v threadtime -b radio >> %s'
-        start_proc_mock.assert_called_with(adb_cmd % (ad.serial,
-                                                      expected_log_path))
+        start_proc_mock.assert_called_with(
+              adb_cmd % (ad.serial, expected_log_path), shell=True)
         self.assertEqual(ad.adb_logcat_file_path, expected_log_path)
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy', return_value=mock_android_device.MockAdbProxy(1))

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -29,18 +29,18 @@ class UtilsTest(unittest.TestCase):
     def test_start_standing_subproc(self):
         with self.assertRaisesRegexp(utils.Error,
                                      "Process .* has terminated"):
-            utils.start_standing_subprocess("sleep 0", check_health_delay=0.5)
+            utils.start_standing_subprocess(
+                  ['sleep', '0'], check_health_delay=0.5)
 
     def test_stop_standing_subproc(self):
-        p = utils.start_standing_subprocess('sleep 5')
+        p = utils.start_standing_subprocess(['sleep', '5'])
         utils.stop_standing_subprocess(p)
         self.assertIsNotNone(p.poll())
 
     def test_stop_standing_subproc_already_dead(self):
-        p = utils.start_standing_subprocess("sleep 0")
+        p = utils.start_standing_subprocess(['sleep', '0'])
         time.sleep(0.5)
-        with self.assertRaisesRegexp(utils.Error,
-                                     "Process .* has terminated"):
+        with self.assertRaisesRegexp(utils.Error, 'Process .* has terminated'):
             utils.stop_standing_subprocess(p)
 
     @mock.patch('mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')


### PR DESCRIPTION
Using the system shell is fragile and dangerous. See the subprocess
documentation for more details.

Issue #151
Issue #163
Issue #166

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/167)
<!-- Reviewable:end -->
