### PR TITLE
Detach stdin of standing subprocesses.

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -339,10 +339,16 @@ def start_standing_subprocess(cmd, check_health_delay=0):
     """
     proc = subprocess.Popen(
         cmd,
+        stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         shell=True)
     logging.debug('Start standing subprocess with cmd: %s', cmd)
+    # Leaving stdin open causes problems for input, e.g. breaking the
+    # code.inspect() shell (http://stackoverflow.com/a/25512460/1612937), so
+    # explicitly close it assuming it is not needed for standing subprocesses.
+    proc.stdin.close()
+    proc.stdin = None
     if check_health_delay > 0:
         time.sleep(check_health_delay)
         _assert_subprocess_running(proc)


### PR DESCRIPTION
Leaving stdin attached causes problems for the code.inspect() shell because
the subprocess starts swallowing input intended for the console.

Needed for issue #166

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/168)
<!-- Reviewable:end -->
