### PR TITLE
Fix snippet_client so that it can be used with default device.

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -71,7 +71,10 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         # helpful since they need to create their own instrumentations and
         # manifest.
         self.log.info('Launching snippet apk %s', self.package)
-        adb_cmd = ['adb', '-s', self._adb.serial, 'shell', cmd]
+        adb_cmd = ['adb']
+        if self._adb.serial:
+            adb_cmd += ['-s', self._adb.serial]
+        adb_cmd += ['shell', cmd]
         self._proc = utils.start_standing_subprocess(adb_cmd, shell=False)
 
     def stop_app(self):


### PR DESCRIPTION
The problem was introduced in [1], where snippet_client always assumes
that device has a serial number, which may not always be the case.

[1] https://github.com/google/mobly/commit/e5a553c6cb238c354b6402e6de1876c3605beb77

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/180)
<!-- Reviewable:end -->
