### PR TITLE
Changing Mobly to use portpicker 

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -458,32 +458,8 @@ def get_available_host_port():
         forward.
     """
     while True:
-        port = portpicker.PickUnusedPort()
-        if is_port_available(port):
+        port = portpicker.PickUnusedPort()        
+        # Make sure adb is not using this port so we don't accidentally
+        # interrupt ongoing runs by trying to bind to the port.
+        if port not in adb.list_occupied_adb_ports():
             return port
-
-
-def is_port_available(port):
-    """Checks if a given port number is available on the system.
-
-    Args:
-        port: An integer which is the port number to check.
-
-    Returns:
-        True if the port is available; False otherwise.
-    """
-    # Make sure adb is not using this port so we don't accidentally interrupt
-    # ongoing runs by trying to bind to the port.
-    if port in adb.list_occupied_adb_ports():
-        return False
-    s = None
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        s.bind(('localhost', port))
-        return True
-    except socket.error:
-        return False
-    finally:
-        if s:
-            s.close()

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -411,8 +411,7 @@ def get_available_host_port():
         forward.
 
     Raises:
-      Error is raised when no port is found after
-      MAX_PORT_ALLOCATION_RETRY times.
+      Error: when no port is found after MAX_PORT_ALLOCATION_RETRY times.
     """
     for _ in range(MAX_PORT_ALLOCATION_RETRY):
         port = portpicker.PickUnusedPort()

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -349,7 +349,7 @@ def stop_standing_subprocess(proc, kill_signal=signal.SIGTERM):
     Args:
         proc: Subprocess to terminate.
 
-    Throws:
+    Raises:
         Error: if the subprocess could not be stopped.
     """
     pid = proc.pid
@@ -458,6 +458,7 @@ def get_available_host_port():
     Returns:
         An integer representing a port number on the host available for adb
         forward.
+
     Raises:
       Error is raised when no port is found after
       MAX_PORT_ALLOCATION_RETRY times.

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -19,6 +19,7 @@ import functools
 import logging
 import os
 import platform
+import portpicker
 import psutil
 import random
 import signal
@@ -457,7 +458,7 @@ def get_available_host_port():
         forward.
     """
     while True:
-        port = random.randint(1024, 9900)
+        port = portpicker.PickUnusedPort()
         if is_port_available(port):
             return port
 

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -33,6 +33,8 @@ from mobly.controllers.android_device_lib import adb
 # File name length is limited to 255 chars on some OS, so we need to make sure
 # the file names we output fits within the limit.
 MAX_FILENAME_LEN = 255
+# Number of times to retry to get available port
+MAX_RETRY = 50
 
 ascii_letters_and_digits = string.ascii_letters + string.digits
 valid_filename_chars = "-_." + ascii_letters_and_digits
@@ -457,9 +459,12 @@ def get_available_host_port():
         An integer representing a port number on the host available for adb
         forward.
     """
-    while True:
+    i = 0
+    while i < MAX_RETRY:
         port = portpicker.PickUnusedPort()        
         # Make sure adb is not using this port so we don't accidentally
         # interrupt ongoing runs by trying to bind to the port.
         if port not in adb.list_occupied_adb_ports():
             return port
+    raise Error('Failed to find available port after {} retries'.
+                format(MAX_RETRY))

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ if sys.version_info < (3, ):
         'futures',
     ])
 
-
 if platform.system() == 'Windows':
     install_requires.append('pywin32')
 
@@ -60,19 +59,18 @@ def main():
     setuptools.setup(
         name='mobly',
         version='1.2.1',
-        maintainer = 'Ang Li',
-        maintainer_email = 'mobly-github@googlegroups.com',
+        maintainer='Ang Li',
+        maintainer_email='mobly-github@googlegroups.com',
         description='Automation framework for special end-to-end test cases',
         license='Apache2.0',
-        url = 'https://github.com/google/mobly',
-        download_url = 'https://github.com/google/mobly/tarball/1.2.1',
+        url='https://github.com/google/mobly',
+        download_url='https://github.com/google/mobly/tarball/1.2.1',
         packages=setuptools.find_packages(),
         include_package_data=False,
         scripts=['tools/sl4a_shell.py', 'tools/snippet_shell.py'],
         tests_require=['pytest'],
         install_requires=install_requires,
-        cmdclass={'test': PyTest},
-    )
+        cmdclass={'test': PyTest}, )
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ install_requires = [
     # mock-1.0.1 is the last version compatible with setuptools <17.1,
     # which is what comes with Ubuntu 14.04 LTS.
     'mock<=1.0.1',
+    'portpicker',
     'psutil',
     'pytz',
     'pyyaml'

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -20,7 +20,7 @@ import unittest
 import portpicker
 from mobly import utils
 
-AVAILABLE_PORT = 5
+MOCK_AVAILABLE_PORT = 5
 
 
 class UtilsTest(unittest.TestCase):
@@ -46,15 +46,15 @@ class UtilsTest(unittest.TestCase):
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')
-    @mock.patch('portpicker.PickUnusedPort', return_value=AVAILABLE_PORT)
+    @mock.patch('portpicker.PickUnusedPort', return_value=MOCK_AVAILABLE_PORT)
     def test_get_available_port_positive(self, mock_list_occupied_adb_ports,
                                          mock_pick_unused_port):
-        self.assertEqual(utils.get_available_host_port(), AVAILABLE_PORT)
+        self.assertEqual(utils.get_available_host_port(), MOCK_AVAILABLE_PORT)
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports',
-        return_value=[AVAILABLE_PORT])
-    @mock.patch('portpicker.PickUnusedPort', return_value=AVAILABLE_PORT)
+        return_value=[MOCK_AVAILABLE_PORT])
+    @mock.patch('portpicker.PickUnusedPort', return_value=MOCK_AVAILABLE_PORT)
     def test_get_available_port_negative(self, mock_list_occupied_adb_ports,
                                          mock_pick_unused_port):
         with self.assertRaisesRegexp(utils.Error, 'Failed to find.* retries'):

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -60,14 +60,18 @@ class UtilsTest(unittest.TestCase):
         with self.assertRaisesRegexp(utils.Error, 'Failed to find.* retries'):
             utils.get_available_host_port()
 
-    def test_get_available_port_returns_free_port(self):
-        port = utils.get_available_host_port()	
+    @mock.patch(
+        'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')
+    def test_get_available_port_returns_free_port(
+            self, mock_list_occupied_adb_ports):
+        port = utils.get_available_host_port()
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
-            s.bind(('localhost', port))        
+            s.bind(('localhost', port))
         finally:
             s.close()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -20,17 +20,18 @@ import unittest
 import portpicker
 from mobly import utils
 
-AVAILABLE_PORT=5
+AVAILABLE_PORT = 5
+
 
 class UtilsTest(unittest.TestCase):
     """This test class has unit tests for the implementation of everything
     under mobly.utils.
     """
+
     def test_start_standing_subproc(self):
-        with self.assertRaisesRegexp(utils.Error,
-                                     "Process .* has terminated"):
+        with self.assertRaisesRegexp(utils.Error, 'Process .* has terminated'):
             utils.start_standing_subprocess(
-                  ['sleep', '0'], check_health_delay=0.5)
+                ['sleep', '0'], check_health_delay=0.5)
 
     def test_stop_standing_subproc(self):
         p = utils.start_standing_subprocess(['sleep', '5'])
@@ -43,20 +44,22 @@ class UtilsTest(unittest.TestCase):
         with self.assertRaisesRegexp(utils.Error, 'Process .* has terminated'):
             utils.stop_standing_subprocess(p)
 
-    @mock.patch('mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')
-    def test_get_available_port_positive(self, mock_list_occupied_adb_ports):
-        with mock.patch.object(portpicker, 'PickUnusedPort', return_value=AVAILABLE_PORT):
-            self.assertEqual(utils.get_available_host_port(), AVAILABLE_PORT)
+    @mock.patch(
+        'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')
+    @mock.patch('portpicker.PickUnusedPort', return_value=AVAILABLE_PORT)
+    def test_get_available_port_positive(self, mock_list_occupied_adb_ports,
+                                         mock_pick_unused_port):
+        self.assertEqual(utils.get_available_host_port(), AVAILABLE_PORT)
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports',
         return_value=[AVAILABLE_PORT])
-    def test_get_available_port_negative(self, mock_list_occupied_adb_ports):
-        with mock.patch.object(portpicker, 'PickUnusedPort',
-                               return_value=AVAILABLE_PORT):
-            with self.assertRaisesRegexp(utils.Error, 'Failed to find.* retries'):
-                utils.get_available_host_port()
+    @mock.patch('portpicker.PickUnusedPort', return_value=AVAILABLE_PORT)
+    def test_get_available_port_negative(self, mock_list_occupied_adb_ports,
+                                         mock_pick_unused_port):
+        with self.assertRaisesRegexp(utils.Error, 'Failed to find.* retries'):
+            utils.get_available_host_port()
 
 
-if __name__ == "__main__":
-   unittest.main()
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -61,14 +61,13 @@ class UtilsTest(unittest.TestCase):
             utils.get_available_host_port()
 
     def test_get_available_port_returns_free_port(self):
+        port = utils.get_available_host_port()	
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
-            port = utils.get_available_host_port()	
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind(('localhost', port))        
         finally:
-            if s:
-                s.close()
+            s.close()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -20,6 +20,7 @@ import unittest
 import portpicker
 from mobly import utils
 
+AVAILABLE_PORT=5
 
 class UtilsTest(unittest.TestCase):
     """This test class has unit tests for the implementation of everything

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -60,6 +60,15 @@ class UtilsTest(unittest.TestCase):
         with self.assertRaisesRegexp(utils.Error, 'Failed to find.* retries'):
             utils.get_available_host_port()
 
+    def test_get_available_port_returns_free_port(self):
+        try:
+            port = utils.get_available_host_port()	
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(('localhost', port))        
+        finally:
+            if s:
+                s.close()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Making mobly use portpicker instead of picking random port.

Note: I am not sure if after this change you still need the list_occupied_adb_ports logic in is_port_available.  I am guessing yes, because you dont know if other processes running in the same machine are picking the same portsw that portserver allocates for you. 

We probably need also some documentation about portpicker/portserver

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/185)
<!-- Reviewable:end -->
