### PR TITLE
Fix start_app timeout mechanism which assumes _is_app_running() retur…

### DIFF
--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -175,8 +175,9 @@ class JsonRpcClientBase(object):
         """Starts the server app on the android device.
 
         Args:
-            wait_time: int, The *minimum* number of seconds to wait for the app
-                to come up before raising an error.
+            wait_time: int, The minimum number of seconds to wait for the app
+                to come up before raising an error. Note that _is_app_running()
+                may take longer than wait_time.
 
         Raises:
             AppStartError: When the app was not able to be started.

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -183,11 +183,12 @@ class JsonRpcClientBase(object):
         """
         self.check_app_installed()
         self._do_start_app()
-        for _ in range(wait_time):
-            time.sleep(1)
+        expiration_time = time.time() + wait_time
+        while time.time() < expiration_time:
             if self._is_app_running():
                 self._log.debug('Successfully started %s', self.app_name)
                 return
+            time.sleep(1)
         raise AppStartError('%s failed to start on %s.' %
                             (self.app_name, self._adb.serial))
 

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -175,8 +175,8 @@ class JsonRpcClientBase(object):
         """Starts the server app on the android device.
 
         Args:
-            wait_time: float, The time to wait for the app to come up before
-                       raising an error.
+            wait_time: int, The *minimum* number of seconds to wait for the app
+                to come up before raising an error.
 
         Raises:
             AppStartError: When the app was not able to be started.


### PR DESCRIPTION
…ns immediately.

Previously, this was looping for 
wait_time x (1+_SOCKET_CONNECTION_TIMEOUT+_SOCKET_READ_TIMEOUT) seconds
instead of
wait_time x (1) seconds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/186)
<!-- Reviewable:end -->
