### PR TITLE
Fix cleaning up log aliases which are broken symlinks.

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -105,7 +105,7 @@ def create_alias(target_path, alias_path):
     """
     if platform.system() == 'Windows' and not alias_path.endswith('.lnk'):
         alias_path += '.lnk'
-    if os.path.exists(alias_path):
+    if os.path.lexists(alias_path):
         os.remove(alias_path)
     if platform.system() == 'Windows':
         from win32com import client


### PR DESCRIPTION
os.path.exists() returns False for broken symlinks, so we weren't removing
it, causing us to fail later when we tried to recreate it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/189)
<!-- Reviewable:end -->
