### PR TITLE
Fix a bug where the standing adb logcat process fails to start.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -756,27 +756,13 @@ class AndroidDevice(object):
         f_name = 'adblog,%s,%s.txt' % (self.model, self.serial)
         utils.create_dir(self.log_path)
         logcat_file_path = os.path.join(self.log_path, f_name)
-        use_default_param = False
         try:
             extra_params = self.adb_logcat_param
         except AttributeError:
-            use_default_param = True
-            extra_params = '-b all'
+            extra_params = ''
         cmd = 'adb -s %s logcat -v threadtime %s >> %s' % (
             self.serial, extra_params, logcat_file_path)
-        try:
-            process = utils.start_standing_subprocess(
-                cmd, check_health_delay=0.1, shell=True)
-        except utils.Error:
-            # adb process did not start succesfully.
-            # If the user specificed the params, raise the error.
-            if not use_default_param:
-                raise
-            # Otherwise retry without params.
-            cmd = 'adb -s %s logcat -v threadtime >> %s' % (self.serial,
-                                                            logcat_file_path)
-            process = utils.start_standing_subprocess(
-                cmd, check_health_delay=0.1, shell=True)
+        process = utils.start_standing_subprocess(cmd, shell=True)
         self._adb_logcat_process = process
         self.adb_logcat_file_path = logcat_file_path
 

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -759,7 +759,7 @@ class AndroidDevice(object):
         try:
             extra_params = self.adb_logcat_param
         except AttributeError:
-            extra_params = '-b all'
+            extra_params = '-b main -b crash -b system -b radio'
         cmd = 'adb -s %s logcat -v threadtime %s >> %s' % (
             self.serial, extra_params, logcat_file_path)
         self._adb_logcat_process = utils.start_standing_subprocess(

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -756,14 +756,28 @@ class AndroidDevice(object):
         f_name = 'adblog,%s,%s.txt' % (self.model, self.serial)
         utils.create_dir(self.log_path)
         logcat_file_path = os.path.join(self.log_path, f_name)
+        use_default_param = False
         try:
             extra_params = self.adb_logcat_param
         except AttributeError:
-            extra_params = '-b main -b crash -b system -b radio'
+            use_default_param = True
+            extra_params = '-b all'
         cmd = 'adb -s %s logcat -v threadtime %s >> %s' % (
             self.serial, extra_params, logcat_file_path)
-        self._adb_logcat_process = utils.start_standing_subprocess(
-            cmd, shell=True)
+        try:
+            process = utils.start_standing_subprocess(
+                cmd, check_health_delay=0.1, shell=True)
+        except utils.Error:
+            # adb process did not start succesfully.
+            # If the user specificed the params, raise the error.
+            if not use_default_param:
+                raise
+            # Otherwise retry without params.
+            cmd = 'adb -s %s logcat -v threadtime >> %s' % (self.serial,
+                                                            logcat_file_path)
+            process = utils.start_standing_subprocess(
+                cmd, check_health_delay=0.1, shell=True)
+        self._adb_logcat_process = process
         self.adb_logcat_file_path = logcat_file_path
 
     def stop_adb_logcat(self):

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -280,10 +280,9 @@ class AndroidDeviceTest(unittest.TestCase):
                                          "AndroidDevice%s" % ad.serial,
                                          "adblog,fakemodel,%s.txt" % ad.serial)
         creat_dir_mock.assert_called_with(os.path.dirname(expected_log_path))
-        adb_cmd = 'adb -s %s logcat -v threadtime -b all >> %s'
+        adb_cmd = 'adb -s %s logcat -v threadtime  >> %s'
         start_proc_mock.assert_called_with(
-              adb_cmd % (ad.serial, expected_log_path), check_health_delay=0.1,
-                         shell=True)
+              adb_cmd % (ad.serial, expected_log_path), shell=True)
         self.assertEqual(ad.adb_logcat_file_path, expected_log_path)
         expected_msg = ('Logcat thread is already running, cannot start another'
                         ' one.')
@@ -327,8 +326,7 @@ class AndroidDeviceTest(unittest.TestCase):
         creat_dir_mock.assert_called_with(os.path.dirname(expected_log_path))
         adb_cmd = 'adb -s %s logcat -v threadtime -b radio >> %s'
         start_proc_mock.assert_called_with(
-              adb_cmd % (ad.serial, expected_log_path), check_health_delay=0.1,
-                         shell=True)
+              adb_cmd % (ad.serial, expected_log_path), shell=True)
         self.assertEqual(ad.adb_logcat_file_path, expected_log_path)
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy', return_value=mock_android_device.MockAdbProxy(1))

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -282,7 +282,8 @@ class AndroidDeviceTest(unittest.TestCase):
         creat_dir_mock.assert_called_with(os.path.dirname(expected_log_path))
         adb_cmd = 'adb -s %s logcat -v threadtime -b all >> %s'
         start_proc_mock.assert_called_with(
-              adb_cmd % (ad.serial, expected_log_path), shell=True)
+              adb_cmd % (ad.serial, expected_log_path), check_health_delay=0.1,
+                         shell=True)
         self.assertEqual(ad.adb_logcat_file_path, expected_log_path)
         expected_msg = ('Logcat thread is already running, cannot start another'
                         ' one.')
@@ -326,7 +327,8 @@ class AndroidDeviceTest(unittest.TestCase):
         creat_dir_mock.assert_called_with(os.path.dirname(expected_log_path))
         adb_cmd = 'adb -s %s logcat -v threadtime -b radio >> %s'
         start_proc_mock.assert_called_with(
-              adb_cmd % (ad.serial, expected_log_path), shell=True)
+              adb_cmd % (ad.serial, expected_log_path), check_health_delay=0.1,
+                         shell=True)
         self.assertEqual(ad.adb_logcat_file_path, expected_log_path)
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy', return_value=mock_android_device.MockAdbProxy(1))


### PR DESCRIPTION
List the individual buffers useful for debugging instead of using "all".
Fixes #190

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/194)
<!-- Reviewable:end -->
