### PR TITLE
update test_get_available_port_returns_free_port for ipv6 sockets

### DIFF
--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -64,9 +64,9 @@ class UtilsTest(unittest.TestCase):
         'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')    
     def test_get_available_port_returns_free_port(
             self, mock_list_occupied_adb_ports):
-    """This test checks we can bind to a socket on the port returned by portpicker 
-    and should pass as long as we can bind to either an ipv4 or ipv6 socket on 
-    such port."""
+        """This test checks we can bind to a socket on the port returned by portpicker 
+        and should pass as long as we can bind to either an ipv4 or ipv6 socket on 
+        such port."""
         port = utils.get_available_host_port()
         got_socket = False
         for family in (socket.AF_INET6, socket.AF_INET):

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -61,7 +61,7 @@ class UtilsTest(unittest.TestCase):
             utils.get_available_host_port()
 
     @mock.patch(
-        'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')    
+        'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')
     def test_get_available_port_returns_free_port(
             self, mock_list_occupied_adb_ports):
         """This test checks we can bind to a socket on the port returned by portpicker 
@@ -81,6 +81,7 @@ class UtilsTest(unittest.TestCase):
             finally:
                 s.close()
         self.assertTrue(got_socket)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -75,6 +75,7 @@ class UtilsTest(unittest.TestCase):
             try:
                 s = socket.socket(family, socket.SOCK_STREAM)
                 got_socket = True
+                break
             except socket.error:
                 continue
         self.assertTrue(got_socket)

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -82,7 +82,6 @@ class UtilsTest(unittest.TestCase):
             s.bind(('localhost', port))
         finally:
             s.close()
-        self.assertTrue(got_socket)
 
 
 if __name__ == '__main__':

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -65,13 +65,19 @@ class UtilsTest(unittest.TestCase):
     def test_get_available_port_returns_free_port(
             self, mock_list_occupied_adb_ports):
         port = utils.get_available_host_port()
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        try:
-            s.bind(('localhost', port))
-        finally:
-            s.close()
-
+        got_socket = False
+        for family in (socket.AF_INET6, socket.AF_INET):
+            try:
+                s = socket.socket(family, socket.SOCK_STREAM)
+                got_socket = True
+            except socket.error:
+                continue
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:                
+                s.bind(('localhost', port))
+            finally:
+                s.close()
+        self.assertTrue(got_socket)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -73,7 +73,7 @@ class UtilsTest(unittest.TestCase):
             except socket.error:
                 continue
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            try:                
+            try:
                 s.bind(('localhost', port))
             finally:
                 s.close()

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -67,7 +67,8 @@ class UtilsTest(unittest.TestCase):
         """Verifies logic to pick a free port on the host.
 
         Test checks we can bind to either an ipv4 or ipv6 socket on the port
-        returned by portpicker on host machine."""
+        returned by get_available_host_port.
+        """
         port = utils.get_available_host_port()
         got_socket = False
         for family in (socket.AF_INET, socket.AF_INET6):

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -64,9 +64,10 @@ class UtilsTest(unittest.TestCase):
         'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')
     def test_get_available_port_returns_free_port(
             self, mock_list_occupied_adb_ports):
-        """This test checks we can bind to a socket on the port returned by portpicker 
-        and should pass as long as we can bind to either an ipv4 or ipv6 socket on 
-        such port."""
+        """Verifies logic to pick a free port on the host.
+
+        Test checks we can bind to either an ipv4 or ipv6 socket on the port
+        returned by portpicker on host machine."""
         port = utils.get_available_host_port()
         got_socket = False
         for family in (socket.AF_INET6, socket.AF_INET):
@@ -75,11 +76,12 @@ class UtilsTest(unittest.TestCase):
                 got_socket = True
             except socket.error:
                 continue
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            try:
-                s.bind(('localhost', port))
-            finally:
-                s.close()
+        self.assertTrue(got_socket)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            s.bind(('localhost', port))
+        finally:
+            s.close()
         self.assertTrue(got_socket)
 
 

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -61,9 +61,12 @@ class UtilsTest(unittest.TestCase):
             utils.get_available_host_port()
 
     @mock.patch(
-        'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')
+        'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')    
     def test_get_available_port_returns_free_port(
             self, mock_list_occupied_adb_ports):
+    """This test checks we can bind to a socket on the port returned by portpicker 
+    and should pass as long as we can bind to either an ipv4 or ipv6 socket on 
+    such port."""
         port = utils.get_available_host_port()
         got_socket = False
         for family in (socket.AF_INET6, socket.AF_INET):

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -70,7 +70,7 @@ class UtilsTest(unittest.TestCase):
         returned by portpicker on host machine."""
         port = utils.get_available_host_port()
         got_socket = False
-        for family in (socket.AF_INET6, socket.AF_INET):
+        for family in (socket.AF_INET, socket.AF_INET6):
             try:
                 s = socket.socket(family, socket.SOCK_STREAM)
                 got_socket = True


### PR DESCRIPTION
updating test_get_available_port_returns_free_port so test also passes with ipv6 sockets

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/209)
<!-- Reviewable:end -->
