### PR TITLE
Handle IllegalArgumentException for v0 fallback.

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -93,7 +93,9 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         # TODO(adorokhine): delete this in Mobly 1.6 when snippet v0 support is
         # removed.
         line = self._read_line()
-        if line == 'INSTRUMENTATION_RESULT: shortMsg=Process crashed.':
+        if line in ('INSTRUMENTATION_RESULT: shortMsg=Process crashed.',
+                    'INSTRUMENTATION_RESULT: shortMsg='
+                    'java.lang.IllegalArgumentException'):
             self.log.warning('Snippet %s crashed on startup. This might be an '
                              'actual error or a snippet using deprecated v0 '
                              'start protocol. Retrying as a v0 snippet.',


### PR DESCRIPTION
Some OS versions propagate the real exception message to instrumentation output, so this code handles that situation as well.

This code is temporary until v0 snippets are deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/223)
<!-- Reviewable:end -->
