### PR TITLE
Remove deprecated code path for generated tests.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -333,7 +333,6 @@ class BaseTestClass(object):
             args: A tuple of params.
             kwargs: Extra kwargs.
         """
-        is_generate_trigger = False
         tr_record = records.TestResultRecord(test_name, self.TAG)
         tr_record.test_begin()
         logging.info('%s %s', TEST_CASE_TOKEN, test_name)
@@ -369,10 +368,6 @@ class BaseTestClass(object):
             # Explicit test pass.
             tr_record.test_pass(e)
             self._exec_procedure_func(self._on_pass, tr_record)
-        except signals.TestSilent as e:
-            # This is a trigger test for generated tests, suppress reporting.
-            is_generate_trigger = True
-            self.results.requested.remove(test_name)
         except Exception as e:
             logging.exception(e)
             # Exception happened during test.
@@ -382,8 +377,7 @@ class BaseTestClass(object):
             tr_record.test_pass()
             self._exec_procedure_func(self._on_pass, tr_record)
         finally:
-            if not is_generate_trigger:
-                self.results.add_record(tr_record)
+            self.results.add_record(tr_record)
 
     def _assert_function_name_in_stack(self, expected_func_name):
         """Asserts that the current stack contains the given function name."""

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -426,63 +426,6 @@ class BaseTestClass(object):
             test_func = functools.partial(test_logic, *args)
             self._generated_test_table[test_name] = test_func
 
-    def run_generated_testcases(self,
-                                test_func,
-                                settings,
-                                args=None,
-                                kwargs=None,
-                                tag='',
-                                name_func=None):
-        """Runs generated test cases.
-
-        !DEPRECATED! Use self.generate_tests instead.
-
-        Generated test cases are not written down as functions, but as a list
-        of parameter sets. This way we reduce code repetition and improve
-        test case scalability.
-
-        Args:
-            test_func: The common logic shared by all these generated test
-                       cases. This function should take at least one argument,
-                       which is a parameter set.
-            settings: A list of strings representing parameter sets. These are
-                      usually json strings that get loaded in the test_func.
-            args: Iterable of additional position args to be passed to
-                  test_func.
-            kwargs: Dict of additional keyword args to be passed to test_func
-            tag: Name of this group of generated test cases. Ignored if
-                 name_func is provided and operates properly.
-            name_func: A function that takes a test setting and generates a
-                       proper test name. The test name should be shorter than
-                       utils.MAX_FILENAME_LEN. Names over the limit will be
-                       truncated.
-
-        Returns:
-            A list of settings that did not pass.
-        """
-        logging.warning(
-            '"run_generated_testcases" is deprecated and will be '
-            'removed in Mobly 1.5, please use "generate_tests" instead.')
-        args = args or ()
-        kwargs = kwargs or {}
-        failed_settings = []
-        for s in settings:
-            test_name = '%s %s' % (tag, s)
-            if name_func:
-                try:
-                    test_name = name_func(s, *args, **kwargs)
-                except:
-                    logging.exception('Failed to get test name from test_func.'
-                                      ' Fall back to default %s.', test_name)
-            self.results.requested.append(test_name)
-            if len(test_name) > utils.MAX_FILENAME_LEN:
-                test_name = test_name[:utils.MAX_FILENAME_LEN]
-            previous_success_cnt = len(self.results.passed)
-            self.exec_one_test(test_name, test_func, (s, ) + args, **kwargs)
-            if len(self.results.passed) - previous_success_cnt != 1:
-                failed_settings.append(s)
-        return failed_settings
-
     def _safe_exec_func(self, func, *args):
         """Executes a function with exception safeguard.
 

--- a/mobly/signals.py
+++ b/mobly/signals.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """This module is where all the test signal classes and related utilities live.
 """
 
@@ -32,6 +31,7 @@ class TestSignal(Exception):
         extras: A json-serializable data type to convey extra information about
                 a test result.
     """
+
     def __init__(self, details, extras=None):
         super(TestSignal, self).__init__(details)
         self.details = str(details)

--- a/mobly/signals.py
+++ b/mobly/signals.py
@@ -19,25 +19,6 @@ import functools
 import json
 
 
-def generated_test(func):
-    """A decorator used to suppress result reporting for the test method that
-    kicks off a group of generated tests.
-
-    !DEPRECATED! self.setup_generated_tests() should be used instead.
-
-    Returns:
-        What the decorated function returns.
-    """
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        func(*args, **kwargs)
-        raise TestSilent('Result reporting for %s is suppressed' %
-                         func.__name__)
-
-    return wrapper
-
-
 class TestSignalError(Exception):
     """Raised when an error occurs inside a test signal."""
 
@@ -75,14 +56,6 @@ class TestPass(TestSignal):
 
 class TestSkip(TestSignal):
     """Raised when a test has been skipped."""
-
-
-class TestSilent(TestSignal):
-    """Raised when a test should not be reported. This should only be used for
-    generated tests.
-
-    !DEPRECATED! self.setup_generated_tests() should be used instead.
-    """
 
 
 class TestAbortClass(TestSignal):

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -46,9 +46,10 @@ class BaseTestTest(unittest.TestCase):
     def test_current_test_name(self):
         class MockBaseTest(base_test.BaseTestClass):
             def test_func(self):
-                asserts.assert_true(self.current_test_name == "test_func", (
-                    "Got "
-                    "unexpected test name %s.") % self.current_test_name)
+                asserts.assert_true(
+                    self.current_test_name == "test_func",
+                    ("Got "
+                     "unexpected test name %s.") % self.current_test_name)
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run(test_names=["test_func"])
@@ -89,8 +90,9 @@ class BaseTestTest(unittest.TestCase):
                 never_call()
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
-        expected_msg = ('Test method name not_a_test_something does not follow '
-                        'naming convention test_\*, abort.')
+        expected_msg = (
+            'Test method name not_a_test_something does not follow '
+            'naming convention test_\*, abort.')
         with self.assertRaisesRegexp(base_test.Error, expected_msg):
             bt_cls.run()
 
@@ -126,8 +128,9 @@ class BaseTestTest(unittest.TestCase):
                 never_call()
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
-        expected_msg = ('Test method name not_a_test_something does not follow '
-                        'naming convention test_\*, abort.')
+        expected_msg = (
+            'Test method name not_a_test_something does not follow '
+            'naming convention test_\*, abort.')
         with self.assertRaisesRegexp(base_test.Error, expected_msg):
             bt_cls.run(test_names=["not_a_test_something"])
 

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -967,63 +967,6 @@ class BaseTestTest(unittest.TestCase):
                             "Requested 0, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
-    def test_generated_tests(self):
-        """Execute code paths for generated test cases.
-
-        Three test cases are generated, each of them produces a different
-        result: one pass, one fail, and one skip.
-
-        This test verifies that the exact three tests are executed and their
-        results are reported correctly.
-        """
-        static_arg = "haha"
-        static_kwarg = "meh"
-        itrs = ["pass", "fail", "skip"]
-
-        class MockBaseTest(base_test.BaseTestClass):
-            def name_gen(self, setting, arg, special_arg=None):
-                return 'test_%s_%s' % (setting, arg)
-
-            def logic(self, setting, arg, special_arg=None):
-                asserts.assert_true(setting in itrs, (
-                    "%s is not in acceptable settings range %s") %
-                                    (setting, itrs))
-                asserts.assert_true(arg == static_arg,
-                                    "Expected %s, got %s" % (static_arg, arg))
-                asserts.assert_true(arg == static_arg, "Expected %s, got %s" %
-                                    (static_kwarg, special_arg))
-                if setting == "pass":
-                    asserts.explicit_pass(
-                        MSG_EXPECTED_EXCEPTION, extras=MOCK_EXTRA)
-                elif setting == "fail":
-                    asserts.fail(MSG_EXPECTED_EXCEPTION, extras=MOCK_EXTRA)
-                elif setting == "skip":
-                    asserts.skip(MSG_EXPECTED_EXCEPTION, extras=MOCK_EXTRA)
-
-            @signals.generated_test
-            def test_func(self):
-                self.run_generated_testcases(
-                    test_func=self.logic,
-                    settings=itrs,
-                    args=(static_arg, ),
-                    name_func=self.name_gen)
-
-        bt_cls = MockBaseTest(self.mock_test_cls_configs)
-        bt_cls.run(test_names=["test_func"])
-        self.assertEqual(len(bt_cls.results.requested), 3)
-        pass_record = bt_cls.results.passed[0]
-        self.assertEqual(pass_record.test_name, "test_pass_%s" % static_arg)
-        self.assertEqual(pass_record.details, MSG_EXPECTED_EXCEPTION)
-        self.assertEqual(pass_record.extras, MOCK_EXTRA)
-        skip_record = bt_cls.results.skipped[0]
-        self.assertEqual(skip_record.test_name, "test_skip_%s" % static_arg)
-        self.assertEqual(skip_record.details, MSG_EXPECTED_EXCEPTION)
-        self.assertEqual(skip_record.extras, MOCK_EXTRA)
-        fail_record = bt_cls.results.failed[0]
-        self.assertEqual(fail_record.test_name, "test_fail_%s" % static_arg)
-        self.assertEqual(fail_record.details, MSG_EXPECTED_EXCEPTION)
-        self.assertEqual(fail_record.extras, MOCK_EXTRA)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As planned for release 1.5, we are removing the old code path for
generated tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/242)
<!-- Reviewable:end -->
