### PR TITLE
Properly serialize test results object

### DIFF
--- a/mobly/records.py
+++ b/mobly/records.py
@@ -14,6 +14,7 @@
 """This module is where all the record definitions and record containers live.
 """
 
+import itertools
 import json
 import logging
 import pprint
@@ -337,7 +338,9 @@ class TestResult(object):
         """
         d = {}
         d['ControllerInfo'] = self.controller_info
-        d['Results'] = [record.to_dict() for record in self.executed]
+        records_to_write = itertools.chain(self.passed, self.failed,
+                                           self.skipped, self.error)
+        d['Results'] = [record.to_dict() for record in records_to_write]
         d['Summary'] = self.summary_dict()
         json_str = json.dumps(d, indent=4, sort_keys=True)
         return json_str

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -555,6 +555,7 @@ class BaseTestTest(unittest.TestCase):
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run(test_names=["test_1", "test_2", "test_3"])
+        self.assertEqual(len(bt_cls.results.skipped), 3)
         self.assertEqual(bt_cls.results.summary_str(),
                          ("Error 0, Executed 0, Failed 0, Passed 0, "
                           "Requested 3, Skipped 3"))


### PR DESCRIPTION
Fix a bug where summary json does not include the entries for skipped tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/244)
<!-- Reviewable:end -->
