### PR TITLE
Support persistent session to make sure UIAutomation works with USB disconnection

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -89,7 +89,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         """Overrides superclass. Launches a snippet app and connects to it."""
         self._check_app_installed()
 
-        persists_shell_cmd = self._get_command_executable()
+        persists_shell_cmd = self._get_persist_command_executable()
         # Try launching the app with the v1 protocol. If that fails, fall back
         # to v0 for compatibility. Use info here so people know exactly what's
         # happening here, which is helpful since they need to create their own
@@ -305,7 +305,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
             self.log.debug('Discarded line from instrumentation output: "%s"',
                            line)
 
-    def _get_command_executable(self):
+    def _get_persist_command_executable(self):
         """Check availability and return path of command if available."""
         for command in [_SETSID_COMMAND, _NOHUP_COMMAND]:
             try:

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -315,5 +315,6 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
                 continue
         self.log.warning('No %s and %s commands available to launch instrument '
                          'persistently, tests that depend on UiAutomator and '
-                         'at the same time performs USB disconnection may fail')
+                         'at the same time performs USB disconnection may fail',
+                         _SETSID_COMMAND, _NOHUP_COMMAND)
         return ''

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -89,7 +89,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         """Overrides superclass. Launches a snippet app and connects to it."""
         self._check_app_installed()
 
-        persists_shell_cmd = self._get_persist_command_executable()
+        persists_shell_cmd = self._get_persist_command()
         # Try launching the app with the v1 protocol. If that fails, fall back
         # to v0 for compatibility. Use info here so people know exactly what's
         # happening here, which is helpful since they need to create their own
@@ -305,7 +305,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
             self.log.debug('Discarded line from instrumentation output: "%s"',
                            line)
 
-    def _get_persist_command_executable(self):
+    def _get_persist_command(self):
         """Check availability and return path of command if available."""
         for command in [_SETSID_COMMAND, _NOHUP_COMMAND]:
             try:

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -313,4 +313,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
                     return command
             except adb.AdbError:
                 continue
+        self.log.warning('No %s and %s commands available to launch instrument '
+                         'persistently, tests that depend on UiAutomator and '
+                         'at the same time performs USB disconnection may fail')
         return ''

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -24,11 +24,11 @@ _INSTRUMENTATION_RUNNER_PACKAGE = (
     'com.google.android.mobly.snippet.SnippetRunner')
 
 # TODO(adorokhine): delete this in Mobly 1.6 when snippet v0 support is removed.
-_LAUNCH_CMD_V0 = ('am instrument -w -e action start -e port %s %s/' +
+_LAUNCH_CMD_V0 = ('%s am instrument -w -e action start -e port %s %s/' +
                   _INSTRUMENTATION_RUNNER_PACKAGE)
 
 _LAUNCH_CMD_V1 = (
-    'am instrument -w -e action start %s/' + _INSTRUMENTATION_RUNNER_PACKAGE)
+    '%s am instrument -w -e action start %s/' + _INSTRUMENTATION_RUNNER_PACKAGE)
 
 _STOP_CMD = (
     'am instrument -w -e action stop %s/' + _INSTRUMENTATION_RUNNER_PACKAGE)
@@ -100,7 +100,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         # instrumentations and manifest.
         self.log.info('Launching snippet apk %s with protocol v1',
                       self.package)
-        cmd = persists_shell_cmd + ' ' + _LAUNCH_CMD_V1 % self.package
+        cmd = _LAUNCH_CMD_V1 % (persists_shell_cmd, self.package)
         start_time = time.time()
         self._proc = self._do_start_app(cmd)
 
@@ -123,8 +123,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
             # Reuse the host port as the device port in v0 snippet. This isn't
             # safe in general, but the protocol is deprecated.
             self.device_port = self.host_port
-            cmd = persists_shell_cmd + ' ' + _LAUNCH_CMD_V0 % (
-                self.device_port, self.package)
+            cmd = _LAUNCH_CMD_V0 % (persists_shell_cmd, self.device_port, self.package)
             self._proc = self._do_start_app(cmd)
             self._connect_to_v0()
             self._launch_version = 'v0'
@@ -312,7 +311,5 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
 
     def _file_exists(self, path):
         """Check whether or not a file exists on device."""
-        # adb shell always return 0
-        # https://code.google.com/p/android/issues/detail?id=3254
-        rc = self._adb.shell('[ -e "%s" ]; echo $?' % path)
-        return rc.strip() == '0'
+        return_code = self._adb.shell('[ -e "%s" ]; echo $?' % path)
+        return return_code.strip() == '0'

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -37,7 +37,7 @@ _STOP_CMD = (
 # test is in progress. However, this requirement does not hold for the test that
 # deals with device USB disconnection (Once device disconnects, the shell
 # session that started the instrument ends, and UiAutomation fails with error:
-# "UiAutomation not connected"). To keep the shell session and redirects
+# "UiAutomation not connected"). To keep the shell session and redirect
 # stdin/stdout/stderr, use "setsid" or "nohup" while launching the
 # instrumentation test. Because these commands may not be available in every
 # android system, try to use them only if exists.
@@ -89,7 +89,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         """Overrides superclass. Launches a snippet app and connects to it."""
         self._check_app_installed()
 
-        persists_shell_cmd = self._get_command_path()
+        persists_shell_cmd = self._get_command_executable()
         # Try launching the app with the v1 protocol. If that fails, fall back
         # to v0 for compatibility. Use info here so people know exactly what's
         # happening here, which is helpful since they need to create their own
@@ -305,11 +305,12 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
             self.log.debug('Discarded line from instrumentation output: "%s"',
                            line)
 
-    def _get_command_path(self):
+    def _get_command_executable(self):
         """Check availability and return path of command if available."""
         for command in [_SETSID_COMMAND, _NOHUP_COMMAND]:
             try:
-                return self._adb.shell('which %s' % command)
+                if command in self._adb.shell('which %s' % command):
+                    return command
             except adb.AdbError:
                 continue
         return ''

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -18,6 +18,7 @@ from builtins import bytes
 import mock
 import unittest
 
+from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import jsonrpc_client_base
 from mobly.controllers.android_device_lib import snippet_client
 from tests.lib import jsonrpc_client_test_base
@@ -51,8 +52,8 @@ class MockAdbProxy(object):
             return bytes('instrumentation:{p}/{r} (target={p})'.format(
                 p=MOCK_PACKAGE_NAME,
                 r=snippet_client._INSTRUMENTATION_RUNNER_PACKAGE), 'utf-8')
-        elif 'echo' in params:
-            return '0'
+        elif 'which' in params:
+            return ''
 
     def __getattr__(self, name):
         """All calls to the none-existent functions in adb proxy would
@@ -178,8 +179,12 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
         client.start_app_and_connect()
         self.assertEqual(123, client.device_port)
 
-    @mock.patch('mobly.controllers.android_device_lib.snippet_client.'
-                'SnippetClient._file_exists')
+    def _mocked_shell(self, arg):
+        if 'setsid' in arg:
+            raise adb.AdbError('cmd', 'stdout', 'stderr', 'ret_code')
+        else:
+            return 'nohup'
+
     @mock.patch('mobly.controllers.android_device_lib.snippet_client.'
                 'SnippetClient._do_start_app')
     @mock.patch('mobly.controllers.android_device_lib.snippet_client.'
@@ -188,10 +193,12 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
                 'SnippetClient._read_protocol_line')
     @mock.patch('mobly.controllers.android_device_lib.snippet_client.'
                 'SnippetClient._connect_to_v1')
+    @mock.patch('mobly.controllers.android_device_lib.snippet_client.'
+                'utils.get_available_host_port')
     def test_snippet_start_app_and_connect_v1_persistent_session(
-            self, mock_connect_to_v1, mock_read_protocol_line,
-            mock_check_app_installed, mock_do_start_app,
-            mock_file_exists):
+            self, mock_get_port, mock_connect_to_v1, mock_read_protocol_line,
+            mock_check_app_installed, mock_do_start_app):
+        mock_get_port.return_value = 123
         mock_read_protocol_line.side_effect = [
             'SNIPPET START, PROTOCOL 1 234',
             'SNIPPET SERVING, PORT 1234',
@@ -200,22 +207,23 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
             'SNIPPET START, PROTOCOL 1 234',
             'SNIPPET SERVING, PORT 1234',
         ]
+
         # Test 'setsid' exists
-        mock_file_exists.return_value = True
         client = self._make_client()
+        client._adb.shell = mock.Mock(return_value='setsid')
         client.start_app_and_connect()
         cmd_setsid = '%s am instrument -w -e action start %s/%s' % (
-            snippet_client._SETSID_PATH,
+            snippet_client._SETSID_COMMAND,
             MOCK_PACKAGE_NAME,
             snippet_client._INSTRUMENTATION_RUNNER_PACKAGE)
         mock_do_start_app.assert_has_calls(mock.call(cmd_setsid))
 
         # Test 'setsid' does not exist, but 'nohup' exsits
-        mock_file_exists.side_effect = [False, True]
         client = self._make_client()
+        client._adb.shell = self._mocked_shell
         client.start_app_and_connect()
         cmd_nohup = '%s am instrument -w -e action start %s/%s' % (
-            snippet_client._NOHUP_PATH,
+            snippet_client._NOHUP_COMMAND,
             MOCK_PACKAGE_NAME,
             snippet_client._INSTRUMENTATION_RUNNER_PACKAGE)
         mock_do_start_app.assert_has_calls([
@@ -224,7 +232,8 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
         ])
 
         # Test both 'setsid' and 'nohup' do not exist
-        mock_file_exists.side_effect = [False, False]
+        client._adb.shell = mock.Mock(
+            side_effect=adb.AdbError('cmd', 'stdout', 'stderr', 'ret_code'))
         client = self._make_client()
         client.start_app_and_connect()
         cmd_not_persist = ' am instrument -w -e action start %s/%s' % (

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -51,6 +51,8 @@ class MockAdbProxy(object):
             return bytes('instrumentation:{p}/{r} (target={p})'.format(
                 p=MOCK_PACKAGE_NAME,
                 r=snippet_client._INSTRUMENTATION_RUNNER_PACKAGE), 'utf-8')
+        elif 'echo' in params:
+            return '0'
 
     def __getattr__(self, name):
         """All calls to the none-existent functions in adb proxy would


### PR DESCRIPTION
For test that performs USB disconnection, if it also depends on UiAutomation, it will fail because UiAutomation requires persistent shell session.

Add "setsid" or "nohup" in front of instrument command to make sure the session is persistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/251)
<!-- Reviewable:end -->
