### PR TITLE
Fix a bug where timestamps are set on tests that didn't even start.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -503,9 +503,6 @@ class BaseTestClass(object):
             if not self.results.is_test_executed(test_name):
                 test_record = records.TestResultRecord(test_name, self.TAG)
                 test_record.test_skip(exception)
-                # Set the begin and end time to None as the test never started.
-                test_record.begin_time = None
-                test_record.end_time = None
                 self.results.add_record(test_record)
 
     def run(self, test_names=None):

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -503,6 +503,9 @@ class BaseTestClass(object):
             if not self.results.is_test_executed(test_name):
                 test_record = records.TestResultRecord(test_name, self.TAG)
                 test_record.test_skip(exception)
+                # Set the begin and end time to None as the test never started.
+                test_record.begin_time = None
+                test_record.end_time = None
                 self.results.add_record(test_record)
 
     def run(self, test_names=None):

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -89,7 +89,8 @@ class TestResultRecord(object):
                 be any exception instance or of any subclass of
                 mobly.signals.TestSignal.
         """
-        self.end_time = utils.get_current_epoch_time()
+        if self.begin_time is not None:
+            self.end_time = utils.get_current_epoch_time()
         self.result = result
         if self.extra_errors:
             self.result = TestResultEnums.TEST_RESULT_ERROR

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -871,6 +871,8 @@ class BaseTestTest(unittest.TestCase):
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run(test_names=["test_func"])
         actual_record = bt_cls.results.skipped[0]
+        self.assertIsNotNone(actual_record.begin_time)
+        self.assertIsNotNone(actual_record.end_time)
         self.assertEqual(actual_record.test_name, "test_func")
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertEqual(actual_record.extras, MOCK_EXTRA)
@@ -886,6 +888,8 @@ class BaseTestTest(unittest.TestCase):
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run(test_names=["test_func"])
         actual_record = bt_cls.results.skipped[0]
+        self.assertIsNotNone(actual_record.begin_time)
+        self.assertIsNotNone(actual_record.end_time)
         self.assertEqual(actual_record.test_name, "test_func")
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertEqual(actual_record.extras, MOCK_EXTRA)

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -189,9 +189,11 @@ class BaseTestTest(unittest.TestCase):
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
         actual_record = bt_cls.results.error[0]
+        skipped_record = bt_cls.results.skipped[0]
+        self.assertIsNone(skipped_record.begin_time)
+        self.assertIsNone(skipped_record.end_time)
         utils.validate_test_result(bt_cls.results)
         self.assertEqual(actual_record.test_name, "setup_class")
-
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
         expected_summary = ("Error 1, Executed 0, Failed 0, Passed 0, "


### PR DESCRIPTION
Also add unit test conditions for this case.
Fixes #268

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/269)
<!-- Reviewable:end -->
