### PR TITLE
Minor fix in AndroidDevice.load_snippet doc.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -688,7 +688,6 @@ class AndroidDevice(object):
         """Starts the snippet apk with the given package name and connects.
 
         Examples:
-            >>> ad = AndroidDevice()
             >>> ad.load_snippet(
                     name='maps', package='com.google.maps.snippets')
             >>> ad.maps.activateZoom('3')


### PR DESCRIPTION
Remove the instantiation line as tests should use `register_controller` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/280)
<!-- Reviewable:end -->
