### PR TITLE
Properly record extra errors.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -327,6 +327,7 @@ class BaseTestClass(object):
         tr_record = records.TestResultRecord(test_name, self.TAG)
         tr_record.test_begin()
         logging.info('%s %s', TEST_CASE_TOKEN, test_name)
+        teardown_test_failed = False
         try:
             try:
                 self._setup_test(test_name)
@@ -348,6 +349,7 @@ class BaseTestClass(object):
                 except Exception as e:
                     logging.exception(e)
                     tr_record.add_error('teardown_test', e)
+                    teardown_test_failed = True
         except (signals.TestFailure, AssertionError) as e:
             tr_record.test_fail(e)
         except signals.TestSkip as e:
@@ -364,7 +366,8 @@ class BaseTestClass(object):
             # Exception happened during test.
             tr_record.test_error(e)
         else:
-            tr_record.test_pass()
+            if not teardown_test_failed:
+                tr_record.test_pass()
         finally:
             if tr_record.result in (records.TestResultEnums.TEST_RESULT_ERROR,
                                     records.TestResultEnums.TEST_RESULT_FAIL):

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -301,9 +301,9 @@ class BaseTestClass(object):
                 executed.
         """
         try:
-          # Pass a copy of the record instead of the actual object so that it
-          # will not be modified.
-          func(copy.deepcopy(tr_record))
+            # Pass a copy of the record instead of the actual object so that it
+            # will not be modified.
+            func(copy.deepcopy(tr_record))
         except signals.TestAbortAll:
             raise
         except Exception as e:
@@ -369,6 +369,7 @@ class BaseTestClass(object):
             if not teardown_test_failed:
                 tr_record.test_pass()
         finally:
+            tr_record.update_record()
             if tr_record.result in (records.TestResultEnums.TEST_RESULT_ERROR,
                                     records.TestResultEnums.TEST_RESULT_FAIL):
                 self._exec_procedure_func(self._on_fail, tr_record)

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -196,17 +196,10 @@ class TestResultRecord(object):
         begin_time: Epoch timestamp of when the test started.
         end_time: Epoch timestamp of when the test ended.
         uid: Unique identifier of a test.
+        termination_signal: ExceptionRecord, the main exception of the test.
+        extra_errors: OrderedDict, all exceptions occurred during the entire
+            test lifecycle. The order of occurrence is preserved.
         result: TestResultEnum.TEAT_RESULT_*, PASS/FAIL/SKIP.
-        extras: User defined extra information of the test result, must be
-                serializable.
-        details: string, description of the cause of the test's termination.
-                 Note a passed test can have this as well due to the explicit
-                 pass signal. If the test passed implicitly, this field would
-                 be None.
-        stacktrace: string, the stacktrace for the exception that terminated
-                    the test.
-        extra_errors: OrderedDict, all exceptions occurred during the entire test
-                    lifecycle. The order of occurrence is preserved.
     """
 
     def __init__(self, t_name, t_class=None):
@@ -221,16 +214,27 @@ class TestResultRecord(object):
 
     @property
     def details(self):
+        """String description of the cause of the test's termination.
+
+        Note a passed test can have this as well due to the explicit pass
+        signal. If the test passed implicitly, this field would be None.
+        """
         if self.termination_signal:
             return self.termination_signal.details
 
     @property
     def stacktrace(self):
+        """The stacktrace string for the exception that terminated the test.
+        """
         if self.termination_signal:
             return self.termination_signal.stacktrace
 
     @property
     def extras(self):
+        """User defined extra information of the test result.
+
+        Must be serializable.
+        """
         if self.termination_signal:
             return self.termination_signal.extras
 
@@ -247,8 +251,8 @@ class TestResultRecord(object):
         Args:
             result: One of the TEST_RESULT enums in TestResultEnums.
             e: A test termination signal (usually an exception object). It can
-               be any exception instance or of any subclass of
-               mobly.signals.TestSignal.
+                be any exception instance or of any subclass of
+                mobly.signals.TestSignal.
         """
         if self.begin_time is not None:
             self.end_time = utils.get_current_epoch_time()

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -226,7 +226,8 @@ class TestResultRecord(object):
             # have to immediately retrieve stacktrace from `sys.exc_info`.
             _, _, exc_traceback = sys.exc_info()
         if exc_traceback:
-            stacktrace_str = ''.join(traceback.format_tb(exc_traceback))
+            stacktrace_str = ''.join(
+                traceback.format_exception(e.__class__, e, exc_traceback))
             self.stacktrace = stacktrace_str
             if e and not hasattr(e, 'stacktrace_str'):
                 e.stacktrace_str = stacktrace_str
@@ -293,7 +294,8 @@ class TestResultRecord(object):
             # have to immediately retrieve stacktrace from `sys.exc_info`.
             _, _, exc_traceback = sys.exc_info()
         if exc_traceback:
-            stacktrace_str = ''.join(traceback.format_tb(exc_traceback))
+            stacktrace_str = ''.join(
+                traceback.format_exception(e.__class__, e, exc_traceback))
             if not hasattr(e, 'stacktrace_str'):
                 e.stacktrace_str = stacktrace_str
 

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -127,7 +127,7 @@ class TestResultEnums(object):
 
 
 class TestResultRecord(object):
-    """A record that holds the information of a single test case.
+    """A record that holds the information of a single test.
 
     Attributes:
         test_name: string, the name of the test.

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -245,11 +245,14 @@ class TestResultRecord(object):
         if e:
             self.termination_signal = ExceptionRecord(e)
 
-    def finalize_record(self):
-        """Finalizes the content of a record.
+    def update_record(self):
+        """Updates the content of a record.
 
-        No write operation should be performed on the record after this is
-        called.
+        Several display fields like "details" and "stacktrace" need to be
+        updated based on the content of the record object.
+
+        As the content of the record change, call this method to update all
+        the appropirate fields.
         """
         if self.extra_errors:
             if self.result in (TestResultEnums.TEST_RESULT_PASS,
@@ -437,7 +440,7 @@ class TestResult(object):
         Args:
             record: A test record object to add.
         """
-        record.finalize_record()
+        record.update_record()
         if record.result == TestResultEnums.TEST_RESULT_SKIP:
             self.skipped.append(record)
             return
@@ -470,7 +473,7 @@ class TestResult(object):
         Args:
             test_record: A TestResultRecord object for the test class.
         """
-        test_record.finalize_record()
+        test_record.update_record()
         self.error.append(test_record)
 
     def is_test_executed(self, test_name):

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -216,6 +216,9 @@ class TestResultRecord(object):
             self.extras = e.extras
         elif isinstance(e, Exception):
             self.details = failure_location + str(e)
+        # Record stacktrace of the exception.
+        # In py2, exception objects don't have built-in traceback, so we have
+        # to immediately retrieve stacktrace from `sys.exc_info`.
         _, _, exc_traceback = sys.exc_info()
         if exc_traceback:
             stacktrace_str = ''.join(traceback.format_tb(exc_traceback))

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -129,6 +129,14 @@ class TestResultEnums(object):
 
 class ExceptionRecord(object):
     """A wrapper class for representing exception objects in TestResultRecord.
+
+    Attributes:
+        exception: Exception object, the original Exception.
+        stacktrace: string, stacktrace of the Exception.
+        extras: optional serializable, this corresponds to the
+            `TestSignal.extras` field.
+        position: string, an optional label specifying the position where the
+            Exception ocurred.
     """
 
     def __init__(self, e, position=None):
@@ -238,6 +246,11 @@ class TestResultRecord(object):
             self.termination_signal = ExceptionRecord(e)
 
     def finalize_record(self):
+        """Finalizes the content of a record.
+
+        No write operation should be performed on the record after this is
+        called.
+        """
         if self.extra_errors:
             if self.result in (TestResultEnums.TEST_RESULT_PASS,
                                TestResultEnums.TEST_RESULT_SKIP):
@@ -417,6 +430,9 @@ class TestResult(object):
         """Adds a test record to test result.
 
         A record is considered executed once it's added to the test result.
+
+        Adding the record finalizes the content of a record, so no change
+        should be made to the record afterwards.
 
         Args:
             record: A test record object to add.

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -217,13 +217,18 @@ class TestResultRecord(object):
         elif isinstance(e, Exception):
             self.details = failure_location + str(e)
         # Record stacktrace of the exception.
-        # In py2, exception objects don't have built-in traceback, so we have
-        # to immediately retrieve stacktrace from `sys.exc_info`.
-        _, _, exc_traceback = sys.exc_info()
+        # This check cannot be based on try...except, which messes up
+        # `exc_info`.
+        if e and hasattr(e, '__traceback__'):
+            exc_traceback = e.__traceback__
+        else:
+            # In py2, exception objects don't have built-in traceback, so we
+            # have to immediately retrieve stacktrace from `sys.exc_info`.
+            _, _, exc_traceback = sys.exc_info()
         if exc_traceback:
             stacktrace_str = ''.join(traceback.format_tb(exc_traceback))
             self.stacktrace = stacktrace_str
-            if not hasattr(e, 'stacktrace_str'):
+            if e and not hasattr(e, 'stacktrace_str'):
                 e.stacktrace_str = stacktrace_str
 
     def test_pass(self, e=None):
@@ -279,7 +284,14 @@ class TestResultRecord(object):
         """
         self.result = TestResultEnums.TEST_RESULT_ERROR
         self.extra_errors[position] = e
-        _, _, exc_traceback = sys.exc_info()
+        # This check cannot be based on try...except, which messes up
+        # `exc_info`.
+        if e and hasattr(e, '__traceback__'):
+            exc_traceback = e.__traceback__
+        else:
+            # In py2, exception objects don't have built-in traceback, so we
+            # have to immediately retrieve stacktrace from `sys.exc_info`.
+            _, _, exc_traceback = sys.exc_info()
         if exc_traceback:
             stacktrace_str = ''.join(traceback.format_tb(exc_traceback))
             if not hasattr(e, 'stacktrace_str'):

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -259,8 +259,7 @@ class BaseTestTest(unittest.TestCase):
         bt_cls.run()
         actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
-        self.assertEqual(actual_record.details,
-                         'teardown_test: ' + MSG_EXPECTED_EXCEPTION)
+        self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
@@ -278,8 +277,7 @@ class BaseTestTest(unittest.TestCase):
         bt_cls.run()
         actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
-        self.assertEqual(actual_record.details,
-                         'teardown_test: ' + MSG_EXPECTED_EXCEPTION)
+        self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
         self.assertFalse(actual_record.extra_errors)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
@@ -373,11 +371,10 @@ class BaseTestTest(unittest.TestCase):
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        my_mock.assert_called_once_with("on_fail")
+        my_mock.assert_called_once_with('on_fail')
         actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
-        self.assertEqual(actual_record.details,
-                         'teardown_test: ' + MSG_EXPECTED_EXCEPTION)
+        self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
@@ -465,9 +462,8 @@ class BaseTestTest(unittest.TestCase):
         actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
-        self.assertEqual(
-            str(actual_record.extra_errors['teardown_test']),
-            'This is an expected exception.ha')
+        self.assertEqual(actual_record.extra_errors['teardown_test'].details,
+                         'This is an expected exception.ha')
         self.assertIsNone(actual_record.extras)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
@@ -507,12 +503,12 @@ class BaseTestTest(unittest.TestCase):
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.error[0]
+        actual_record = bt_cls.results.failed[0]
         self.assertIn('_on_fail', actual_record.extra_errors)
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+        expected_summary = ("Error 0, Executed 1, Failed 1, Passed 0, "
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
@@ -529,9 +525,8 @@ class BaseTestTest(unittest.TestCase):
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
         actual_record = bt_cls.results.error[0]
-        print(actual_record.to_dict())
-        self.assertEqual(
-            str(actual_record.extra_errors['_on_pass']), expected_msg)
+        self.assertEqual(actual_record.extra_errors['_on_pass'].details,
+                         expected_msg)
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
@@ -553,9 +548,9 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, "Test Body Exception.")
         self.assertIsNone(actual_record.extras)
-        self.assertEqual(
-            str(actual_record.extra_errors["teardown_test"]),
-            "Details=This is an expected exception., Extras=None")
+        self.assertEqual(actual_record.extra_errors['teardown_test'].details,
+                         MSG_EXPECTED_EXCEPTION)
+        self.assertIsNone(actual_record.extra_errors['teardown_test'].extras)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
@@ -576,13 +571,13 @@ class BaseTestTest(unittest.TestCase):
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
         actual_record = bt_cls.results.error[0]
-        self.assertIs(actual_record.termination_signal,
+        self.assertIs(actual_record.termination_signal.exception,
                       expected_termination_signal)
-        self.assertIsNotNone(actual_record.termination_signal.stacktrace_str)
+        self.assertIsNotNone(actual_record.termination_signal.stacktrace)
         self.assertEqual(len(actual_record.extra_errors), 1)
         extra_error = actual_record.extra_errors['teardown_test']
-        self.assertIs(extra_error, expected_extra_error)
-        self.assertIsNotNone(extra_error.stacktrace_str)
+        self.assertIs(extra_error.exception, expected_extra_error)
+        self.assertIsNotNone(extra_error.stacktrace)
         self.assertIsNone(actual_record.extras)
 
     def test_promote_extra_errors_to_termination_signal(self):
@@ -602,8 +597,7 @@ class BaseTestTest(unittest.TestCase):
         bt_cls.run()
         actual_record = bt_cls.results.error[0]
         self.assertFalse(actual_record.extra_errors)
-        self.assertEqual(actual_record.details,
-                         'teardown_test: teardown_test Exception.')
+        self.assertEqual(actual_record.details, 'teardown_test Exception.')
         self.assertIsNotNone(actual_record.stacktrace)
 
     def test_explicit_pass_but_teardown_test_raises_an_exception(self):
@@ -615,17 +609,17 @@ class BaseTestTest(unittest.TestCase):
                 asserts.assert_true(False, MSG_EXPECTED_EXCEPTION)
 
             def test_something(self):
-                asserts.explicit_pass("Test Passed!")
+                asserts.explicit_pass('Test Passed!')
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
         actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
-        self.assertEqual(actual_record.details, "Test Passed!")
+        self.assertEqual(actual_record.details, 'Test Passed!')
         self.assertIsNone(actual_record.extras)
-        self.assertEqual(
-            str(actual_record.extra_errors["teardown_test"]),
-            "Details=This is an expected exception., Extras=None")
+        self.assertEqual(actual_record.extra_errors['teardown_test'].details,
+                         MSG_EXPECTED_EXCEPTION)
+        self.assertIsNone(actual_record.extra_errors['teardown_test'].extras)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
@@ -658,9 +652,8 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertEqual(actual_record.extras, MOCK_EXTRA)
-        self.assertEqual(
-            str(actual_record.extra_errors['_on_pass']),
-            MSG_EXPECTED_EXCEPTION)
+        self.assertEqual(actual_record.extra_errors['_on_pass'].details,
+                         MSG_EXPECTED_EXCEPTION)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
@@ -675,15 +668,13 @@ class BaseTestTest(unittest.TestCase):
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        actual_record = bt_cls.results.error[0]
-        self.assertEqual(bt_cls.results.failed, [])
+        actual_record = bt_cls.results.failed[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertEqual(actual_record.extras, MOCK_EXTRA)
-        self.assertEqual(
-            str(actual_record.extra_errors['_on_fail']),
-            MSG_EXPECTED_EXCEPTION)
-        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
+        self.assertEqual(actual_record.extra_errors['_on_fail'].details,
+                         MSG_EXPECTED_EXCEPTION)
+        expected_summary = ("Error 0, Executed 1, Failed 1, Passed 0, "
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -250,7 +250,7 @@ class BaseTestTest(unittest.TestCase):
     def test_teardown_test_assert_fail(self):
         class MockBaseTest(base_test.BaseTestClass):
             def teardown_test(self):
-                asserts.assert_true(False, MSG_EXPECTED_EXCEPTION)
+                asserts.fail(MSG_EXPECTED_EXCEPTION)
 
             def test_something(self):
                 pass
@@ -259,7 +259,8 @@ class BaseTestTest(unittest.TestCase):
         bt_cls.run()
         actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
-        self.assertIsNone(actual_record.details)
+        self.assertEqual(actual_record.details,
+                         'teardown_test: ' + MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
@@ -277,10 +278,10 @@ class BaseTestTest(unittest.TestCase):
         bt_cls.run()
         actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
-        self.assertIsNone(actual_record.details)
+        self.assertEqual(actual_record.details,
+                         'teardown_test: ' + MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
-        expected_extra_error = {"teardown_test": MSG_EXPECTED_EXCEPTION}
-        self.assertEqual(actual_record.extra_errors, expected_extra_error)
+        self.assertFalse(actual_record.extra_errors)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
@@ -375,7 +376,8 @@ class BaseTestTest(unittest.TestCase):
         my_mock.assert_called_once_with("on_fail")
         actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
-        self.assertIsNone(actual_record.details)
+        self.assertEqual(actual_record.details,
+                         'teardown_test: ' + MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
@@ -463,8 +465,9 @@ class BaseTestTest(unittest.TestCase):
         actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
-        self.assertEqual(actual_record.extra_errors,
-                         {'teardown_test': 'This is an expected exception.ha'})
+        self.assertEqual(
+            str(actual_record.extra_errors['teardown_test']),
+            'This is an expected exception.ha')
         self.assertIsNone(actual_record.extras)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
@@ -526,8 +529,8 @@ class BaseTestTest(unittest.TestCase):
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
         actual_record = bt_cls.results.error[0]
-        expected_extra_error = {'_on_pass': expected_msg}
-        self.assertEqual(actual_record.extra_errors, expected_extra_error)
+        self.assertEqual(
+            str(actual_record.extra_errors['_on_pass']), expected_msg)
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertIsNone(actual_record.extras)
@@ -549,8 +552,10 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, "Test Body Exception.")
         self.assertIsNone(actual_record.extras)
-        self.assertEqual(actual_record.extra_errors["teardown_test"],
-                         "Details=This is an expected exception., Extras=None")
+        # self.assertIsNone(actual_record.to_dict())
+        self.assertEqual(
+            str(actual_record.extra_errors["teardown_test"]),
+            "Details=This is an expected exception., Extras=None")
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
@@ -572,8 +577,9 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, "Test Passed!")
         self.assertIsNone(actual_record.extras)
-        self.assertEqual(actual_record.extra_errors["teardown_test"],
-                         "Details=This is an expected exception., Extras=None")
+        self.assertEqual(
+            str(actual_record.extra_errors["teardown_test"]),
+            "Details=This is an expected exception., Extras=None")
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
@@ -606,8 +612,9 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertEqual(actual_record.extras, MOCK_EXTRA)
-        self.assertEqual(actual_record.extra_errors,
-                         {'_on_pass': MSG_EXPECTED_EXCEPTION})
+        self.assertEqual(
+            str(actual_record.extra_errors['_on_pass']),
+            MSG_EXPECTED_EXCEPTION)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
@@ -627,8 +634,9 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertEqual(actual_record.extras, MOCK_EXTRA)
-        self.assertEqual(actual_record.extra_errors,
-                         {'_on_fail': MSG_EXPECTED_EXCEPTION})
+        self.assertEqual(
+            str(actual_record.extra_errors['_on_fail']),
+            MSG_EXPECTED_EXCEPTION)
         expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -40,7 +40,7 @@ class RecordsTest(unittest.TestCase):
         shutil.rmtree(self.tmp_path)
 
     def verify_record(self, record, result, details, extras, stacktrace=None):
-        record.finalize_record()
+        record.update_record()
         # Verify each field.
         self.assertEqual(record.test_name, self.tn)
         self.assertEqual(record.result, result)

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -131,15 +131,14 @@ class RecordsTest(unittest.TestCase):
         # Verify stacktrace separately if we expect a non-None value.
         # Because stacktrace includes file names and line numbers, we can't do
         # a simple equality check.
-        record.stacktrace = None
         self.verify_record(
             record=record,
             result=records.TestResultEnums.TEST_RESULT_FAIL,
             details='Something failed.',
             extras=None,
-            stacktrace=
-            'in test_result_record_fail_stacktrace\n    raise Exception(\'Something failed.\')\nException: Something failed.\n'
-        )
+            stacktrace='in test_result_record_fail_stacktrace\n    '
+            'raise Exception(\'Something failed.\')\nException: '
+            'Something failed.\n')
 
     def test_result_record_fail_with_float_extra(self):
         record = records.TestResultRecord(self.tn)

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -28,6 +28,7 @@ from tests.lib import utils
 class RecordsTest(unittest.TestCase):
     """This test class tests the implementation of classes in mobly.records.
     """
+
     def setUp(self):
         self.tn = "test_name"
         self.details = "Some details about the test execution."
@@ -58,7 +59,7 @@ class RecordsTest(unittest.TestCase):
         d[records.TestResultEnums.RECORD_END_TIME] = record.end_time
         d[records.TestResultEnums.RECORD_UID] = None
         d[records.TestResultEnums.RECORD_CLASS] = None
-        d[records.TestResultEnums.RECORD_EXTRA_ERRORS] = {}
+        d[records.TestResultEnums.RECORD_EXTRA_ERRORS] = []
         d[records.TestResultEnums.RECORD_STACKTRACE] = None
         actual_d = record.to_dict()
         self.assertDictEqual(actual_d, d)

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -39,7 +39,8 @@ class RecordsTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp_path)
 
-    def verify_record(self, record, result, details, extras):
+    def verify_record(self, record, result, details, extras, stacktrace=None):
+        record.finalize_record()
         # Verify each field.
         self.assertEqual(record.test_name, self.tn)
         self.assertEqual(record.result, result)
@@ -60,8 +61,14 @@ class RecordsTest(unittest.TestCase):
         d[records.TestResultEnums.RECORD_UID] = None
         d[records.TestResultEnums.RECORD_CLASS] = None
         d[records.TestResultEnums.RECORD_EXTRA_ERRORS] = []
-        d[records.TestResultEnums.RECORD_STACKTRACE] = None
+        d[records.TestResultEnums.RECORD_STACKTRACE] = stacktrace
         actual_d = record.to_dict()
+        # Verify stacktrace partially match as stacktraces often have file path
+        # in them.
+        if stacktrace:
+            stacktrace_key = records.TestResultEnums.RECORD_STACKTRACE
+            self.assertTrue(
+                d.pop(stacktrace_key) in actual_d.pop(stacktrace_key))
         self.assertDictEqual(actual_d, d)
         # Verify that these code paths do not cause crashes and yield non-empty
         # results.
@@ -124,16 +131,15 @@ class RecordsTest(unittest.TestCase):
         # Verify stacktrace separately if we expect a non-None value.
         # Because stacktrace includes file names and line numbers, we can't do
         # a simple equality check.
-        self.assertTrue('Something failed.' in record.stacktrace)
-        self.assertTrue(
-            'in test_result_record_fail_stacktrace\n    raise Exception' in
-            record.stacktrace)
         record.stacktrace = None
         self.verify_record(
             record=record,
             result=records.TestResultEnums.TEST_RESULT_FAIL,
             details='Something failed.',
-            extras=None)
+            extras=None,
+            stacktrace=
+            'in test_result_record_fail_stacktrace\n    raise Exception(\'Something failed.\')\nException: Something failed.\n'
+        )
 
     def test_result_record_fail_with_float_extra(self):
         record = records.TestResultRecord(self.tn)


### PR DESCRIPTION
* Bump the first extra error to the main error of the record, if the test implicitly passed.
* Adjust unit tests to check the new behavior.
* Fix docstring for `TestResultRecord`.

This is the first PR for #264, more to come.
Fixes #261 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/284)
<!-- Reviewable:end -->
