### PR TITLE
Modified parse_args to parse_known_args

### DIFF
--- a/mobly/suite_runner.py
+++ b/mobly/suite_runner.py
@@ -70,7 +70,7 @@ def run_suite(test_classes, argv=None):
         help='A list of test classes and optional tests to execute.')
     if not argv:
         argv = sys.argv[1:]
-    args = parser.parse_args(argv)
+    args = parser.parse_known_args(argv)
     # Load test config file.
     test_configs = config_parser.load_test_config_file(args.config[0])
 

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -80,7 +80,7 @@ def main(argv=None):
         help='Specify which test beds to run tests on.')
     if not argv:
         argv = sys.argv[1:]
-    args = parser.parse_args(argv)
+    args = parser.parse_known_args(argv)
     # Load test config file.
     test_configs = config_parser.load_test_config_file(args.config[0],
                                                        args.test_bed)


### PR DESCRIPTION
Hey, I'm on Daydream and we use Mobly alongside OpenHTF to test our devices. This fix would make using Mobly with other libraries go more smoothly as Mobly currently fails when it sees arguments it doesn't recognize.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/286)
<!-- Reviewable:end -->
