### PR TITLE
Pass test record to procedure on_xxxx functions.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import collections
+import copy
 import functools
 import inspect
 import logging
@@ -218,21 +219,18 @@ class BaseTestClass(object):
         Args:
             record: The records.TestResultRecord object for the failed test.
         """
-        test_name = record.test_name
-        if record.details:
-            logging.error(record.details)
-        begin_time = logger.epoch_to_log_line_timestamp(record.begin_time)
-        logging.info(RESULT_LINE_TEMPLATE, test_name, record.result)
-        self.on_fail(test_name, begin_time)
+        logging.info(RESULT_LINE_TEMPLATE, record.test_name, record.result)
+        self.on_fail(copy.deepcopy(record))
 
-    def on_fail(self, test_name, begin_time):
+    def on_fail(self, record):
         """A function that is executed upon a test failure.
 
         User implementation is optional.
 
         Args:
-            test_name: Name of the test that triggered this function.
-            begin_time: Logline format timestamp taken when the test started.
+            record: records.TestResultRecord, the test record for this test,
+                    containing all information of the test execution including
+                    exception objects.
         """
 
     def _on_pass(self, record):
@@ -242,22 +240,21 @@ class BaseTestClass(object):
         Args:
             record: The records.TestResultRecord object for the passed test.
         """
-        test_name = record.test_name
-        begin_time = logger.epoch_to_log_line_timestamp(record.begin_time)
         msg = record.details
         if msg:
             logging.info(msg)
-        logging.info(RESULT_LINE_TEMPLATE, test_name, record.result)
-        self.on_pass(test_name, begin_time)
+        logging.info(RESULT_LINE_TEMPLATE, record.test_name, record.result)
+        self.on_pass(copy.deepcopy(record))
 
-    def on_pass(self, test_name, begin_time):
+    def on_pass(self, record):
         """A function that is executed upon a test passing.
 
         Implementation is optional.
 
         Args:
-            test_name: Name of the test that triggered this function.
-            begin_time: Logline format timestamp taken when the test started.
+            record: records.TestResultRecord, the test record for this test,
+                    containing all information of the test execution including
+                    exception objects.
         """
 
     def _on_skip(self, record):
@@ -267,20 +264,19 @@ class BaseTestClass(object):
         Args:
             record: The records.TestResultRecord object for the skipped test.
         """
-        test_name = record.test_name
-        begin_time = logger.epoch_to_log_line_timestamp(record.begin_time)
-        logging.info(RESULT_LINE_TEMPLATE, test_name, record.result)
         logging.info('Reason to skip: %s', record.details)
-        self.on_skip(test_name, begin_time)
+        logging.info(RESULT_LINE_TEMPLATE, record.test_name, record.result)
+        self.on_skip(copy.deepcopy(record))
 
-    def on_skip(self, test_name, begin_time):
+    def on_skip(self, record):
         """A function that is executed upon a test being skipped.
 
         Implementation is optional.
 
         Args:
-            test_name: Name of the test that triggered this function.
-            begin_time: Logline format timestamp taken when the test started.
+            record: records.TestResultRecord, the test record for this test,
+                    containing all information of the test execution including
+                    exception objects.
         """
 
     def _exec_procedure_func(self, func, tr_record):

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -406,6 +406,28 @@ class BaseTestTest(unittest.TestCase):
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
+    def test_procedure_function_gets_correct_record(self):
+        on_fail_mock = mock.MagicMock()
+        class MockBaseTest(base_test.BaseTestClass):
+            def on_fail(self, record):
+                on_fail_mock.record = record
+
+            def test_something(self):
+                asserts.fail(MSG_EXPECTED_EXCEPTION)
+
+        bt_cls = MockBaseTest(self.mock_test_cls_configs)
+        bt_cls.run()
+        actual_record = bt_cls.results.failed[0]
+        self.assertEqual(actual_record.test_name, 'test_something')
+        self.assertEqual(on_fail_mock.record.test_name, actual_record.test_name)
+        self.assertEqual(on_fail_mock.record.begin_time, actual_record.begin_time)
+        self.assertEqual(on_fail_mock.record.end_time, actual_record.end_time)
+        self.assertEqual(on_fail_mock.record.stacktrace, actual_record.stacktrace)
+        self.assertEqual(on_fail_mock.record.extras, actual_record.extras)
+        self.assertEqual(on_fail_mock.record.extra_errors, actual_record.extra_errors)
+        # But they are not the same object.
+        self.assertIsNot(on_fail_mock.record, actual_record)
+
     def test_on_fail_cannot_modify_original_record(self):
         class MockBaseTest(base_test.BaseTestClass):
             def on_fail(self, record):

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -184,7 +184,7 @@ class BaseTestTest(unittest.TestCase):
                 if not self.results.is_all_pass:
                     teardown_class_call_check("heehee")
 
-            def on_fail(self, test_name, begin_time):
+            def on_fail(self, record):
                 on_fail_call_check("haha")
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
@@ -337,7 +337,7 @@ class BaseTestTest(unittest.TestCase):
             def teardown_test(self):
                 my_mock("teardown_test")
 
-            def on_pass(self, test_name, begin_time):
+            def on_pass(self, record):
                 never_call()
 
             def test_something(self):
@@ -358,10 +358,10 @@ class BaseTestTest(unittest.TestCase):
         my_mock = mock.MagicMock()
 
         class MockBaseTest(base_test.BaseTestClass):
-            def on_fail(self, test_name, begin_time):
+            def on_fail(self, record):
                 my_mock("on_fail")
 
-            def on_pass(self, test_name, begin_time):
+            def on_pass(self, record):
                 never_call()
 
             def teardown_test(self):
@@ -385,11 +385,11 @@ class BaseTestTest(unittest.TestCase):
         my_mock = mock.MagicMock()
 
         class MockBaseTest(base_test.BaseTestClass):
-            def on_fail(self, test_name, begin_time):
+            def on_fail(self, record):
                 assert self.current_test_name == 'test_something'
                 my_mock("on_fail")
 
-            def on_pass(self, test_name, begin_time):
+            def on_pass(self, record):
                 never_call()
 
             def test_something(self):
@@ -406,14 +406,27 @@ class BaseTestTest(unittest.TestCase):
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
+    def test_on_fail_cannot_modify_original_record(self):
+        class MockBaseTest(base_test.BaseTestClass):
+            def on_fail(self, record):
+                record.test_name = 'blah'
+
+            def test_something(self):
+                asserts.assert_true(False, MSG_EXPECTED_EXCEPTION)
+
+        bt_cls = MockBaseTest(self.mock_test_cls_configs)
+        bt_cls.run()
+        actual_record = bt_cls.results.failed[0]
+        self.assertEqual(actual_record.test_name, 'test_something')
+
     def test_on_fail_executed_if_both_test_and_teardown_test_fails(self):
         on_fail_mock = mock.MagicMock()
 
         class MockBaseTest(base_test.BaseTestClass):
-            def on_fail(self, test_name, begin_time):
+            def on_fail(self, record):
                 on_fail_mock("on_fail")
 
-            def on_pass(self, test_name, begin_time):
+            def on_pass(self, record):
                 never_call()
 
             def teardown_test(self):
@@ -442,7 +455,7 @@ class BaseTestTest(unittest.TestCase):
             def setup_test(self):
                 raise Exception(MSG_EXPECTED_EXCEPTION)
 
-            def on_fail(self, test_name, begin_time):
+            def on_fail(self, record):
                 my_mock("on_fail")
 
             def test_something(self):
@@ -482,7 +495,7 @@ class BaseTestTest(unittest.TestCase):
         expected_msg = "Something failed in on_pass."
 
         class MockBaseTest(base_test.BaseTestClass):
-            def on_pass(self, test_name, begin_time):
+            def on_pass(self, record):
                 raise Exception(expected_msg)
 
             def test_something(self):
@@ -543,9 +556,22 @@ class BaseTestTest(unittest.TestCase):
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
+    def test_on_pass_cannot_modify_original_record(self):
+        class MockBaseTest(base_test.BaseTestClass):
+            def on_pass(self, record):
+                record.test_name = 'blah'
+
+            def test_something(self):
+                asserts.explicit_pass('Extra pass!')
+
+        bt_cls = MockBaseTest(self.mock_test_cls_configs)
+        bt_cls.run()
+        actual_record = bt_cls.results.passed[0]
+        self.assertEqual(actual_record.test_name, 'test_something')
+
     def test_on_pass_raise_exception(self):
         class MockBaseTest(base_test.BaseTestClass):
-            def on_pass(self, test_name, begin_time):
+            def on_pass(self, record):
                 raise Exception(MSG_EXPECTED_EXCEPTION)
 
             def test_something(self):
@@ -566,7 +592,7 @@ class BaseTestTest(unittest.TestCase):
 
     def test_on_fail_raise_exception(self):
         class MockBaseTest(base_test.BaseTestClass):
-            def on_fail(self, test_name, begin_time):
+            def on_fail(self, record):
                 raise Exception(MSG_EXPECTED_EXCEPTION)
 
             def test_something(self):


### PR DESCRIPTION
Instead of arbitrary fields, now pass all the info of the test execution so procedure functions can be more useful.

Also remove duplicated error log lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/293)
<!-- Reviewable:end -->
