### PR TITLE
Expose the callback id of `CallbackHandler`

### DIFF
--- a/mobly/controllers/android_device_lib/callback_handler.py
+++ b/mobly/controllers/android_device_lib/callback_handler.py
@@ -60,6 +60,10 @@ class CallbackHandler(object):
         self.ret_value = ret_value
         self._method_name = method_name
 
+    @property
+    def callback_id(self):
+        return self._id
+
     def waitAndGet(self, event_name, timeout=DEFAULT_TIMEOUT):
         """Blocks until an event of the specified name has been received and
         return the event, or timeout.

--- a/tests/mobly/controllers/android_device_lib/callback_handler_test.py
+++ b/tests/mobly/controllers/android_device_lib/callback_handler_test.py
@@ -39,6 +39,17 @@ class CallbackHandlerTest(unittest.TestCase):
         self.assertGreaterEqual(jsonrpc_client_base._SOCKET_READ_TIMEOUT,
                                 callback_handler.MAX_TIMEOUT)
 
+    def test_callback_id_property(self):
+        mock_event_client = mock.Mock()
+        handler = callback_handler.CallbackHandler(
+            callback_id=MOCK_CALLBACK_ID,
+            event_client=mock_event_client,
+            ret_value=None,
+            method_name=None)
+        self.assertEqual(handler.callback_id, MOCK_CALLBACK_ID)
+        with self.assertRaisesRegex(AttributeError, "can't set attribute"):
+            handler.callback_id = 'ha'
+
     def test_event_dict_to_snippet_event(self):
         mock_event_client = mock.Mock()
         mock_event_client.eventWaitAndGet = mock.Mock(


### PR DESCRIPTION
Use case: MBS's BLE stop scan APIs requires the callback id of the callback object generated by start scan.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/294)
<!-- Reviewable:end -->
