### PR TITLE
Refactor standing subprocess utils.

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -273,29 +273,13 @@ def concurrent_exec(func, param_list):
             try:
                 return_vals.append(future.result())
             except Exception as exc:
-                print("{} generated an exception: {}".format(
+                logging.exception("{} generated an exception: {}".format(
                     params, traceback.format_exc()))
                 return_vals.append(exc)
         return return_vals
 
 
-def _assert_subprocess_running(proc):
-    """Checks if a subprocess has terminated on its own.
-
-    Args:
-        proc: A subprocess returned by subprocess.Popen.
-
-    Raises:
-        Error is raised if the subprocess has stopped.
-    """
-    ret = proc.poll()
-    if ret is not None:
-        out, err = proc.communicate()
-        raise Error("Process %d has terminated. ret: %d, stderr: %s,"
-                    " stdout: %s" % (proc.pid, ret, err, out))
-
-
-def start_standing_subprocess(cmd, check_health_delay=0, shell=False):
+def start_standing_subprocess(cmd, shell=False):
     """Starts a long-running subprocess.
 
     This is not a blocking call and the subprocess started by it should be
@@ -304,36 +288,27 @@ def start_standing_subprocess(cmd, check_health_delay=0, shell=False):
     For short-running commands, you should use subprocess.check_call, which
     blocks.
 
-    You can specify a health check after the subprocess is started to make sure
-    it did not stop prematurely.
-
     Args:
         cmd: string, the command to start the subprocess with.
-        check_health_delay: float, the number of seconds to wait after the
-                            subprocess starts to check its health. Default is 0,
-                            which means no check.
         shell: bool, True to run this command through the system shell,
             False to invoke it directly. See subprocess.Proc() docs.
 
     Returns:
         The subprocess that was started.
     """
-    logging.debug('Start standing subprocess with cmd: %s', cmd)
+    logging.debug('Starting standing subprocess with: %s', cmd)
     proc = subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         shell=shell)
-    logging.debug('Start standing subprocess with cmd: %s', cmd)
     # Leaving stdin open causes problems for input, e.g. breaking the
     # code.inspect() shell (http://stackoverflow.com/a/25512460/1612937), so
     # explicitly close it assuming it is not needed for standing subprocesses.
     proc.stdin.close()
     proc.stdin = None
-    if check_health_delay > 0:
-        time.sleep(check_health_delay)
-        _assert_subprocess_running(proc)
+    logging.debug('Started standing subprocess %d', proc.pid)
     return proc
 
 
@@ -352,10 +327,9 @@ def stop_standing_subprocess(proc, kill_signal=signal.SIGTERM):
         Error: if the subprocess could not be stopped.
     """
     pid = proc.pid
-    logging.debug('Stop standing subprocess %d', pid)
-    _assert_subprocess_running(proc)
+    logging.debug('Stopping standing subprocess %d', pid)
     process = psutil.Process(pid)
-    success = True
+    failed = []
     try:
         children = process.children(recursive=True)
     except AttributeError:
@@ -365,18 +339,25 @@ def stop_standing_subprocess(proc, kill_signal=signal.SIGTERM):
         try:
             child.kill()
             child.wait(timeout=10)
+        except psutil.NoSuchProcess:
+            # Ignore if the child process has already terminated.
+            pass
         except:
-            success = False
+            failed.append(child.pid)
             logging.exception('Failed to kill standing subprocess %d',
                               child.pid)
     try:
         process.kill()
         process.wait(timeout=10)
+    except psutil.NoSuchProcess:
+        # Ignore if the process has already terminated.
+        pass
     except:
-        success = False
+        failed.append(pid)
         logging.exception('Failed to kill standing subprocess %d', pid)
-    if not success:
-        raise Error('Some standing subprocess failed to die')
+    if failed:
+        raise Error('Failed to kill standing subprocesses: %s' % failed)
+    logging.debug('Stopped standing subprocess %d', pid)
 
 
 def wait_for_standing_subprocess(proc, timeout=None):

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -18,6 +18,7 @@ import time
 from future.tests.base import unittest
 
 import portpicker
+import psutil
 from mobly import utils
 
 MOCK_AVAILABLE_PORT = 5
@@ -27,21 +28,17 @@ class UtilsTest(unittest.TestCase):
     """This test class has unit tests for the implementation of everything
     under mobly.utils.
     """
+
     def test_start_standing_subproc(self):
-        with self.assertRaisesRegex(utils.Error, 'Process .* has terminated'):
-            utils.start_standing_subprocess(
-                ['sleep', '0'], check_health_delay=0.5)
+        p = utils.start_standing_subprocess(['sleep', '1'])
+        p1 = psutil.Process(p.pid)
+        self.assertTrue(p1.is_running())
 
     def test_stop_standing_subproc(self):
-        p = utils.start_standing_subprocess(['sleep', '5'])
+        p = utils.start_standing_subprocess(['sleep', '4'])
+        p1 = psutil.Process(p.pid)
         utils.stop_standing_subprocess(p)
-        self.assertIsNotNone(p.poll())
-
-    def test_stop_standing_subproc_already_dead(self):
-        p = utils.start_standing_subprocess(['sleep', '0'])
-        time.sleep(0.5)
-        with self.assertRaisesRegex(utils.Error, 'Process .* has terminated'):
-            utils.stop_standing_subprocess(p)
+        self.assertFalse(p1.is_running())
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')


### PR DESCRIPTION
* Remove _assert_subprocess_running checks from util functions.
  - Users can use psutil.Process(pid) to do this check if needed..
* Better error msg for `stop_standing_subprocess`.
Fixes #288

Accidentally closed #290, reuploading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/297)
<!-- Reviewable:end -->
