### PR TITLE
Refactor passing record to procedure functions like `on_fail`

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -217,7 +217,7 @@ class BaseTestClass(object):
         called.
 
         Args:
-            record: records.TestResultRecord,  a copy of the test record for
+            record: records.TestResultRecord, a copy of the test record for
                     this test, containing all information of the test execution
                     including exception objects.
         """
@@ -230,7 +230,7 @@ class BaseTestClass(object):
         User implementation is optional.
 
         Args:
-            record: records.TestResultRecord,  a copy of the test record for
+            record: records.TestResultRecord, a copy of the test record for
                     this test, containing all information of the test execution
                     including exception objects.
         """
@@ -240,7 +240,7 @@ class BaseTestClass(object):
         called.
 
         Args:
-            record: records.TestResultRecord,  a copy of the test record for
+            record: records.TestResultRecord, a copy of the test record for
                     this test, containing all information of the test execution
                     including exception objects.
         """
@@ -256,7 +256,7 @@ class BaseTestClass(object):
         Implementation is optional.
 
         Args:
-            record: records.TestResultRecord,  a copy of the test record for
+            record: records.TestResultRecord, a copy of the test record for
                     this test, containing all information of the test execution
                     including exception objects.
         """
@@ -266,7 +266,7 @@ class BaseTestClass(object):
         called.
 
         Args:
-            record: records.TestResultRecord,  a copy of the test record for
+            record: records.TestResultRecord, a copy of the test record for
                     this test, containing all information of the test execution
                     including exception objects.
         """
@@ -280,7 +280,7 @@ class BaseTestClass(object):
         Implementation is optional.
 
         Args:
-            record: records.TestResultRecord,  a copy of the test record for
+            record: records.TestResultRecord, a copy of the test record for
                     this test, containing all information of the test execution
                     including exception objects.
         """
@@ -288,8 +288,10 @@ class BaseTestClass(object):
     def _exec_procedure_func(self, func, tr_record):
         """Executes a procedure function like on_pass, on_fail etc.
 
-        This function will alternate the 'Result' of the test's record if
-        exceptions happened when executing the procedure function.
+        This function will alter the 'Result' of the test's record if
+        exceptions happened when executing the procedure function, but
+        prevents procedure functions from altering test records themselves
+        by only passing in a copy.
 
         This will let signals.TestAbortAll through so abort_all works in all
         procedure functions.

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -217,10 +217,12 @@ class BaseTestClass(object):
         called.
 
         Args:
-            record: The records.TestResultRecord object for the failed test.
+            record: records.TestResultRecord,  a copy of the test record for
+                    this test, containing all information of the test execution
+                    including exception objects.
         """
         logging.info(RESULT_LINE_TEMPLATE, record.test_name, record.result)
-        self.on_fail(copy.deepcopy(record))
+        self.on_fail(record)
 
     def on_fail(self, record):
         """A function that is executed upon a test failure.
@@ -228,9 +230,9 @@ class BaseTestClass(object):
         User implementation is optional.
 
         Args:
-            record: records.TestResultRecord, the test record for this test,
-                    containing all information of the test execution including
-                    exception objects.
+            record: records.TestResultRecord,  a copy of the test record for
+                    this test, containing all information of the test execution
+                    including exception objects.
         """
 
     def _on_pass(self, record):
@@ -238,13 +240,15 @@ class BaseTestClass(object):
         called.
 
         Args:
-            record: The records.TestResultRecord object for the passed test.
+            record: records.TestResultRecord,  a copy of the test record for
+                    this test, containing all information of the test execution
+                    including exception objects.
         """
         msg = record.details
         if msg:
             logging.info(msg)
         logging.info(RESULT_LINE_TEMPLATE, record.test_name, record.result)
-        self.on_pass(copy.deepcopy(record))
+        self.on_pass(record)
 
     def on_pass(self, record):
         """A function that is executed upon a test passing.
@@ -252,9 +256,9 @@ class BaseTestClass(object):
         Implementation is optional.
 
         Args:
-            record: records.TestResultRecord, the test record for this test,
-                    containing all information of the test execution including
-                    exception objects.
+            record: records.TestResultRecord,  a copy of the test record for
+                    this test, containing all information of the test execution
+                    including exception objects.
         """
 
     def _on_skip(self, record):
@@ -262,11 +266,13 @@ class BaseTestClass(object):
         called.
 
         Args:
-            record: The records.TestResultRecord object for the skipped test.
+            record: records.TestResultRecord,  a copy of the test record for
+                    this test, containing all information of the test execution
+                    including exception objects.
         """
         logging.info('Reason to skip: %s', record.details)
         logging.info(RESULT_LINE_TEMPLATE, record.test_name, record.result)
-        self.on_skip(copy.deepcopy(record))
+        self.on_skip(record)
 
     def on_skip(self, record):
         """A function that is executed upon a test being skipped.
@@ -274,9 +280,9 @@ class BaseTestClass(object):
         Implementation is optional.
 
         Args:
-            record: records.TestResultRecord, the test record for this test,
-                    containing all information of the test execution including
-                    exception objects.
+            record: records.TestResultRecord,  a copy of the test record for
+                    this test, containing all information of the test execution
+                    including exception objects.
         """
 
     def _exec_procedure_func(self, func, tr_record):
@@ -294,7 +300,9 @@ class BaseTestClass(object):
                        executed.
         """
         try:
-            func(tr_record)
+          # Pass a copy of the record instead of the actual object so that it
+          # will not be modified.
+          func(copy.deepcopy(tr_record))
         except signals.TestAbortAll:
             raise
         except Exception as e:


### PR DESCRIPTION
Factor the deepcopy up to _exec_procedure_func so that the scope of the record is contained at one point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/301)
<!-- Reviewable:end -->
