### PR TITLE
Handle int timestamp in `android_device.take_bug_reports`.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -354,11 +354,7 @@ def take_bug_reports(ads, test_name, begin_time):
         begin_time: timestamp taken when the test started, can be either
             string or int.
     """
-    try:
-        begin_time = mobly_logger.normalize_log_line_timestamp(begin_time)
-    except AttributeError:
-        # Ignore errors from this step if begin_time is not string.
-        pass
+    begin_time = mobly_logger.normalize_log_line_timestamp(str(begin_time))
 
     def take_br(test_name, begin_time, ad):
         ad.take_bug_report(test_name, begin_time)
@@ -854,7 +850,7 @@ class AndroidDevice(object):
 
         Args:
             test_name: Name of the test method that triggered this bug report.
-            begin_time: Logline format timestamp taken when the test started.
+            begin_time: Timestamp of when the test started.
         """
         new_br = True
         try:

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -351,9 +351,14 @@ def take_bug_reports(ads, test_name, begin_time):
     Args:
         ads: A list of AndroidDevice instances.
         test_name: Name of the test method that triggered this bug report.
-        begin_time: Logline format timestamp taken when the test started.
+        begin_time: timestamp taken when the test started, can be either
+            string or int.
     """
-    begin_time = mobly_logger.normalize_log_line_timestamp(begin_time)
+    try:
+        begin_time = mobly_logger.normalize_log_line_timestamp(begin_time)
+    except AttributeError:
+        # Ignore errors from this step if begin_time is not string.
+        pass
 
     def take_br(test_name, begin_time, ad):
         ad.take_bug_report(test_name, begin_time)


### PR DESCRIPTION
Fixes #285

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/309)
<!-- Reviewable:end -->
