### PR TITLE
Fix tallying for FAIL from `setup_test`

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -17,6 +17,7 @@ import copy
 import functools
 import inspect
 import logging
+import sys
 
 from mobly import logger
 from mobly import records
@@ -316,7 +317,7 @@ class BaseTestClass(object):
 
         Executes setup_test, the test method, and teardown_test; then creates a
         records.TestResultRecord object with the execution information and adds
-        the record to the test class's test results.
+        the record to the test class's test result s.
 
         Args:
             test_name: Name of the test.
@@ -330,7 +331,12 @@ class BaseTestClass(object):
         teardown_test_failed = False
         try:
             try:
-                self._setup_test(test_name)
+                try:
+                    self._setup_test(test_name)
+                except signals.TestFailure as e:
+                    new_e = signals.TestError(e.details, e.extras)
+                    _, _, new_e.__traceback__ = sys.exc_info()
+                    raise new_e
                 if args or kwargs:
                     test_method(*args, **kwargs)
                 else:

--- a/mobly/signals.py
+++ b/mobly/signals.py
@@ -46,6 +46,10 @@ class TestSignal(Exception):
         return 'Details=%s, Extras=%s' % (self.details, self.extras)
 
 
+class TestError(TestSignal):
+    """Raised when a test has an unexpected error."""
+
+
 class TestFailure(TestSignal):
     """Raised when a test has failed."""
 

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -239,11 +239,13 @@ class BaseTestTest(unittest.TestCase):
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run(test_names=["test_something"])
-        actual_record = bt_cls.results.failed[0]
+        actual_record = bt_cls.results.error[0]
         self.assertEqual(actual_record.test_name, self.mock_test_name)
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
+        # Make sure the full stacktrace of `setup_test` is preserved.
+        self.assertTrue('self.setup_test()' in actual_record.stacktrace)
         self.assertIsNone(actual_record.extras)
-        expected_summary = ("Error 0, Executed 1, Failed 1, Passed 0, "
+        expected_summary = ("Error 1, Executed 1, Failed 0, Passed 0, "
                             "Requested 1, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
 
@@ -407,6 +409,7 @@ class BaseTestTest(unittest.TestCase):
 
     def test_procedure_function_gets_correct_record(self):
         on_fail_mock = mock.MagicMock()
+
         class MockBaseTest(base_test.BaseTestClass):
             def on_fail(self, record):
                 on_fail_mock.record = record
@@ -418,12 +421,16 @@ class BaseTestTest(unittest.TestCase):
         bt_cls.run()
         actual_record = bt_cls.results.failed[0]
         self.assertEqual(actual_record.test_name, 'test_something')
-        self.assertEqual(on_fail_mock.record.test_name, actual_record.test_name)
-        self.assertEqual(on_fail_mock.record.begin_time, actual_record.begin_time)
+        self.assertEqual(on_fail_mock.record.test_name,
+                         actual_record.test_name)
+        self.assertEqual(on_fail_mock.record.begin_time,
+                         actual_record.begin_time)
         self.assertEqual(on_fail_mock.record.end_time, actual_record.end_time)
-        self.assertEqual(on_fail_mock.record.stacktrace, actual_record.stacktrace)
+        self.assertEqual(on_fail_mock.record.stacktrace,
+                         actual_record.stacktrace)
         self.assertEqual(on_fail_mock.record.extras, actual_record.extras)
-        self.assertEqual(on_fail_mock.record.extra_errors, actual_record.extra_errors)
+        self.assertEqual(on_fail_mock.record.extra_errors,
+                         actual_record.extra_errors)
         # But they are not the same object.
         self.assertIsNot(on_fail_mock.record, actual_record)
 

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -996,6 +996,23 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
         self.assertEqual(actual_record.extras, MOCK_EXTRA)
 
+    def test_skip_in_setup_test(self):
+        class MockBaseTest(base_test.BaseTestClass):
+            def setup_test(self):
+                asserts.skip(MSG_EXPECTED_EXCEPTION, extras=MOCK_EXTRA)
+
+            def test_func(self):
+                never_call()
+
+        bt_cls = MockBaseTest(self.mock_test_cls_configs)
+        bt_cls.run(test_names=["test_func"])
+        actual_record = bt_cls.results.skipped[0]
+        self.assertIsNotNone(actual_record.begin_time)
+        self.assertIsNotNone(actual_record.end_time)
+        self.assertEqual(actual_record.test_name, "test_func")
+        self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
+        self.assertEqual(actual_record.extras, MOCK_EXTRA)
+
     def test_unpack_userparams_required(self):
         """Missing a required param should raise an error."""
         required = ["some_param"]


### PR DESCRIPTION
If `setup_test` fails with TestFailure, it should be tallied with ERROR status.

Fixes #229 
Related to #264

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/311)
<!-- Reviewable:end -->
