### PR TITLE
Fix timeout units in callback_handler logging

### DIFF
--- a/mobly/controllers/android_device_lib/callback_handler.py
+++ b/mobly/controllers/android_device_lib/callback_handler.py
@@ -85,10 +85,10 @@ class CallbackHandler(object):
                 raise Error(
                     'Specified timeout %s is longer than max timeout %s.' %
                     (timeout, MAX_TIMEOUT))
-            timeout *= 1000  # convert to milliseconds for java side
+        timeout_ms = timeout * 1000  # convert to milliseconds for java side
         try:
             raw_event = self._event_client.eventWaitAndGet(
-                self._id, event_name, timeout)
+                self._id, event_name, timeout_ms)
         except Exception as e:
             if 'EventSnippetException: timeout.' in str(e):
                 raise TimeoutError(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/312)
<!-- Reviewable:end -->
