### PR TITLE
Fix deepcopy of `ExceptionRecord` objects.

### DIFF
--- a/mobly/records.py
+++ b/mobly/records.py
@@ -186,6 +186,9 @@ class ExceptionRecord(object):
             exception = self.exception
         result = ExceptionRecord(exception, self.position)
         result.stacktrace = self.stacktrace
+        result.details = self.details
+        result.extras = self.extras
+        result.position = self.position
         return result
 
 

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -172,6 +172,22 @@ class ExceptionRecord(object):
         result[TestResultEnums.RECORD_EXTRAS] = copy.deepcopy(self.extras)
         return result
 
+    def __deepcopy__(self, memo):
+        """Overrides deepcopy for the class.
+
+        If the exception object has a constructor that takes extra args, deep
+        copy won't work. So we need to have a custom logic for deepcopy.
+        """
+        try:
+            exception = copy.deepcopy(self.exception)
+        except TypeError:
+            # If the exception object cannot be copied, use the original
+            # exception object.
+            exception = self.exception
+        result = ExceptionRecord(exception, self.position)
+        result.stacktrace = self.stacktrace
+        return result
+
 
 class TestResultRecord(object):
     """A record that holds the information of a single test.

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -340,7 +340,9 @@ class RecordsTest(unittest.TestCase):
             raise RecordTestError('Oh ha!')
         except RecordTestError as e:
             er = records.ExceptionRecord(e)
-        copy.deepcopy(er)
+        new_er = copy.deepcopy(er)
+        self.assertIsNot(er, new_er)
+        self.assertDictEqual(er.to_dict(), new_er.to_dict())
 
 
 if __name__ == "__main__":

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import os
 import shutil
 import tempfile
@@ -23,6 +24,16 @@ from mobly import records
 from mobly import signals
 
 from tests.lib import utils
+
+
+class RecordTestError(Exception):
+    """Error class with constructors that take extra args.
+
+    Used for ExceptionRecord tests.
+    """
+
+    def __init__(self, something):
+        self._something = something
 
 
 class RecordsTest(unittest.TestCase):
@@ -322,6 +333,14 @@ class RecordsTest(unittest.TestCase):
             content = yaml.load(f)
             self.assertEqual(content['Type'],
                              records.TestSummaryEntryType.RECORD.value)
+
+    def test_exception_record_deepcopy(self):
+        """Makes sure ExceptionRecord wrapper handles deep copy properly."""
+        try:
+            raise RecordTestError('Oh ha!')
+        except RecordTestError as e:
+            er = records.ExceptionRecord(e)
+        copy.deepcopy(er)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #315

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/316)
<!-- Reviewable:end -->
