### PR TITLE
Escape spaces in logcat file names for cli inputs.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -836,8 +836,8 @@ class AndroidDevice(object):
             extra_params = self.adb_logcat_param
         except AttributeError:
             extra_params = ''
-        cmd = '"%s" -s %s logcat -v threadtime %s >> %s' % (
-            adb.ADB, self.serial, extra_params, '"%s"' % logcat_file_path)
+        cmd = '"%s" -s %s logcat -v threadtime %s >> "%s"' % (
+            adb.ADB, self.serial, extra_params, logcat_file_path)
         process = utils.start_standing_subprocess(cmd, shell=True)
         self._adb_logcat_process = process
         self.adb_logcat_file_path = logcat_file_path

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -829,19 +829,17 @@ class AndroidDevice(object):
         if self.is_rootable:
             self.adb.shell('logpersist.stop --clear')
             self.adb.shell('logpersist.start')
-        f_name = 'adblog,%s,%s.txt' % (self.model, self.serial)
+        f_name = 'adblog,%s,%s.txt' % ('model a c', self.serial)
         utils.create_dir(self.log_path)
-        logcat_file_path = os.path.join(self.log_path, f_name)
+        logcat_file_path = '"%s"' % os.path.join(self.log_path, f_name)
         try:
             extra_params = self.adb_logcat_param
         except AttributeError:
             extra_params = ''
-        cmd = '"%s" -s %s logcat -v threadtime %s >> %s' % (
-            adb.ADB,
-            self.serial,
-            extra_params,
-            # Only need to escape space here as it's a raw cli string for `>>`.
-            logcat_file_path.replace(' ', r'\ '))
+        cmd = '"%s" -s %s logcat -v threadtime %s >> %s' % (adb.ADB,
+                                                            self.serial,
+                                                            extra_params,
+                                                            logcat_file_path)
         process = utils.start_standing_subprocess(cmd, shell=True)
         self._adb_logcat_process = process
         self.adb_logcat_file_path = logcat_file_path

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -829,17 +829,15 @@ class AndroidDevice(object):
         if self.is_rootable:
             self.adb.shell('logpersist.stop --clear')
             self.adb.shell('logpersist.start')
-        f_name = 'adblog,%s,%s.txt' % ('model a c', self.serial)
+        f_name = 'adblog,%s,%s.txt' % (self.model, self.serial)
         utils.create_dir(self.log_path)
-        logcat_file_path = '"%s"' % os.path.join(self.log_path, f_name)
+        logcat_file_path = os.path.join(self.log_path, f_name)
         try:
             extra_params = self.adb_logcat_param
         except AttributeError:
             extra_params = ''
-        cmd = '"%s" -s %s logcat -v threadtime %s >> %s' % (adb.ADB,
-                                                            self.serial,
-                                                            extra_params,
-                                                            logcat_file_path)
+        cmd = '"%s" -s %s logcat -v threadtime %s >> %s' % (
+            adb.ADB, self.serial, extra_params, '"%s"' % logcat_file_path)
         process = utils.start_standing_subprocess(cmd, shell=True)
         self._adb_logcat_process = process
         self.adb_logcat_file_path = logcat_file_path

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -836,10 +836,12 @@ class AndroidDevice(object):
             extra_params = self.adb_logcat_param
         except AttributeError:
             extra_params = ''
-        cmd = '"%s" -s %s logcat -v threadtime %s >> %s' % (adb.ADB,
-                                                            self.serial,
-                                                            extra_params,
-                                                            logcat_file_path)
+        cmd = '"%s" -s %s logcat -v threadtime %s >> %s' % (
+            adb.ADB,
+            self.serial,
+            extra_params,
+            # Only need to escape space here as it's a raw cli string for `>>`.
+            logcat_file_path.replace(' ', r'\ '))
         process = utils.start_standing_subprocess(cmd, shell=True)
         self._adb_logcat_process = process
         self.adb_logcat_file_path = logcat_file_path

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -326,7 +326,7 @@ class AndroidDeviceTest(unittest.TestCase):
         creat_dir_mock.assert_called_with(os.path.dirname(expected_log_path))
         adb_cmd = '"adb" -s %s logcat -v threadtime  >> %s'
         start_proc_mock.assert_called_with(
-            adb_cmd % (ad.serial, expected_log_path), shell=True)
+            adb_cmd % (ad.serial, '"%s"' % expected_log_path), shell=True)
         self.assertEqual(ad.adb_logcat_file_path, expected_log_path)
         expected_msg = (
             'Logcat thread is already running, cannot start another'
@@ -373,7 +373,7 @@ class AndroidDeviceTest(unittest.TestCase):
         creat_dir_mock.assert_called_with(os.path.dirname(expected_log_path))
         adb_cmd = '"adb" -s %s logcat -v threadtime -b radio >> %s'
         start_proc_mock.assert_called_with(
-            adb_cmd % (ad.serial, expected_log_path), shell=True)
+            adb_cmd % (ad.serial, '"%s"' % expected_log_path), shell=True)
         self.assertEqual(ad.adb_logcat_file_path, expected_log_path)
 
     @mock.patch(


### PR DESCRIPTION
Fixes #327

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/328)
<!-- Reviewable:end -->
