### PR TITLE
Expose more test runtime info.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -21,6 +21,7 @@ import sys
 
 from mobly import records
 from mobly import signals
+from mobly import test_info
 
 # Macro strings for test result reporting
 TEST_CASE_TOKEN = '[Test]'
@@ -50,8 +51,11 @@ class BaseTestClass(object):
             name.
         results: A records.TestResult object for aggregating test results from
             the execution of tests.
-        current_test_name: A string that's the name of the test method currently
-            being executed. If no test is executing, this should be None.
+        current_test_name: [Deprecated, use `self.current_test_info.test_name`]
+            A string that's the name of the test method currently being
+            executed. If no test is executing, this should be None.
+        current_test_info: TestInfo, runtime information on the test currently
+            being executed.
         log_path: string, specifies the root directory for all logs written
             by a test run.
         test_bed_name: string, the name of the test bed used by a test run.
@@ -87,6 +91,7 @@ class BaseTestClass(object):
         self.register_controller = configs.register_controller
         self.results = records.TestResult()
         self.summary_writer = configs.summary_writer
+        # Deprecated, use `self.current_test_info.test_name`.
         self.current_test_name = None
         self._generated_test_table = collections.OrderedDict()
 
@@ -338,6 +343,8 @@ class BaseTestClass(object):
         """
         tr_record = records.TestResultRecord(test_name, self.TAG)
         tr_record.test_begin()
+        self.current_test_info = test_info.TestInfo(test_name, self.log_path,
+                                                    tr_record)
         logging.info('%s %s', TEST_CASE_TOKEN, test_name)
         teardown_test_failed = False
         try:
@@ -400,6 +407,7 @@ class BaseTestClass(object):
                 self.results.add_record(tr_record)
                 self.summary_writer.dump(tr_record.to_dict(),
                                          records.TestSummaryEntryType.RECORD)
+                self.current_test_info = None
                 self.current_test_name = None
 
     def _assert_function_name_in_stack(self, expected_func_name):

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -21,7 +21,7 @@ import sys
 
 from mobly import records
 from mobly import signals
-from mobly import test_info
+from mobly import runtime_test_info
 
 # Macro strings for test result reporting
 TEST_CASE_TOKEN = '[Test]'
@@ -91,7 +91,7 @@ class BaseTestClass(object):
         self.register_controller = configs.register_controller
         self.results = records.TestResult()
         self.summary_writer = configs.summary_writer
-        # Deprecated, use `self.current_test_info.test_name`.
+        # Deprecated, use `self.current_test_info.name`.
         self.current_test_name = None
         self._generated_test_table = collections.OrderedDict()
 
@@ -343,8 +343,8 @@ class BaseTestClass(object):
         """
         tr_record = records.TestResultRecord(test_name, self.TAG)
         tr_record.test_begin()
-        self.current_test_info = test_info.TestInfo(test_name, self.log_path,
-                                                    tr_record)
+        self.current_test_info = runtime_test_info.RuntimeTestInfo(
+            test_name, self.log_path, tr_record)
         logging.info('%s %s', TEST_CASE_TOKEN, test_name)
         teardown_test_failed = False
         try:

--- a/mobly/runtime_test_info.py
+++ b/mobly/runtime_test_info.py
@@ -18,19 +18,19 @@ import os
 from mobly import utils
 
 
-class TestInfo(object):
+class RuntimeTestInfo(object):
     """Container class for runtime information of a test.
 
-    One object corresponds to one test.
+    One object corresponds to one test. This is meant to be a read-only class.
 
     Attributes:
-        test_name: string, name of the test.
-        test_signature: string, an identifier of the test, a combination of
-            test name and begin time.
-        test_record: TestResultRecord, the current test result record. This
-            changes as the test's execution progresses.
-        test_output_path: string, path to the test's output directory. It's
-            created upon accessing.
+        name: string, name of the test.
+        signature: string, an identifier of the test, a combination of test
+            name and begin time.
+        record: TestResultRecord, the current test result record. This changes
+            as the test's execution progresses.
+        output_path: string, path to the test's output directory. It's created
+            upon accessing.
     """
 
     def __init__(self, test_name, log_path, record):
@@ -41,18 +41,18 @@ class TestInfo(object):
             os.path.join(log_path, self._signature))
 
     @property
-    def test_name(self):
+    def name(self):
         return self._name
 
     @property
-    def test_signature(self):
+    def signature(self):
         return self._signature
 
     @property
-    def test_record(self):
+    def record(self):
         return copy.deepcopy(self._record)
 
     @property
-    def test_output_path(self):
+    def output_path(self):
         utils.create_dir(self._output_dir_path)
         return self._output_dir_path

--- a/mobly/test_info.py
+++ b/mobly/test_info.py
@@ -1,0 +1,58 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import os
+
+from mobly import utils
+
+
+class TestInfo(object):
+    """Container class for runtime information of a test.
+
+    One object corresponds to one test.
+
+    Attributes:
+        test_name: string, name of the test.
+        test_signature: string, an identifier of the test, a combination of
+            test name and begin time.
+        test_record: TestResultRecord, the current test result record. This
+            changes as the test's execution progresses.
+        test_output_path: string, path to the test's output directory. It's
+            created upon accessing.
+    """
+
+    def __init__(self, test_name, log_path, record):
+        self._name = test_name
+        self._record = record
+        self._signature = '%s-%s' % (test_name, record.begin_time)
+        self._output_dir_path = utils.abs_path(
+            os.path.join(log_path, self._signature))
+
+    @property
+    def test_name(self):
+        return self._name
+
+    @property
+    def test_signature(self):
+        return self._signature
+
+    @property
+    def test_record(self):
+        return copy.deepcopy(self._record)
+
+    @property
+    def test_output_path(self):
+        utils.create_dir(self._output_dir_path)
+        return self._output_dir_path

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -72,11 +72,10 @@ class BaseTestTest(unittest.TestCase):
     def test_current_test_info(self):
         class MockBaseTest(base_test.BaseTestClass):
             def test_func(self):
-                asserts.assert_true(
-                    self.current_test_info.test_name == 'test_func',
-                    'Got unexpected test name %s.' %
-                    self.current_test_info.test_name)
-                output_path = self.current_test_info.test_output_path
+                asserts.assert_true(self.current_test_info.name == 'test_func',
+                                    'Got unexpected test name %s.' %
+                                    self.current_test_info.name)
+                output_path = self.current_test_info.output_path
                 asserts.assert_true(
                     os.path.exists(output_path), 'test output path missing')
 


### PR DESCRIPTION
Add a `TestInfo` class to expose more runtime info of the test.
This way we don't have to keep adding more attributes to base class.

Fixes #240

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/330)
<!-- Reviewable:end -->
