### PR TITLE
Fix runtime warnings in py3.

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -357,6 +357,11 @@ def stop_standing_subprocess(proc, kill_signal=signal.SIGTERM):
         logging.exception('Failed to kill standing subprocess %d', pid)
     if failed:
         raise Error('Failed to kill standing subprocesses: %s' % failed)
+    # Call wait and close pipes on the original Python object so we don't get
+    # runtime warnings.
+    proc.stdout.close()
+    proc.stderr.close()
+    proc.wait()
     logging.debug('Stopped standing subprocess %d', pid)
 
 

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -35,15 +35,23 @@ class UtilsTest(unittest.TestCase):
         self.sleep_cmd = 'timeout' if system == 'Windows' else 'sleep'
 
     def test_start_standing_subproc(self):
-        p = utils.start_standing_subprocess([self.sleep_cmd, '1'])
-        p1 = psutil.Process(p.pid)
-        self.assertTrue(p1.is_running())
+        try:
+            p = utils.start_standing_subprocess([self.sleep_cmd, '0.1'])
+            p1 = psutil.Process(p.pid)
+            self.assertTrue(p1.is_running())
+        finally:
+            p.stdout.close()
+            p.stderr.close()
+            p.wait()
 
     def test_stop_standing_subproc(self):
         p = utils.start_standing_subprocess([self.sleep_cmd, '4'])
         p1 = psutil.Process(p.pid)
+        start_time = time.time()
         utils.stop_standing_subprocess(p)
         self.assertFalse(p1.is_running())
+        stop_time = time.time()
+        self.assertTrue(stop_time - start_time < 0.1)
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')


### PR DESCRIPTION
Applying two fixes in both `stop_standing_subprocess` and the subprocess unit tests.

* Call `wait` on the actual Python object. Because Python throws a warning if `wait` is not called on the original object regardless of the actual state of the subprocess.
* Close pipes for subprocesses.

Fixes #254

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/332)
<!-- Reviewable:end -->
