### PR TITLE
Fix system command for Windows

### DIFF
--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import mock
+import platform
 import socket
 import time
 from future.tests.base import unittest
@@ -30,12 +31,14 @@ class UtilsTest(unittest.TestCase):
     """
 
     def test_start_standing_subproc(self):
-        p = utils.start_standing_subprocess(['sleep', '1'])
+        cmd = 'timeout' if platform.system() == 'Windows' else 'sleep'
+        p = utils.start_standing_subprocess([cmd, '1'])
         p1 = psutil.Process(p.pid)
         self.assertTrue(p1.is_running())
 
     def test_stop_standing_subproc(self):
-        p = utils.start_standing_subprocess(['sleep', '4'])
+        cmd = 'timeout' if platform.system() == 'Windows' else 'sleep'
+        p = utils.start_standing_subprocess([cmd, '4'])
         p1 = psutil.Process(p.pid)
         utils.stop_standing_subprocess(p)
         self.assertFalse(p1.is_running())

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -30,15 +30,16 @@ class UtilsTest(unittest.TestCase):
     under mobly.utils.
     """
 
+    def setUp(self):
+        self.sleep_cmd = 'timeout' if platform.system() == 'Windows' else 'sleep'
+    
     def test_start_standing_subproc(self):
-        cmd = 'timeout' if platform.system() == 'Windows' else 'sleep'
-        p = utils.start_standing_subprocess([cmd, '1'])
+        p = utils.start_standing_subprocess([self.sleep_cmd, '1'])
         p1 = psutil.Process(p.pid)
         self.assertTrue(p1.is_running())
 
     def test_stop_standing_subproc(self):
-        cmd = 'timeout' if platform.system() == 'Windows' else 'sleep'
-        p = utils.start_standing_subprocess([cmd, '4'])
+        p = utils.start_standing_subprocess([self.sleep_cmd, '4'])
         p1 = psutil.Process(p.pid)
         utils.stop_standing_subprocess(p)
         self.assertFalse(p1.is_running())

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -31,7 +31,8 @@ class UtilsTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.sleep_cmd = 'timeout' if platform.system() == 'Windows' else 'sleep'
+        system = platform.system()
+        self.sleep_cmd = 'timeout' if system == 'Windows' else 'sleep'
     
     def test_start_standing_subproc(self):
         p = utils.start_standing_subprocess([self.sleep_cmd, '1'])

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -33,7 +33,7 @@ class UtilsTest(unittest.TestCase):
     def setUp(self):
         system = platform.system()
         self.sleep_cmd = 'timeout' if system == 'Windows' else 'sleep'
-    
+
     def test_start_standing_subproc(self):
         p = utils.start_standing_subprocess([self.sleep_cmd, '1'])
         p1 = psutil.Process(p.pid)


### PR DESCRIPTION
In test_start_standing_subproc() and test_stop_standing_subproc(), change system command from "sleep" to "timeout" when the platform is "Windows".

Fixes #299

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/335)
<!-- Reviewable:end -->
