### PR TITLE
Better error message for errors specific to an `AndroidDevice` object

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -723,8 +723,7 @@ class AndroidDevice(object):
                     self,
                     'Snippet package "%s" has already been loaded under name'
                     ' "%s".' % (package, client_name))
-        client = snippet_client.SnippetClient(
-            package=package, adb_proxy=self.adb, log=self.log)
+        client = snippet_client.SnippetClient(package=package, ad=self)
         try:
             client.start_app_and_connect()
         except Exception as e:

--- a/mobly/controllers/android_device_lib/errors.py
+++ b/mobly/controllers/android_device_lib/errors.py
@@ -1,0 +1,28 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Module for errors thrown from AndroidDevice object.
+
+from mobly import signals
+
+
+class Error(signals.ControllerError):
+    pass
+
+
+class DeviceError(Error):
+    """Raised for errors specific to an AndroidDevice object."""
+    def __init__(self, ad, msg):
+        new_msg = '%s %s' % (repr(ad), msg)
+        super(DeviceError, self).__init__(new_msg)

--- a/tests/mobly/controllers/android_device_lib/callback_handler_test.py
+++ b/tests/mobly/controllers/android_device_lib/callback_handler_test.py
@@ -45,7 +45,8 @@ class CallbackHandlerTest(unittest.TestCase):
             callback_id=MOCK_CALLBACK_ID,
             event_client=mock_event_client,
             ret_value=None,
-            method_name=None)
+            method_name=None,
+            ad=mock.Mock())
         self.assertEqual(handler.callback_id, MOCK_CALLBACK_ID)
         with self.assertRaisesRegex(AttributeError, "can't set attribute"):
             handler.callback_id = 'ha'
@@ -58,7 +59,8 @@ class CallbackHandlerTest(unittest.TestCase):
             callback_id=MOCK_CALLBACK_ID,
             event_client=mock_event_client,
             ret_value=None,
-            method_name=None)
+            method_name=None,
+            ad=mock.Mock())
         event = handler.waitAndGet('ha')
         self.assertEqual(event.name, MOCK_RAW_EVENT['name'])
         self.assertEqual(event.creation_time, MOCK_RAW_EVENT['time'])
@@ -70,12 +72,14 @@ class CallbackHandlerTest(unittest.TestCase):
         java_timeout_msg = ('com.google.android.mobly.snippet.event.'
                             'EventSnippet$EventSnippetException: timeout.')
         mock_event_client.eventWaitAndGet = mock.Mock(
-            side_effect=jsonrpc_client_base.ApiError(java_timeout_msg))
+            side_effect=jsonrpc_client_base.ApiError(mock.Mock(),
+                java_timeout_msg))
         handler = callback_handler.CallbackHandler(
             callback_id=MOCK_CALLBACK_ID,
             event_client=mock_event_client,
             ret_value=None,
-            method_name=None)
+            method_name=None,
+            ad=mock.Mock())
         expected_msg = 'Timed out after waiting .*s for event "ha" .*'
         with self.assertRaisesRegex(callback_handler.TimeoutError,
                                     expected_msg):
@@ -89,7 +93,8 @@ class CallbackHandlerTest(unittest.TestCase):
             callback_id=MOCK_CALLBACK_ID,
             event_client=mock_event_client,
             ret_value=None,
-            method_name=None)
+            method_name=None,
+            ad=mock.Mock())
 
         def some_condition(event):
             return event.data['successful']
@@ -104,7 +109,8 @@ class CallbackHandlerTest(unittest.TestCase):
             callback_id=MOCK_CALLBACK_ID,
             event_client=mock_event_client,
             ret_value=None,
-            method_name=None)
+            method_name=None,
+            ad=mock.Mock())
         expected_msg = (
             'Timed out after 0.01s waiting for an "AsyncTaskResult" event that'
             ' satisfies the predicate "some_condition".')

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
@@ -25,7 +25,8 @@ from tests.lib import jsonrpc_client_test_base
 
 class FakeRpcClient(jsonrpc_client_base.JsonRpcClientBase):
     def __init__(self):
-        super(FakeRpcClient, self).__init__(app_name='FakeRpcClient')
+        super(FakeRpcClient, self).__init__(app_name='FakeRpcClient',
+            ad=mock.Mock())
 
 
 class JsonRpcClientBaseTest(jsonrpc_client_test_base.JsonRpcClientTestBase):

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -77,14 +77,14 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
 
     def test_check_app_installed_fail_app_not_installed(self):
         sc = self._make_client(MockAdbProxy(apk_not_installed=True))
-        expected_msg = '%s is not installed on .*' % MOCK_PACKAGE_NAME
+        expected_msg = '.* %s is not installed.' % MOCK_PACKAGE_NAME
         with self.assertRaisesRegex(jsonrpc_client_base.AppStartError,
                                     expected_msg):
             sc._check_app_installed()
 
     def test_check_app_installed_fail_not_instrumented(self):
         sc = self._make_client(MockAdbProxy(apk_not_instrumented=True))
-        expected_msg = ('%s is installed on .*, but it is not instrumented.' %
+        expected_msg = ('.* %s is installed, but it is not instrumented.' %
                         MOCK_PACKAGE_NAME)
         with self.assertRaisesRegex(jsonrpc_client_base.AppStartError,
                                     expected_msg):
@@ -92,7 +92,7 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
 
     def test_check_app_installed_fail_target_not_installed(self):
         sc = self._make_client(MockAdbProxy(target_not_installed=True))
-        expected_msg = ('Instrumentation target %s is not installed on .*' %
+        expected_msg = ('.* Instrumentation target %s is not installed.' %
                         MOCK_MISSING_PACKAGE_NAME)
         with self.assertRaisesRegex(jsonrpc_client_base.AppStartError,
                                     expected_msg):
@@ -321,8 +321,10 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
 
     def _make_client(self, adb_proxy=None):
         adb_proxy = adb_proxy or MockAdbProxy()
+        ad = mock.Mock()
+        ad.adb = adb_proxy
         return snippet_client.SnippetClient(
-            package=MOCK_PACKAGE_NAME, adb_proxy=adb_proxy)
+            package=MOCK_PACKAGE_NAME, ad=ad)
 
     def _setup_mock_instrumentation_cmd(self, mock_start_standing_subprocess,
                                         resp_lines):


### PR DESCRIPTION
* Add device identifier to all error messages thrown from a specific
  device object, which is critical for debugging multi-device tests.
* Have a single base class for all errors associated with a specific
  device object, so the test only needs to catch one instead of
  multiple types of errors.

Not changing adb and fastboot proxy as all device-specifi adb/fastboot
cmds already include device's info.

Fixes #123
Fixes #320 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/336)
<!-- Reviewable:end -->
