### PR TITLE
Allow setting destination in `take_bug_report`.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -339,7 +339,7 @@ def get_device(ads, **kwargs):
         raise Error('More than one device matched: %s' % serials)
 
 
-def take_bug_reports(ads, test_name, begin_time):
+def take_bug_reports(ads, test_name, begin_time, destination=None):
     """Takes bug reports on a list of android devices.
 
     If you want to take a bug report, call this function with a list of
@@ -352,11 +352,13 @@ def take_bug_reports(ads, test_name, begin_time):
         test_name: Name of the test method that triggered this bug report.
         begin_time: timestamp taken when the test started, can be either
             string or int.
+        destination: string, path to the directory where the bugreport
+            should be saved.
     """
     begin_time = mobly_logger.normalize_log_line_timestamp(str(begin_time))
 
     def take_br(test_name, begin_time, ad):
-        ad.take_bug_report(test_name, begin_time)
+        ad.take_bug_report(test_name, begin_time, destination)
 
     args = [(test_name, begin_time, ad) for ad in ads]
     utils.concurrent_exec(take_br, args)
@@ -732,7 +734,8 @@ class AndroidDevice(object):
                 client.stop_app()
             except:
                 self.log.exception(
-                    'Failed to stop app after failure to start app and connect.')
+                    'Failed to stop app after failure to start app and connect.'
+                )
             # Raise the error from start app failure.
             raise e
         self._snippet_clients[name] = client
@@ -854,7 +857,11 @@ class AndroidDevice(object):
         utils.stop_standing_subprocess(self._adb_logcat_process)
         self._adb_logcat_process = None
 
-    def take_bug_report(self, test_name, begin_time, timetout=300):
+    def take_bug_report(self,
+                        test_name,
+                        begin_time,
+                        timetout=300,
+                        destination=None):
         """Takes a bug report on the device and stores it in a file.
 
         Args:
@@ -862,6 +869,8 @@ class AndroidDevice(object):
             begin_time: Timestamp of when the test started.
             timeout: float, the number of seconds to wait for bugreport to
                 complete, default is 5min.
+            destination: string, path to the directory where the bugreport
+                should be saved.
         """
         new_br = True
         try:
@@ -872,7 +881,10 @@ class AndroidDevice(object):
                 new_br = False
         except adb.AdbError:
             new_br = False
-        br_path = os.path.join(self.log_path, 'BugReports')
+        if destination:
+            br_path = utils.abs_path(destination)
+        else:
+            br_path = os.path.join(self.log_path, 'BugReports')
         utils.create_dir(br_path)
         base_name = ',%s,%s.txt' % (begin_time, self.serial)
         if new_br:

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -49,6 +49,7 @@ class AndroidDeviceTest(unittest.TestCase):
     """This test class has unit tests for the implementation of everything
     under mobly.controllers.android_device.
     """
+
     def setUp(self):
         # Set log_path to logging since mobly logger setup is not called.
         if not hasattr(logging, "log_path"):
@@ -251,14 +252,13 @@ class AndroidDeviceTest(unittest.TestCase):
         mock_serial = 1
         ad = android_device.AndroidDevice(serial=mock_serial)
         ad.take_bug_report("test_something", "sometime")
-        expected_path = os.path.join(logging.log_path, "AndroidDevice%s" %
-                                     ad.serial, "BugReports")
+        expected_path = os.path.join(
+            logging.log_path, "AndroidDevice%s" % ad.serial, "BugReports")
         create_dir_mock.assert_called_with(expected_path)
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.AdbProxy',
-        return_value=mock_android_device.MockAdbProxy(
-            1, fail_br=True))
+        return_value=mock_android_device.MockAdbProxy(1, fail_br=True))
     @mock.patch(
         'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
         return_value=mock_android_device.MockFastbootProxy(1))
@@ -276,6 +276,22 @@ class AndroidDeviceTest(unittest.TestCase):
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.AdbProxy',
+        return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch(
+        'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+        return_value=mock_android_device.MockFastbootProxy(1))
+    @mock.patch('mobly.utils.create_dir')
+    def test_AndroidDevice_take_bug_report_with_destination(
+            self, create_dir_mock, FastbootProxy, MockAdbProxy):
+        mock_serial = 1
+        ad = android_device.AndroidDevice(serial=mock_serial)
+        dest = tempfile.gettempdir()
+        ad.take_bug_report("test_something", "sometime", destination=dest)
+        expected_path = os.path.join(dest)
+        create_dir_mock.assert_called_with(expected_path)
+
+    @mock.patch(
+        'mobly.controllers.android_device_lib.adb.AdbProxy',
         return_value=mock_android_device.MockAdbProxy(
             1, fail_br_before_N=True))
     @mock.patch(
@@ -290,8 +306,8 @@ class AndroidDeviceTest(unittest.TestCase):
         mock_serial = 1
         ad = android_device.AndroidDevice(serial=mock_serial)
         ad.take_bug_report("test_something", "sometime")
-        expected_path = os.path.join(logging.log_path, "AndroidDevice%s" %
-                                     ad.serial, "BugReports")
+        expected_path = os.path.join(
+            logging.log_path, "AndroidDevice%s" % ad.serial, "BugReports")
         create_dir_mock.assert_called_with(expected_path)
 
     @mock.patch(
@@ -410,8 +426,9 @@ class AndroidDeviceTest(unittest.TestCase):
         with open(mock_adb_log_path, 'w') as f:
             f.write(MOCK_ADB_LOGCAT)
         ad.cat_adb_log("some_test", MOCK_ADB_LOGCAT_BEGIN_TIME)
-        cat_file_path = os.path.join(ad.log_path, "AdbLogExcerpts", (
-            "some_test,02-29 14:02:20.123,%s,%s.txt") % (ad.model, ad.serial))
+        cat_file_path = os.path.join(
+            ad.log_path, "AdbLogExcerpts",
+            ("some_test,02-29 14:02:20.123,%s,%s.txt") % (ad.model, ad.serial))
         with open(cat_file_path, 'r') as f:
             actual_cat = f.read()
         self.assertEqual(actual_cat, ''.join(MOCK_ADB_LOGCAT_CAT_RESULT))


### PR DESCRIPTION
Fixes #349 