### PR TITLE
Move test_suite functionality to test_runner

### DIFF
--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -167,12 +167,11 @@ def _compute_selected_tests(selected_tests):
     """Computes tests to run for each class from selector strings.
 
     This function transforms a list of selector strings (such as FooTest or
-    FooTest.test_method_a) to a dict where keys are test classes (strings), and
+    FooTest.test_method_a) to an ordered dict where keys are test classes (strings), and
     values are lists of selected test methods (strings) in those classes. 
     None means all methods in that class are selected.
 
     Args:
-        test_classes: (list of class) all classes that are part of this suite.
         selected_tests: (list of string) list of tests to execute, eg:
             [
                 'FooTest',
@@ -183,8 +182,8 @@ def _compute_selected_tests(selected_tests):
             May be empty, in which case all tests in the class are selected.
 
     Returns:
-        dict: str class -> list(str method):
-        identifiers for TestRunner. For the above example:
+        dict: str class -> list(str method).
+        For above example: 
         {
             'FooTest': None,
             'BarTest': None,
@@ -210,7 +209,7 @@ def _compute_selected_tests(selected_tests):
 
 
 def _get_all_tests(test_class, config):
-    """Returns all test methods (including generated ones) belonging to test_class(config)."""
+    """Returns all test methods (including generated ones) belonging to  test_class(config)."""
     config_copy = config.copy()  # just in case.
     test_instance = test_class(config_copy)
     test_instance.setup_generated_tests
@@ -402,6 +401,7 @@ class TestRunner(object):
                             'Trying to selected nonexistent test methods %s from test class %s'
                             % (nonexistent_methods, test_class_name))
 
+                # class and method selections are valid. Add new test_run_info to plan.
                 test_run_info.tests = selected_test_methods
                 new_test_run_infos.append(test_run_info)
         if test_selector:
@@ -417,8 +417,6 @@ class TestRunner(object):
             FooTest.test_method_a
             FooTest.test_method_b
             BarTest.test_method_a
-        Note that this function will instantiate test classes in order to generate tests. 
-
         """
         test_names_to_print = []
         for test_run_info in self._test_run_infos:

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -17,6 +17,7 @@ from future import standard_library
 standard_library.install_aliases()
 
 import argparse
+import collections
 import copy
 import functools
 import inspect
@@ -161,6 +162,57 @@ def _print_test_names(test_class):
     for name in cls.get_existing_test_names():
         print(name)
 
+def _compute_selected_tests(selected_tests): 
+    """Computes tests to run for each class from selector strings.
+
+    This function transforms a list of selector strings (such as FooTest or
+    FooTest.test_method_a) to a dict where keys are test classes (strings), and
+    values are lists of selected test methods (strings) in those classes. 
+    None means all methods in that class are selected.
+
+    Args:
+        test_classes: (list of class) all classes that are part of this suite.
+        selected_tests: (list of string) list of tests to execute, eg:
+            [
+                'FooTest',
+                'BarTest',
+                'BazTest.test_method_a',
+                'BazTest.test_method_b'
+            ].
+            May be empty, in which case all tests in the class are selected.
+
+    Returns:
+        dict: str class -> list(str method):
+        identifiers for TestRunner. For the above example:
+        {
+            'FooTest': None,
+            'BarTest': None,
+            'BazTest': ['test_method_a', 'test_method_b'],
+        }
+    """
+    test_class_name_to_tests = collections.OrderedDict()
+    for test_name in selected_tests:
+        if '.' in test_name:  # Has a test method
+            (test_class_name, test_name) = test_name.split('.')
+            if test_class_name not in test_class_name_to_tests:
+                # Never seen this class before
+                test_class_name_to_tests[test_class_name] = [test_name]
+            elif test_class_name_to_tests[test_class_name] is None:
+                # Already running all tests in this class, so ignore this extra
+                # test.
+                pass
+            else:
+                test_class_name_to_tests[test_class_name].append(test_name)
+        else:  # No test method; run all tests in this class.
+            test_class_name_to_tests[test_name] = None
+    return test_class_name_to_tests
+
+def _get_all_tests(test_class, config): 
+    """Returns all test methods (including generated ones) belonging to test_class(config)."""
+    config_copy = config.copy()  # just in case. 
+    test_instance = test_class(config_copy)
+    test_instance.setup_generated_tests
+    return test_instance.get_existing_test_names()
 
 def verify_controller_module(module):
     """Verifies a module object follows the required interface for
@@ -294,9 +346,92 @@ class TestRunner(object):
                 'TestRunner\'s test bed is "%s", but a test config with a '
                 'different test bed ("%s") was added.' %
                 (self._test_bed_name, config.test_bed_name))
+
+        if not issubclass(test_class, base_test.BaseTestClass):
+            raise Error(
+                'Test class %s does not extend '
+                'mobly.base_test.BaseTestClass' % test_class.__name__)
+
         self._test_run_infos.append(
             TestRunner._TestRunInfo(
                 config=config, test_class=test_class, tests=tests))
+
+    def select_test_methods(self, test_selections): 
+        """Edits the execution plan of this TestRunner from selector strings.
+
+        This function take a list of selector strings (such as FooTest or
+        FooTest.test_method_a) and edits the execution plan of this TestRunner to 
+        run only the selected tests. Note that all specified test classes must have 
+        been previously added to this TestRunner before this selection can be made.
+
+        Args:
+            test_selections: (list of string) list of tests to execute, eg:
+                [
+                    'FooTest',
+                    'BarTest',
+                    'BazTest.test_method_a',
+                    'BazTest.test_method_b'
+                ].
+                May be empty, in which case all tests in the class are selected.
+            }
+        """
+        if not test_selections: 
+            # if not selecting tests, don't do anything.
+            return
+        test_selector = _compute_selected_tests(test_selections)
+
+        new_test_run_infos = []
+        for test_run_info in self._test_run_infos: 
+            test_class_name = test_run_info.test_class.__name__
+            if test_class_name in test_selector: 
+                selected_test_methods = test_selector.pop(test_class_name)
+
+                if selected_test_methods: 
+                    # verify that the selected test methods exist. 
+                    existing_test_methods = _get_all_tests(
+                        test_run_info.test_class, test_run_info.config)
+                    nonexistent_methods = [
+                        selected_method for selected_method in selected_test_methods
+                        if selected_method not in existing_test_methods]
+                    if nonexistent_methods: 
+                        raise Error(
+                            'Trying to selected nonexistent test methods %s from test class %s'
+                            % (nonexistent_methods, test_class_name)
+                            )
+
+                test_run_info.tests = selected_test_methods
+                new_test_run_infos.append(test_run_info)
+        if test_selector: 
+            raise Error(
+                'Trying to select test methods from classes %s '
+                'that have not been added to TestRunner.' 
+                % [item[0] for item in test_selector.items()]
+                )
+        self._test_run_infos = new_test_run_infos
+
+    def print_all_test_methods(self): 
+        """Prints all test methods in this TestRunner's execution plan. 
+
+        Prints the test methods that this TestRunner will execute in the following format: 
+            FooTest.test_method_a
+            FooTest.test_method_b
+            BarTest.test_method_a
+        Note that this function will instantiate test classes in order to generate tests. 
+
+        """
+        test_names_to_print = []
+        for test_run_info in self._test_run_infos: 
+            existing_test_names = _get_all_tests(test_run_info.test_class, test_run_info.config)
+            prefix = test_run_info.test_class.__name__ + '.'
+            if test_run_info.tests: 
+                assert all(test in existing_test_names for test in test_run_info.tests), 'No method should be specified in test_run_info.tests that is not part of the corresponding class/config\'s existing tess'
+                test_names_to_print += [prefix + test for test in test_run_info.tests]
+            else: 
+                test_names_to_print += [prefix + test for test in existing_test_names]
+        header = '==========> Preview of Test Execution Plan. <=========='
+        print(header)
+        print('\n'.join(test_names_to_print))
+        print('=' * len(header))
 
     def _run_test_class(self, config, test_class, tests=None):
         """Instantiates and executes a test class.

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -162,7 +162,8 @@ def _print_test_names(test_class):
     for name in cls.get_existing_test_names():
         print(name)
 
-def _compute_selected_tests(selected_tests): 
+
+def _compute_selected_tests(selected_tests):
     """Computes tests to run for each class from selector strings.
 
     This function transforms a list of selector strings (such as FooTest or
@@ -207,12 +208,14 @@ def _compute_selected_tests(selected_tests):
             test_class_name_to_tests[test_name] = None
     return test_class_name_to_tests
 
-def _get_all_tests(test_class, config): 
+
+def _get_all_tests(test_class, config):
     """Returns all test methods (including generated ones) belonging to test_class(config)."""
-    config_copy = config.copy()  # just in case. 
+    config_copy = config.copy()  # just in case.
     test_instance = test_class(config_copy)
     test_instance.setup_generated_tests
     return test_instance.get_existing_test_names()
+
 
 def verify_controller_module(module):
     """Verifies a module object follows the required interface for
@@ -348,15 +351,14 @@ class TestRunner(object):
                 (self._test_bed_name, config.test_bed_name))
 
         if not issubclass(test_class, base_test.BaseTestClass):
-            raise Error(
-                'Test class %s does not extend '
-                'mobly.base_test.BaseTestClass' % test_class.__name__)
+            raise Error('Test class %s does not extend '
+                        'mobly.base_test.BaseTestClass' % test_class.__name__)
 
         self._test_run_infos.append(
             TestRunner._TestRunInfo(
                 config=config, test_class=test_class, tests=tests))
 
-    def select_test_methods(self, test_selections): 
+    def select_test_methods(self, test_selections):
         """Edits the execution plan of this TestRunner from selector strings.
 
         This function take a list of selector strings (such as FooTest or
@@ -375,41 +377,40 @@ class TestRunner(object):
                 May be empty, in which case all tests in the class are selected.
             }
         """
-        if not test_selections: 
+        if not test_selections:
             # if not selecting tests, don't do anything.
             return
         test_selector = _compute_selected_tests(test_selections)
 
         new_test_run_infos = []
-        for test_run_info in self._test_run_infos: 
+        for test_run_info in self._test_run_infos:
             test_class_name = test_run_info.test_class.__name__
-            if test_class_name in test_selector: 
+            if test_class_name in test_selector:
                 selected_test_methods = test_selector.pop(test_class_name)
 
-                if selected_test_methods: 
-                    # verify that the selected test methods exist. 
+                if selected_test_methods:
+                    # verify that the selected test methods exist.
                     existing_test_methods = _get_all_tests(
                         test_run_info.test_class, test_run_info.config)
                     nonexistent_methods = [
-                        selected_method for selected_method in selected_test_methods
-                        if selected_method not in existing_test_methods]
-                    if nonexistent_methods: 
+                        selected_method
+                        for selected_method in selected_test_methods
+                        if selected_method not in existing_test_methods
+                    ]
+                    if nonexistent_methods:
                         raise Error(
                             'Trying to selected nonexistent test methods %s from test class %s'
-                            % (nonexistent_methods, test_class_name)
-                            )
+                            % (nonexistent_methods, test_class_name))
 
                 test_run_info.tests = selected_test_methods
                 new_test_run_infos.append(test_run_info)
-        if test_selector: 
-            raise Error(
-                'Trying to select test methods from classes %s '
-                'that have not been added to TestRunner.' 
-                % [item[0] for item in test_selector.items()]
-                )
+        if test_selector:
+            raise Error('Trying to select test methods from classes %s '
+                        'that have not been added to TestRunner.' %
+                        [item[0] for item in test_selector.items()])
         self._test_run_infos = new_test_run_infos
 
-    def print_all_test_methods(self): 
+    def print_all_test_methods(self):
         """Prints all test methods in this TestRunner's execution plan. 
 
         Prints the test methods that this TestRunner will execute in the following format: 
@@ -420,14 +421,21 @@ class TestRunner(object):
 
         """
         test_names_to_print = []
-        for test_run_info in self._test_run_infos: 
-            existing_test_names = _get_all_tests(test_run_info.test_class, test_run_info.config)
+        for test_run_info in self._test_run_infos:
+            existing_test_names = _get_all_tests(test_run_info.test_class,
+                                                 test_run_info.config)
             prefix = test_run_info.test_class.__name__ + '.'
-            if test_run_info.tests: 
-                assert all(test in existing_test_names for test in test_run_info.tests), 'No method should be specified in test_run_info.tests that is not part of the corresponding class/config\'s existing tess'
-                test_names_to_print += [prefix + test for test in test_run_info.tests]
-            else: 
-                test_names_to_print += [prefix + test for test in existing_test_names]
+            if test_run_info.tests:
+                assert all(
+                    test in existing_test_names for test in test_run_info.tests
+                ), 'No method should be specified in test_run_info.tests that is not part of the corresponding class/config\'s existing tess'
+                test_names_to_print += [
+                    prefix + test for test in test_run_info.tests
+                ]
+            else:
+                test_names_to_print += [
+                    prefix + test for test in existing_test_names
+                ]
         header = '==========> Preview of Test Execution Plan. <=========='
         print(header)
         print('\n'.join(test_names_to_print))

--- a/tests/lib/bar_test.py
+++ b/tests/lib/bar_test.py
@@ -1,0 +1,30 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mobly import asserts
+from mobly import base_test
+from mobly import test_runner
+
+
+class BarTest(base_test.BaseTestClass):
+    """Adding some additional test methods for test selection tests. """
+    
+    def test_bar_a(self):
+        asserts.explicit_pass("bar")
+
+    def test_bar_b(self):
+        asserts.explicit_pass("bar")
+
+if __name__ == "__main__":
+    test_runner.main()

--- a/tests/lib/bar_test.py
+++ b/tests/lib/bar_test.py
@@ -19,12 +19,13 @@ from mobly import test_runner
 
 class BarTest(base_test.BaseTestClass):
     """Adding some additional test methods for test selection tests. """
-    
+
     def test_bar_a(self):
         asserts.explicit_pass("bar")
 
     def test_bar_b(self):
         asserts.explicit_pass("bar")
+
 
 if __name__ == "__main__":
     test_runner.main()

--- a/tests/lib/baz_test.py
+++ b/tests/lib/baz_test.py
@@ -19,12 +19,13 @@ from mobly import test_runner
 
 class BazTest(base_test.BaseTestClass):
     """Adding some additional test methods for test selection tests. """
-    
+
     def test_baz_a(self):
         asserts.explicit_pass("baz")
 
     def test_baz_b(self):
         asserts.explicit_pass("baz")
+
 
 if __name__ == "__main__":
     test_runner.main()

--- a/tests/lib/baz_test.py
+++ b/tests/lib/baz_test.py
@@ -1,0 +1,30 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mobly import asserts
+from mobly import base_test
+from mobly import test_runner
+
+
+class BazTest(base_test.BaseTestClass):
+    """Adding some additional test methods for test selection tests. """
+    
+    def test_baz_a(self):
+        asserts.explicit_pass("baz")
+
+    def test_baz_b(self):
+        asserts.explicit_pass("baz")
+
+if __name__ == "__main__":
+    test_runner.main()

--- a/tests/lib/foo_test.py
+++ b/tests/lib/foo_test.py
@@ -1,0 +1,30 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mobly import asserts
+from mobly import base_test
+from mobly import test_runner
+
+
+class FooTest(base_test.BaseTestClass):
+    """Adding some additional test methods for test selection tests. """
+    
+    def test_foo_a(self):
+        asserts.explicit_pass("foo")
+
+    def test_foo_b(self):
+        asserts.explicit_pass("foo")
+
+if __name__ == "__main__":
+    test_runner.main()

--- a/tests/lib/foo_test.py
+++ b/tests/lib/foo_test.py
@@ -19,12 +19,13 @@ from mobly import test_runner
 
 class FooTest(base_test.BaseTestClass):
     """Adding some additional test methods for test selection tests. """
-    
+
     def test_foo_a(self):
         asserts.explicit_pass("foo")
 
     def test_foo_b(self):
         asserts.explicit_pass("foo")
+
 
 if __name__ == "__main__":
     test_runner.main()

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -304,15 +304,16 @@ class TestRunnerTest(unittest.TestCase):
             tr.add_test_class(self.base_mock_test_config,
                               integration_test.IntegrationTest)
 
-    def test_add_test_class_not_subclass_basetest(self): 
+    def test_add_test_class_not_subclass_basetest(self):
         mock_test_config = self.base_mock_test_config.copy()
-        class BadTest(object): 
+
+        class BadTest(object):
             pass
+
         tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
-        with self.assertRaisesRegex(
-                test_runner.Error,
-                'Test class BadTest does not extend '
-                'mobly.base_test.BaseTestClass'):
+        with self.assertRaisesRegex(test_runner.Error,
+                                    'Test class BadTest does not extend '
+                                    'mobly.base_test.BaseTestClass'):
             tr.add_test_class(mock_test_config, BadTest)
 
     def test_run_no_tests(self):
@@ -355,7 +356,7 @@ class TestRunnerTest(unittest.TestCase):
         test_runner.main(['-c', 'some/path/foo.yaml', '-b', 'hello'])
         mock_config.assert_called_with('some/path/foo.yaml', None)
 
-    def test_select_test_methods_valid_selection(self): 
+    def test_select_test_methods_valid_selection(self):
         mock_test_config = self.base_mock_test_config.copy()
         tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
         tr.add_test_class(mock_test_config, foo_test.FooTest)
@@ -366,7 +367,7 @@ class TestRunnerTest(unittest.TestCase):
         results = tr.results.summary_dict()
         self.assertEqual(results['Requested'], 3)
 
-    def test_select_test_methods_invalid_class(self): 
+    def test_select_test_methods_invalid_class(self):
         mock_test_config = self.base_mock_test_config.copy()
         tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
         tr.add_test_class(mock_test_config, foo_test.FooTest)
@@ -377,7 +378,7 @@ class TestRunnerTest(unittest.TestCase):
                 'that have not been added to TestRunner.'):
             tr.select_test_methods(['FooTest', 'BarTest.test_bar'])
 
-    def test_select_test_methods_invalid_method(self): 
+    def test_select_test_methods_invalid_method(self):
         mock_test_config = self.base_mock_test_config.copy()
         tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
         tr.add_test_class(mock_test_config, foo_test.FooTest)
@@ -387,12 +388,12 @@ class TestRunnerTest(unittest.TestCase):
                 r'from test class FooTest'):
             tr.select_test_methods(['FooTest.test_nonexistent_method'])
 
-    def test_print_all_test_methods(self): 
+    def test_print_all_test_methods(self):
         mock_test_config = self.base_mock_test_config.copy()
         tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
         tr.add_test_class(mock_test_config, foo_test.FooTest)
         tr.add_test_class(mock_test_config, bar_test.BarTest)
-        # python 2/3 compatibility. 
+        # python 2/3 compatibility.
         try:
             from StringIO import StringIO
         except ImportError:
@@ -402,7 +403,7 @@ class TestRunnerTest(unittest.TestCase):
         tr.print_all_test_methods()
         expected = 'FooTest.test_foo_a\nFooTest.test_foo_b\nBarTest.test_bar_a\nBarTest.test_bar_b'
         self.assertTrue(re.search(expected, capturedOutput.getvalue()))
-        sys.stdout = sys.__stdout__ 
+        sys.stdout = sys.__stdout__
 
 
 if __name__ == "__main__":

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import mock
 import os
 import shutil
 import tempfile
+import re
+import sys
 import yaml
 from future.tests.base import unittest
 
@@ -28,6 +31,9 @@ from tests.lib import mock_android_device
 from tests.lib import mock_controller
 from tests.lib import integration_test
 from tests.lib import integration2_test
+from tests.lib import foo_test
+from tests.lib import bar_test
+from tests.lib import baz_test
 
 
 class TestRunnerTest(unittest.TestCase):
@@ -298,6 +304,17 @@ class TestRunnerTest(unittest.TestCase):
             tr.add_test_class(self.base_mock_test_config,
                               integration_test.IntegrationTest)
 
+    def test_add_test_class_not_subclass_basetest(self): 
+        mock_test_config = self.base_mock_test_config.copy()
+        class BadTest(object): 
+            pass
+        tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
+        with self.assertRaisesRegex(
+                test_runner.Error,
+                'Test class BadTest does not extend '
+                'mobly.base_test.BaseTestClass'):
+            tr.add_test_class(mock_test_config, BadTest)
+
     def test_run_no_tests(self):
         tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
         with self.assertRaisesRegex(test_runner.Error, 'No tests to execute.'):
@@ -337,6 +354,55 @@ class TestRunnerTest(unittest.TestCase):
                              mock_find_test):
         test_runner.main(['-c', 'some/path/foo.yaml', '-b', 'hello'])
         mock_config.assert_called_with('some/path/foo.yaml', None)
+
+    def test_select_test_methods_valid_selection(self): 
+        mock_test_config = self.base_mock_test_config.copy()
+        tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
+        tr.add_test_class(mock_test_config, foo_test.FooTest)
+        tr.add_test_class(mock_test_config, bar_test.BarTest)
+        tr.add_test_class(mock_test_config, baz_test.BazTest)
+        tr.select_test_methods(['FooTest', 'BarTest.test_bar_a'])
+        tr.run()
+        results = tr.results.summary_dict()
+        self.assertEqual(results['Requested'], 3)
+
+    def test_select_test_methods_invalid_class(self): 
+        mock_test_config = self.base_mock_test_config.copy()
+        tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
+        tr.add_test_class(mock_test_config, foo_test.FooTest)
+        # Note, not adding BarTest
+        with self.assertRaisesRegex(
+                test_runner.Error,
+                'Trying to select test methods from classes \[\'BarTest\'\] '
+                'that have not been added to TestRunner.'):
+            tr.select_test_methods(['FooTest', 'BarTest.test_bar'])
+
+    def test_select_test_methods_invalid_method(self): 
+        mock_test_config = self.base_mock_test_config.copy()
+        tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
+        tr.add_test_class(mock_test_config, foo_test.FooTest)
+        with self.assertRaisesRegex(
+                test_runner.Error,
+                'Trying to selected nonexistent test methods \[\'test_nonexistent_method\'\] '
+                r'from test class FooTest'):
+            tr.select_test_methods(['FooTest.test_nonexistent_method'])
+
+    def test_print_all_test_methods(self): 
+        mock_test_config = self.base_mock_test_config.copy()
+        tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
+        tr.add_test_class(mock_test_config, foo_test.FooTest)
+        tr.add_test_class(mock_test_config, bar_test.BarTest)
+        # python 2/3 compatibility. 
+        try:
+            from StringIO import StringIO
+        except ImportError:
+            from io import StringIO
+        capturedOutput = StringIO()
+        sys.stdout = capturedOutput
+        tr.print_all_test_methods()
+        expected = 'FooTest.test_foo_a\nFooTest.test_foo_b\nBarTest.test_bar_a\nBarTest.test_bar_b'
+        self.assertTrue(re.search(expected, capturedOutput.getvalue()))
+        sys.stdout = sys.__stdout__ 
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
test_runner can edit test methods belonging to classes that have already been added to the runner's execution plan, and can print a list of test methods that are in the runner's execution plan. Users of the test_runner must do their own parsing of command line arguments for test selection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/352)
<!-- Reviewable:end -->
