### PR TITLE
Support remote devices whose serials can change during test.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -540,11 +540,10 @@ class AndroidDevice(object):
 
         Args:
             new_serial: string, the new serial number for the same device.
+
+        Raises:
+            DeviceError: tries to update serial when any service is running.
         """
-        if new_serial == self._serial:
-            raise DeviceError(
-                self, 'Serial is already %s, cannot set to the same value.' %
-                self._serial)
         if self.has_active_service:
             raise DeviceError(
                 self,

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -17,8 +17,10 @@ from builtins import open
 from past.builtins import basestring
 
 import contextlib
+import distutils
 import logging
 import os
+import shutil
 import time
 
 from mobly import logger as mobly_logger
@@ -44,7 +46,12 @@ ANDROID_DEVICE_EMPTY_CONFIG_MSG = 'Configuration is empty, abort!'
 ANDROID_DEVICE_NOT_LIST_CONFIG_MSG = 'Configuration should be a list, abort!'
 
 # Keys for attributes in configs that alternate the controller module behavior.
+# If this is False for a device, errors from that device will be ignored
+# during `create`. Default is True.
 KEY_DEVICE_REQUIRED = 'required'
+# If True, logcat collection will not be started during `create`.
+# Default is False.
+KEY_SKIP_LOGCAT = 'skip_logcat'
 
 # Default Timeout to wait for boot completion
 DEFAULT_TIMEOUT_BOOT_COMPLETION_SECOND = 15 * 60
@@ -142,6 +149,10 @@ def _start_services_on_ads(ads):
     running_ads = []
     for ad in ads:
         running_ads.append(ad)
+        skip_logcat = getattr(ad, KEY_SKIP_LOGCAT, False)
+        print('#######$$$$$$$', ad.serial, skip_logcat)
+        if skip_logcat:
+            continue
         try:
             ad.start_services()
         except Exception:
@@ -414,10 +425,12 @@ class AndroidDevice(object):
     """
 
     def __init__(self, serial=''):
-        self.serial = serial
+        self._serial = serial
         # logging.log_path only exists when this is used in an Mobly test run.
         self._log_path_base = getattr(logging, 'log_path', '/tmp/logs')
-        self._debug_tag = self.serial
+        self._log_path = os.path.join(self._log_path_base,
+                                      'AndroidDevice%s' % self._serial)
+        self._debug_tag = self._serial
         self.log = AndroidDeviceLoggerAdapter(logging.getLogger(),
                                               {'tag': self.debug_tag})
         self.sl4a = None
@@ -466,10 +479,71 @@ class AndroidDevice(object):
         self.log.extra['tag'] = tag
 
     @property
+    def has_active_service(self):
+        """True if any service is running on the device.
+
+        A service can be a snippet or logcat collection.
+        """
+        return any(
+            [self._snippet_clients, self._adb_logcat_process, self.sl4a])
+
+    @property
     def log_path(self):
         """A string that is the path for all logs collected from this device.
+
+        This by design should not be changed during the test.
         """
-        return os.path.join(self._log_path_base, 'AndroidDevice%s' % self.debug_tag)
+        return self._log_path
+
+    @log_path.setter
+    def log_path(self, new_path):
+        if self.has_active_service:
+            raise DeviceError(
+                self,
+                'Cannot change `log_path` when there is service running.')
+        old_path = self._log_path
+        utils.create_dir(new_path)
+        distutils.dir_util.copy_tree(self._log_path, new_path)
+        shutil.rmtree(self._log_path, ignore_errors=True)
+        self._log_path = new_path
+
+    @property
+    def serial(self):
+        """The serial number used to identify a device.
+
+        This is essentially the value used for adb's `-s` arg, which means it
+        can be a network address or USB bus number.
+        """
+        return self._serial
+
+    def update_serial(self, new_serial):
+        """Updates the serial number of a device.
+
+        The "serial number" used with adb's `-s` arg is not necessarily the
+        actual serial number. For remote devices, it could be a combination of
+        host names and port numbers.
+
+        This is used for when such identifier of remote devices changes during
+        a test. For example, when a remote device reboots, it may come back
+        with a different serial number.
+
+        This is NOT meant for switching the object to represent another device.
+
+        We intentionally did not make it a regular setter of the serial
+        property so people don't accidentally call this without understanding
+        the consequences.
+
+        Args:
+            new_serial: string, the new serial number for the same device.
+        """
+        if self.has_active_service:
+            raise DeviceError(
+                self,
+                'Cannot change device serial number when there is service running.'
+            )
+        if self._debug_tag == self.serial:
+            self._debug_tag = new_serial
+        self._serial = new_serial
 
     def start_services(self, clear_log=True):
         """Starts long running services on the android device, like adb logcat

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -416,8 +416,7 @@ class AndroidDevice(object):
     def __init__(self, serial=''):
         self.serial = serial
         # logging.log_path only exists when this is used in an Mobly test run.
-        log_path_base = getattr(logging, 'log_path', '/tmp/logs')
-        self.log_path = os.path.join(log_path_base, 'AndroidDevice%s' % serial)
+        self._log_path_base = getattr(logging, 'log_path', '/tmp/logs')
         self._debug_tag = self.serial
         self.log = AndroidDeviceLoggerAdapter(logging.getLogger(),
                                               {'tag': self.debug_tag})
@@ -465,6 +464,12 @@ class AndroidDevice(object):
         self.log.info('Logging debug tag set to "%s"', tag)
         self._debug_tag = tag
         self.log.extra['tag'] = tag
+
+    @property
+    def log_path(self):
+        """A string that is the path for all logs collected from this device.
+        """
+        return os.path.join(self._log_path_base, 'AndroidDevice%s' % self.debug_tag)
 
     def start_services(self, clear_log=True):
         """Starts long running services on the android device, like adb logcat

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -150,7 +150,6 @@ def _start_services_on_ads(ads):
     for ad in ads:
         running_ads.append(ad)
         skip_logcat = getattr(ad, KEY_SKIP_LOGCAT, False)
-        print('#######$$$$$$$', ad.serial, skip_logcat)
         if skip_logcat:
             continue
         try:
@@ -503,8 +502,9 @@ class AndroidDevice(object):
                 'Cannot change `log_path` when there is service running.')
         old_path = self._log_path
         utils.create_dir(new_path)
-        distutils.dir_util.copy_tree(self._log_path, new_path)
-        shutil.rmtree(self._log_path, ignore_errors=True)
+        if os.path.exists(old_path):
+            distutils.dir_util.copy_tree(self._log_path, new_path)
+            shutil.rmtree(self._log_path, ignore_errors=True)
         self._log_path = new_path
 
     @property

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -49,9 +49,11 @@ ANDROID_DEVICE_NOT_LIST_CONFIG_MSG = 'Configuration should be a list, abort!'
 # If this is False for a device, errors from that device will be ignored
 # during `create`. Default is True.
 KEY_DEVICE_REQUIRED = 'required'
+DEFAULT_VALUE_DEVICE_REQUIRED = True
 # If True, logcat collection will not be started during `create`.
 # Default is False.
 KEY_SKIP_LOGCAT = 'skip_logcat'
+DEFAULT_VALUE_SKIP_LOGCAT = False
 
 # Default Timeout to wait for boot completion
 DEFAULT_TIMEOUT_BOOT_COMPLETION_SECOND = 15 * 60
@@ -149,13 +151,14 @@ def _start_services_on_ads(ads):
     running_ads = []
     for ad in ads:
         running_ads.append(ad)
-        skip_logcat = getattr(ad, KEY_SKIP_LOGCAT, False)
+        skip_logcat = getattr(ad, KEY_SKIP_LOGCAT, DEFAULT_VALUE_SKIP_LOGCAT)
         if skip_logcat:
             continue
         try:
             ad.start_services()
         except Exception:
-            is_required = getattr(ad, KEY_DEVICE_REQUIRED, True)
+            is_required = getattr(ad, KEY_DEVICE_REQUIRED,
+                                  DEFAULT_VALUE_DEVICE_REQUIRED)
             if is_required:
                 ad.log.exception('Failed to start some services, abort!')
                 destroy(running_ads)
@@ -489,13 +492,15 @@ class AndroidDevice(object):
     @property
     def log_path(self):
         """A string that is the path for all logs collected from this device.
-
-        This by design should not be changed during the test.
         """
         return self._log_path
 
     @log_path.setter
     def log_path(self, new_path):
+        """Setter for `log_path`, use with caution.
+
+
+        """
         if self.has_active_service:
             raise DeviceError(
                 self,
@@ -536,6 +541,10 @@ class AndroidDevice(object):
         Args:
             new_serial: string, the new serial number for the same device.
         """
+        if new_serial == self._serial:
+            raise DeviceError(
+                self, 'Serial is already %s, cannot set to the same value.' %
+                self._serial)
         if self.has_active_service:
             raise DeviceError(
                 self,

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -508,8 +508,8 @@ class AndroidDevice(object):
         old_path = self._log_path
         utils.create_dir(new_path)
         if os.path.exists(old_path):
-            distutils.dir_util.copy_tree(self._log_path, new_path)
-            shutil.rmtree(self._log_path, ignore_errors=True)
+            distutils.dir_util.copy_tree(old_path, new_path)
+            shutil.rmtree(old_path, ignore_errors=True)
         self._log_path = new_path
 
     @property

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -36,6 +36,7 @@ def get_mock_ads(num):
     ads = []
     for i in range(num):
         ad = mock.MagicMock(name="AndroidDevice", serial=str(i), h_port=None)
+        ad.skip_logcat = False
         ads.append(ad)
     return ads
 

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -20,6 +20,7 @@ import tempfile
 
 from future.tests.base import unittest
 
+from mobly import utils
 from mobly.controllers import android_device
 
 from tests.lib import mock_android_device
@@ -432,14 +433,15 @@ class AndroidDeviceTest(unittest.TestCase):
         """
         mock_serial = 1
         ad = android_device.AndroidDevice(serial=mock_serial)
+        # Direct the log path of the ad to a temp dir to avoid racing.
+        ad._log_path_base = self.tmp_dir
         # Expect error if attempted to cat adb log before starting adb logcat.
         expected_msg = ('.* Attempting to cat adb log when none'
                         ' has been collected.')
         with self.assertRaisesRegex(android_device.Error, expected_msg):
             ad.cat_adb_log('some_test', MOCK_ADB_LOGCAT_BEGIN_TIME)
         ad.start_adb_logcat()
-        # Direct the log path of the ad to a temp dir to avoid racing.
-        ad.log_path = os.path.join(self.tmp_dir, ad.log_path)
+        utils.create_dir(ad.log_path)
         mock_adb_log_path = os.path.join(ad.log_path, 'adblog,%s,%s.txt' %
                                          (ad.model, ad.serial))
         with open(mock_adb_log_path, 'w') as f:

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -448,6 +448,25 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch(
         'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
         return_value=mock_android_device.MockFastbootProxy(1))
+    @mock.patch(
+        'mobly.utils.start_standing_subprocess', return_value='process')
+    @mock.patch('mobly.utils.stop_standing_subprocess')
+    def test_AndroidDevice_change_log_path_no_log_exists(self, stop_proc_mock,
+                                           start_proc_mock, FastbootProxy,
+                                           MockAdbProxy):
+        ad = android_device.AndroidDevice(serial=1)
+        old_path = ad.log_path
+        new_log_path = tempfile.mkdtemp()
+        ad.log_path = new_log_path
+        self.assertTrue(os.path.exists(new_log_path))
+        self.assertFalse(os.path.exists(old_path))
+
+    @mock.patch(
+        'mobly.controllers.android_device_lib.adb.AdbProxy',
+        return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch(
+        'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+        return_value=mock_android_device.MockFastbootProxy(1))
     @mock.patch('mobly.utils.create_dir')
     @mock.patch(
         'mobly.utils.start_standing_subprocess', return_value='process')


### PR DESCRIPTION
The key problem is that the `log_path` is hard coded to include the device's serial number as part of it. Now that the serial number may change, we should allow users to decouple the log_path from the serial number itself.

So now we allow users to update the serial and log_path during the test to accommodate such devices.

The recommended approach is to skip adb logcat via the config key, then in `setup_class`, set the `log_path` to a location agnostic to the device's actual serial number, then when the device reboots with a different serial, call `update_serial` to use the new serial number on the object.

* Add API to properly update the serial number.
* Allow log_path to be modified.
* Allow not starting logcat collection by default.

@gauravkatoch007

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/363)
<!-- Reviewable:end -->
