### PR TITLE
Fix a bug where exception is thrown by `create_dir`.

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -91,7 +91,12 @@ def create_dir(path):
     """
     full_path = abs_path(path)
     if not os.path.exists(full_path):
-        os.makedirs(full_path)
+        try:
+            os.makedirs(full_path)
+        except OSError as e:
+            # ignore the error for dir already exist.
+            if e.errno != os.errno.EEXIST:
+                raise
 
 
 def create_alias(target_path, alias_path):

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import mock
+import os
 import platform
 import socket
+import tempfile
 import time
 from future.tests.base import unittest
 
@@ -49,6 +51,17 @@ class UtilsTest(unittest.TestCase):
         p1 = psutil.Process(p.pid)
         utils.stop_standing_subprocess(p)
         self.assertFalse(p1.is_running())
+
+    def test_create_dir(self):
+        tmp_dir = tempfile.mkdtemp()
+        new_path = os.path.join(tmp_dir, 'haha')
+        utils.create_dir(new_path)
+        self.assertTrue(os.path.exists(new_path))
+
+    def test_create_dir_already_exists(self):
+        tmp_dir = tempfile.mkdtemp()
+        utils.create_dir(tmp_dir)
+        self.assertTrue(os.path.exists(tmp_dir))
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.list_occupied_adb_ports')

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -55,11 +55,13 @@ class UtilsTest(unittest.TestCase):
     def test_create_dir(self):
         tmp_dir = tempfile.mkdtemp()
         new_path = os.path.join(tmp_dir, 'haha')
+        self.assertFalse(os.path.exists(new_path))
         utils.create_dir(new_path)
         self.assertTrue(os.path.exists(new_path))
 
     def test_create_dir_already_exists(self):
         tmp_dir = tempfile.mkdtemp()
+        self.assertTrue(os.path.exists(tmp_dir))
         utils.create_dir(tmp_dir)
         self.assertTrue(os.path.exists(tmp_dir))
 


### PR DESCRIPTION
`create_dir` sometimes throws `OSError` with code 17.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/367)
<!-- Reviewable:end -->
