### PR TITLE
Restructure adb error classes.

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -16,6 +16,7 @@ from builtins import str
 from past.builtins import basestring
 
 import logging
+import pipes
 import psutil
 import subprocess
 import threading
@@ -53,7 +54,7 @@ class AdbError(Error):
 
     def __str__(self):
         return ('Error executing adb cmd "%s". ret: %d, stdout: %s, stderr: %s'
-                ) % (' '.join(self.cmd), self.ret_code, self.stdout,
+                ) % (cli_cmd_to_string(self.cmd), self.ret_code, self.stdout,
                      self.stderr)
 
 
@@ -71,7 +72,7 @@ class AdbTimeoutError(Error):
 
     def __str__(self):
         return 'Timed out executing command "%s" after %ss.' % (
-            ' '.join(self.cmd), self.timeout)
+            cli_cmd_to_string(self.cmd), self.timeout)
 
 
 def list_occupied_adb_ports():
@@ -94,6 +95,18 @@ def list_occupied_adb_ports():
             continue
         used_ports.append(int(tokens[1]))
     return used_ports
+
+
+def cli_cmd_to_string(args):
+    """Converts a cmd arg list to string.
+
+    Args:
+        args: list of strings, the arguments of a command.
+
+    Returns:
+        String representation of the command.
+    """
+    return ' '.join([pipes.quote(arg) for arg in args])
 
 
 class AdbProxy(object):
@@ -155,7 +168,7 @@ class AdbProxy(object):
         (out, err) = proc.communicate()
         ret = proc.returncode
         logging.debug('cmd: %s, stdout: %s, stderr: %s, ret: %s',
-                      ' '.join(args), out, err, ret)
+                      cli_cmd_to_string(args), out, err, ret)
         if ret == 0:
             return out
         else:

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -53,8 +53,8 @@ class AdbTest(unittest.TestCase):
         # the created process object in adb._exec_cmd()
         mock_psutil_process.return_value = mock.Mock()
 
-        mock_proc.communicate = mock.Mock(
-            return_value=('out'.encode('utf-8'), 'err'.encode('utf-8')))
+        mock_proc.communicate = mock.Mock(return_value=('out'.encode('utf-8'),
+                                                        'err'.encode('utf-8')))
         mock_proc.returncode = 0
         return (mock_psutil_process, mock_popen)
 
@@ -98,7 +98,8 @@ class AdbTest(unittest.TestCase):
             adb.psutil.TimeoutExpired('Timed out'))
 
         with self.assertRaisesRegex(adb.AdbTimeoutError,
-                                    'Timed out Adb cmd .*'):
+                                    'Timed out executing command "fake_cmd" '
+                                    'after 0.1s.'):
             adb.AdbProxy()._exec_cmd(['fake_cmd'], shell=False, timeout=0.1)
 
     @mock.patch('mobly.controllers.android_device_lib.adb.subprocess.Popen')
@@ -106,8 +107,8 @@ class AdbTest(unittest.TestCase):
     def test_exec_cmd_with_negative_timeout_value(self, mock_psutil_process,
                                                   mock_popen):
         self._mock_process(mock_psutil_process, mock_popen)
-        with self.assertRaisesRegex(adb.AdbError,
-                                    'Timeout is a negative value: .*'):
+        with self.assertRaisesRegex(adb.Error,
+                                    'Timeout is not a positive value: -1'):
             adb.AdbProxy()._exec_cmd(['fake_cmd'], shell=False, timeout=-1)
 
     def test_exec_adb_cmd(self):


### PR DESCRIPTION
* AdbTimeoutError should not be a subclass of AdbError as they are
  raised for different occasions.
* Improve log messages.
* Add proper docstrings.

@oprypin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/368)
<!-- Reviewable:end -->
