### PR TITLE
Localize `psutil` usage.

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -19,7 +19,6 @@ import logging
 import os
 import platform
 import portpicker
-import psutil
 import random
 import re
 import signal
@@ -331,6 +330,7 @@ def stop_standing_subprocess(proc, kill_signal=signal.SIGTERM):
     Raises:
         Error: if the subprocess could not be stopped.
     """
+    import psutil
     pid = proc.pid
     logging.debug('Stopping standing subprocess %d', pid)
     process = psutil.Process(pid)

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -330,6 +330,9 @@ def stop_standing_subprocess(proc, kill_signal=signal.SIGTERM):
     Raises:
         Error: if the subprocess could not be stopped.
     """
+    # Only import psutil when actually needed.
+    # psutil may cause import error in certain env. This way the utils module
+    # doesn't crash upon import.
     import psutil
     pid = proc.pid
     logging.debug('Stopping standing subprocess %d', pid)


### PR DESCRIPTION
`psutil` doesn't work well for some specific internal env.
Localizing its import so the utils module can be used without having to have `psutil`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/371)
<!-- Reviewable:end -->
