### PR TITLE
Provide a way to add custom controller info in AndroidDevice.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -130,12 +130,7 @@ def get_info(ads):
     Returns:
         A list of dict, each representing info for an AndroidDevice objects.
     """
-    device_info = []
-    for ad in ads:
-        info = {'serial': ad.serial, 'model': ad.model}
-        info.update(ad.build_info)
-        device_info.append(info)
-    return device_info
+    return [ad.device_info for ad in ads]
 
 
 def _start_services_on_ads(ads):
@@ -432,8 +427,9 @@ class AndroidDevice(object):
         self._log_path = os.path.join(self._log_path_base,
                                       'AndroidDevice%s' % self._serial)
         self._debug_tag = self._serial
-        self.log = AndroidDeviceLoggerAdapter(logging.getLogger(),
-                                              {'tag': self.debug_tag})
+        self.log = AndroidDeviceLoggerAdapter(logging.getLogger(), {
+            'tag': self.debug_tag
+        })
         self.sl4a = None
         self.ed = None
         self._adb_logcat_process = None
@@ -445,9 +441,35 @@ class AndroidDevice(object):
         # A dict for tracking snippet clients. Keys are clients' attribute
         # names, values are the clients: {<attr name string>: <client object>}.
         self._snippet_clients = {}
+        # Device info cache.
+        self._device_info = {}
 
     def __repr__(self):
         return '<AndroidDevice|%s>' % self.debug_tag
+
+    @property
+    def device_info(self):
+        """Information specific to the device's property/state.
+
+        By default, the latest serial, model, and build_info are included.
+
+        Additional info can be added via `add_device_info`.
+        """
+        info = {'serial': self.serial, 'model': self.model}
+        info.update(self.build_info)
+        info.update(self._device_info)
+        return info
+
+    def add_device_info(self, name, info):
+        """Add information of the device to be pulled into controller info.
+
+        Adding the same info name the second time will override existing info.
+
+        Args:
+            name: string, name of this info.
+            info: serializable, content of the info.
+        """
+        self._device_info.update({name: info})
 
     @property
     def debug_tag(self):

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -442,22 +442,24 @@ class AndroidDevice(object):
         # names, values are the clients: {<attr name string>: <client object>}.
         self._snippet_clients = {}
         # Device info cache.
-        self._device_info = {}
+        self._user_added_device_info = {}
 
     def __repr__(self):
         return '<AndroidDevice|%s>' % self.debug_tag
 
     @property
     def device_info(self):
-        """Information specific to the device's property/state.
+        """Information to be pulled into controller info.
 
-        By default, the latest serial, model, and build_info are included.
-
-        Additional info can be added via `add_device_info`.
+        The latest serial, model, and build_info are included. Additional info
+        can be added via `add_device_info`.
         """
-        info = {'serial': self.serial, 'model': self.model}
-        info.update(self.build_info)
-        info.update(self._device_info)
+        info = {
+            'serial': self.serial,
+            'model': self.model,
+            'build_info': self.build_info,
+            'user_added_info': self._user_added_device_info
+        }
         return info
 
     def add_device_info(self, name, info):
@@ -469,7 +471,7 @@ class AndroidDevice(object):
             name: string, name of this info.
             info: serializable, content of the info.
         """
-        self._device_info.update({name: info})
+        self._user_added_device_info.update({name: info})
 
     @property
     def debug_tag(self):

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -277,13 +277,13 @@ class AndroidDeviceTest(unittest.TestCase):
         device_info = ad.device_info
         self.assertEqual(device_info['serial'], 1)
         self.assertEqual(device_info['model'], 'fakemodel')
-        self.assertEqual(device_info['build_id'], 'AB42')
-        self.assertEqual(device_info['build_type'], 'userdebug')
+        self.assertEqual(device_info['build_info']['build_id'], 'AB42')
+        self.assertEqual(device_info['build_info']['build_type'], 'userdebug')
         ad.add_device_info('sim_type', 'Fi')
         ad.add_device_info('build_id', 'CD42')
         device_info = ad.device_info
-        self.assertEqual(device_info['sim_type'], 'Fi')
-        self.assertEqual(device_info['build_id'], 'CD42')
+        self.assertEqual(device_info['user_added_info']['sim_type'], 'Fi')
+        self.assertEqual(device_info['user_added_info']['build_id'], 'CD42')
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.AdbProxy',

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -272,6 +272,25 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch(
         'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
         return_value=mock_android_device.MockFastbootProxy(1))
+    def test_AndroidDevice_device_info(self, MockFastboot, MockAdbProxy):
+        ad = android_device.AndroidDevice(serial=1)
+        device_info = ad.device_info
+        self.assertEqual(device_info['serial'], 1)
+        self.assertEqual(device_info['model'], 'fakemodel')
+        self.assertEqual(device_info['build_id'], 'AB42')
+        self.assertEqual(device_info['build_type'], 'userdebug')
+        ad.add_device_info('sim_type', 'Fi')
+        ad.add_device_info('build_id', 'CD42')
+        device_info = ad.device_info
+        self.assertEqual(device_info['sim_type'], 'Fi')
+        self.assertEqual(device_info['build_id'], 'CD42')
+
+    @mock.patch(
+        'mobly.controllers.android_device_lib.adb.AdbProxy',
+        return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch(
+        'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+        return_value=mock_android_device.MockFastbootProxy(1))
     @mock.patch('mobly.utils.create_dir')
     def test_AndroidDevice_take_bug_report(self, create_dir_mock,
                                            FastbootProxy, MockAdbProxy):


### PR DESCRIPTION
`ControllerInfo` fields of `AndroidDevice` was hard coded by `android_device` module.
This opens up this field for users to add additional `ControllerInfo` for `AndroidDevice` that are useful for their tests.
@JamieKuppel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/377)
<!-- Reviewable:end -->

  