### PR TITLE
Improve the handling of serial number as a string.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str
+from builtins import str as new_str
 from builtins import open
 from past.builtins import basestring
 
@@ -175,7 +175,7 @@ def _parse_device_list(device_list_str, key):
     Returns:
         A list of android device serial numbers.
     """
-    clean_lines = str(device_list_str, 'utf-8').strip().split('\n')
+    clean_lines = new_str(device_list_str, 'utf-8').strip().split('\n')
     results = []
     for line in clean_lines:
         tokens = line.strip().split('\t')
@@ -204,7 +204,7 @@ def list_adb_devices_by_usb_id():
         none.
     """
     out = adb.AdbProxy().devices(['-l'])
-    clean_lines = str(out, 'utf-8').strip().split('\n')
+    clean_lines = new_str(out, 'utf-8').strip().split('\n')
     results = []
     for line in clean_lines:
         tokens = line.strip().split()
@@ -1086,7 +1086,7 @@ class AndroidDevice(object):
             results: results have data flow information
         """
         out = self.adb.shell('iperf3 -c %s %s' % (server_host, extra_args))
-        clean_out = str(out, 'utf-8').strip().split('\n')
+        clean_out = new_str(out, 'utf-8').strip().split('\n')
         if 'error' in clean_out[0].lower():
             return False, clean_out
         return True, clean_out

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from builtins import str as new_str
+
 import logging
 import mock
 import os
 import shutil
 import tempfile
+import yaml
 
 from future.tests.base import unittest
 
@@ -284,6 +287,20 @@ class AndroidDeviceTest(unittest.TestCase):
         device_info = ad.device_info
         self.assertEqual(device_info['user_added_info']['sim_type'], 'Fi')
         self.assertEqual(device_info['user_added_info']['build_id'], 'CD42')
+
+    @mock.patch(
+        'mobly.controllers.android_device_lib.adb.AdbProxy',
+        return_value=mock_android_device.MockAdbProxy('1'))
+    @mock.patch(
+        'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+        return_value=mock_android_device.MockFastbootProxy('1'))
+    def test_AndroidDevice_serial_is_valid(self, MockFastboot, MockAdbProxy):
+        """Verifies that the serial is a primitive string type and serializable.
+        """
+        ad = android_device.AndroidDevice(serial=1)
+        self.assertFalse(isinstance(ad.serial, new_str))
+        self.assertTrue(isinstance(ad.serial, str))
+        yaml.safe_dump(ad.serial)
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.AdbProxy',

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -298,7 +298,12 @@ class AndroidDeviceTest(unittest.TestCase):
         """Verifies that the serial is a primitive string type and serializable.
         """
         ad = android_device.AndroidDevice(serial=1)
-        self.assertFalse(isinstance(ad.serial, new_str))
+        # In py2, checks that ad.serial is not the backported py3 str type, 
+        # which is not dumpable by yaml in py2.
+        # In py3, new_str is equivalent to str, so this check is not
+        # appropirate in py3.
+        if sys.version_info < (3, 0):
+            self.assertFalse(isinstance(ad.serial, new_str))
         self.assertTrue(isinstance(ad.serial, str))
         yaml.safe_dump(ad.serial)
 

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -18,6 +18,7 @@ import logging
 import mock
 import os
 import shutil
+import sys
 import tempfile
 import yaml
 


### PR DESCRIPTION
* Clarify the usage of py-future's new_str type in android_device.
* Add a unit test to make sure `ad.serial` is a regular yaml compatible string.

Without this, the yaml dump of `ad.serial` would fail.
Because the import of py-future's `str` overrode the system's `str` when it didn't need to.
This is a follow-up for #380 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/382)
<!-- Reviewable:end -->

  