### PR TITLE
Fix monsoon module import error.

### DIFF
--- a/mobly/controllers/monsoon.py
+++ b/mobly/controllers/monsoon.py
@@ -1,11 +1,11 @@
 # Copyright 2016 Google Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -57,8 +57,8 @@ def create(configs):
     else:
         raise Error('No valid config found in: %s' % configs)
     return objs
- 
- 
+
+
 def get_instances_with_configs(configs):
     """Create Monsoon instances from a list of dict configs.
 
@@ -73,8 +73,8 @@ def get_instances_with_configs(configs):
         A list of Monsoon objects.
     """
     return get_instances([c['serial'] for c in configs])
- 
- 
+
+
 def get_instances(serials):
     """Create Monsoon instances from a list of serials.
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ install_requires = [
     'psutil',
     'pytz',
     'pyyaml',
-    'timeout_decorator'
+    'timeout_decorator',
+    'pyserial'
 ]
 
 if sys.version_info < (3, ):

--- a/tests/mobly/controllers/monsoon_test.py
+++ b/tests/mobly/controllers/monsoon_test.py
@@ -1,0 +1,25 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from future.tests.base import unittest
+
+
+class MonsoonTest(unittest.TestCase):
+
+    def test_monsoon_import(self):
+        from mobly.controllers import monsoon
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Remove mysterious trailing space like char
* Add a unit test for importing monsoon module
* Add a missing dep in setup.py
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/386)
<!-- Reviewable:end -->
