### PR TITLE
Fix recording of teardown_class failures in new output format.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -189,9 +189,12 @@ class BaseTestClass(object):
         try:
             self.teardown_class()
         except Exception as e:
+            logging.exception('Error encountered in teardown_class.')
             record.test_error(e)
             record.update_record()
             self.results.add_class_error(record)
+            self.summary_writer.dump(record.to_dict(),
+                                     records.TestSummaryEntryType.RECORD)
 
     def teardown_class(self):
         """Teardown function that will be called after all the selected tests in

--- a/tests/lib/teardown_class_failure_test.py
+++ b/tests/lib/teardown_class_failure_test.py
@@ -1,0 +1,28 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A test used to verify the output file includes teardown_class failures."""
+from mobly import base_test
+from mobly import test_runner
+
+
+class TearDownClassFailureTest(base_test.BaseTestClass):
+    def test_foo(self):
+        pass
+
+    def teardown_class(self):
+        raise Exception('Teardown class failed.')
+
+
+if __name__ == '__main__':
+    test_runner.main()


### PR DESCRIPTION
* Record the entry in summary file
* Log the error in test log files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/397)
<!-- Reviewable:end -->
