### PR TITLE
Adding None checks to stop_standing_subprocess

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -366,8 +366,10 @@ def stop_standing_subprocess(proc, kill_signal=signal.SIGTERM):
         raise Error('Failed to kill standing subprocesses: %s' % failed)
     # Call wait and close pipes on the original Python object so we don't get
     # runtime warnings.
-    proc.stdout.close()
-    proc.stderr.close()
+    if proc.stdout:
+        proc.stdout.close()
+    if proc.stderr:
+        proc.stderr.close()
     proc.wait()
     logging.debug('Stopped standing subprocess %d', pid)
 

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -1,11 +1,11 @@
 # Copyright 2016 Google Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@ import mock
 import os
 import platform
 import socket
+import subprocess
 import tempfile
 import time
 from future.tests.base import unittest
@@ -48,6 +49,13 @@ class UtilsTest(unittest.TestCase):
 
     def test_stop_standing_subproc(self):
         p = utils.start_standing_subprocess([self.sleep_cmd, '4'])
+        p1 = psutil.Process(p.pid)
+        utils.stop_standing_subprocess(p)
+        self.assertFalse(p1.is_running())
+
+    def test_stop_standing_subproc_wihtout_pipe(self):
+        p = subprocess.Popen([self.sleep_cmd, '4'])
+        self.assertIsNone(p.stdout)
         p1 = psutil.Process(p.pid)
         utils.stop_standing_subprocess(p)
         self.assertFalse(p1.is_running())


### PR DESCRIPTION
Adding checks to stop_standing_subprocess to ensure it properly handles
subprocesses started with subprocess.Popen directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/399)
<!-- Reviewable:end -->
