### PR TITLE
Fix Windows Android M empty line issue with instrumentation parser

### DIFF
--- a/mobly/base_instrumentation_test.py
+++ b/mobly/base_instrumentation_test.py
@@ -411,7 +411,10 @@ class _InstrumentationBlock(object):
             line: string, the raw instrumentation line to append to the value
                 list.
         """
-        self._empty = False
+        # Don't count whitespace only lines.
+        if line.strip():
+            self._empty = False
+
         if self.current_key in self.known_keys:
             self.known_keys[self.current_key].append(line)
         else:
@@ -459,10 +462,10 @@ class _InstrumentationBlockFormatter(object):
         self._unknown_keys = {}
         for key, value in instrumentation_block.known_keys.items():
             self._known_keys[key] = '\n'.join(
-                instrumentation_block.known_keys[key])
+                instrumentation_block.known_keys[key]).rstrip()
         for key, value in instrumentation_block.unknown_keys.items():
             self._unknown_keys[key] = '\n'.join(
-                instrumentation_block.unknown_keys[key])
+                instrumentation_block.unknown_keys[key]).rstrip()
 
     def _get_name(self):
         """Gets the method name of the test method for the instrumentation

--- a/tests/mobly/base_instrumentation_test_test.py
+++ b/tests/mobly/base_instrumentation_test_test.py
@@ -260,6 +260,61 @@ INSTRUMENTATION_CODE: -1
             expected_executed=expected_executed,
             expected_completed_and_passed=True)
 
+    def test_run_instrumentation_test_with_random_whitespace(self):
+        instrumentation_output = """\
+
+INSTRUMENTATION_STATUS: numtests=1
+
+INSTRUMENTATION_STATUS: stream=
+
+com.my.package.test.BasicTest:
+
+INSTRUMENTATION_STATUS: id=AndroidJUnitRunner
+
+INSTRUMENTATION_STATUS: test=basicTest
+
+INSTRUMENTATION_STATUS: class=com.my.package.test.BasicTest
+
+INSTRUMENTATION_STATUS: current=1
+
+INSTRUMENTATION_STATUS_CODE: 1
+
+INSTRUMENTATION_STATUS: numtests=1
+
+INSTRUMENTATION_STATUS: stream=.
+
+INSTRUMENTATION_STATUS: id=AndroidJUnitRunner
+
+INSTRUMENTATION_STATUS: test=basicTest
+
+INSTRUMENTATION_STATUS: class=com.my.package.test.BasicTest
+
+INSTRUMENTATION_STATUS: current=1
+
+INSTRUMENTATION_STATUS_CODE: 0
+
+INSTRUMENTATION_RESULT: stream=
+
+
+Time: 0.214
+
+
+OK (1 test)
+
+
+
+
+INSTRUMENTATION_CODE: -1
+
+"""
+        expected_executed = [
+            ('com.my.package.test.BasicTest#basicTest', signals.TestPass),
+        ]
+        self.assert_run_instrumentation_test(
+            instrumentation_output,
+            expected_executed=expected_executed,
+            expected_completed_and_passed=True)
+
     def test_run_instrumentation_test_with_prefix_test(self):
         instrumentation_output = """\
 INSTRUMENTATION_STATUS: numtests=1


### PR DESCRIPTION
On Android M on a Windows, each line of the instrumentation output has an extra line, this causes the instrumentation parser to erroneously assume that there is a non-empty malformed instrumentation block.

The fix for this is to simply, ignore whitespace only lines for the purposes of calculating empty blocks.

Additionally, when formatting, the extra new lines at the end of everything should be stripped otherwise stuff like the test name becomes malformed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/400)
<!-- Reviewable:end -->
