### PR TITLE
Modified stack trace handling for setup_test exceptions.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -358,9 +358,7 @@ class BaseTestClass(object):
                 try:
                     self._setup_test(test_name)
                 except signals.TestFailure as e:
-                    new_e = signals.TestError(e.details, e.extras)
-                    _, _, new_e.__traceback__ = sys.exc_info()
-                    raise new_e
+                    raise signals.TestError, e, sys.exc_info()[2]
                 if args or kwargs:
                     test_method(*args, **kwargs)
                 else:

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -19,6 +19,8 @@ import inspect
 import logging
 import sys
 
+from future.utils import raise_with_traceback
+
 from mobly import expects
 from mobly import records
 from mobly import signals
@@ -358,7 +360,7 @@ class BaseTestClass(object):
                 try:
                     self._setup_test(test_name)
                 except signals.TestFailure as e:
-                    raise signals.TestError, e, sys.exc_info()[2]
+                    raise_with_traceback(signals.TestError(e.details, e.extras))
                 if args or kwargs:
                     test_method(*args, **kwargs)
                 else:


### PR DESCRIPTION
Fixes #409 

Ran with python version 2.7.13 and got the sample error response back:

[SampleTestBed] 02-27 16:10:30.221 INFO [Test] test_hello
[SampleTestBed] 02-27 16:10:30.221 ERROR Exception occurred in test_hello.
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/mobly-1.7.1-py2.7.egg/mobly/base_test.py", line 359, in exec_one_test
    self._setup_test(test_name)
  File "/usr/local/lib/python2.7/dist-packages/mobly-1.7.1-py2.7.egg/mobly/base_test.py", line 211, in _setup_test
    self.setup_test()
  File "hello_world_test.py", line 18, in setup_test
    asserts.fail('sample failure')
  File "/usr/local/lib/python2.7/dist-packages/mobly-1.7.1-py2.7.egg/mobly/asserts.py", line 239, in fail
    raise signals.TestFailure(msg, extras)
TestError: Details=Details=sample failure, Extras=None, Extras=None
[SampleTestBed] 02-27 16:10:30.223 INFO [Test] test_hello ERROR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/412)
<!-- Reviewable:end -->
