### PR TITLE
Fix exception raising in `AndroidDevice.load_snippet`.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -879,20 +879,21 @@ class AndroidDevice(object):
         client = snippet_client.SnippetClient(package=package, ad=self)
         try:
             client.start_app_and_connect()
-        except:
+        except snippet_client.AppStartPreCheckError:
+            # Precheck errors don't need cleanup, directly raise.
+            raise
+        except Exception as e:
             # Log the stacktrace of `e` as re-raising doesn't preserve trace.
             self.log.exception('Failed to start app and connect.')
             # If errors happen, make sure we clean up before raising.
             try:
                 client.stop_app()
-            except Exception as e:  # Catch the `stop_app` exception obj so the
-                # subsequent `raise` raises the exception from
-                # `start_app_and_connect`.
+            except:
                 self.log.exception(
                     'Failed to stop app after failure to start app and connect.'
                 )
-            # Raise the error from start app failure.
-            raise
+            # Explicitly raise the error from start app failure.
+            raise e
         self._snippet_clients[name] = client
         setattr(self, name, client)
 

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -56,6 +56,24 @@ _SETSID_COMMAND = 'setsid'
 _NOHUP_COMMAND = 'nohup'
 
 
+class AppStartPreCheckError(jsonrpc_client_base.Error):
+    """Raised when pre checks for the snippet failed."""
+
+
+class SnippetNotInstalledError(AppStartPreCheckError):
+    """Raised when the snippet apk is not installed on the device."""
+
+
+class SnippetNotInstrumentedError(AppStartPreCheckError):
+    """Raised when the snippet apk is installed but not instrumented."""
+
+
+class InstrumentationTargetNotInstalledError(AppStartPreCheckError):
+    """Raised when the instrumentation target of the snippet apk is not
+    installed on device.
+    """
+
+
 class ProtocolVersionError(jsonrpc_client_base.AppStartError):
     """Raised when the protocol reported by the snippet is unknown."""
 
@@ -114,12 +132,14 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         # Forward the device port to a new host port, and connect to that port
         self.host_port = utils.get_available_host_port()
         self._adb.forward(
-            ['tcp:%d' % self.host_port, 'tcp:%d' % self.device_port])
+            ['tcp:%d' % self.host_port,
+             'tcp:%d' % self.device_port])
         self.connect()
 
         # Yaaay! We're done!
         self.log.debug('Snippet %s started after %.1fs on host port %s',
-                       self.package, time.time() - start_time, self.host_port)
+                       self.package,
+                       time.time() - start_time, self.host_port)
 
     def restore_app_connection(self, port=None):
         """Restores the app after device got reconnected.
@@ -139,7 +159,8 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         """
         self.host_port = port or utils.get_available_host_port()
         self._adb.forward(
-            ['tcp:%d' % self.host_port, 'tcp:%d' % self.device_port])
+            ['tcp:%d' % self.host_port,
+             'tcp:%d' % self.device_port])
         try:
             self.connect()
         except:
@@ -198,7 +219,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         # Check that the Mobly Snippet app is installed.
         out = self._adb.shell('pm list package')
         if not utils.grep('^package:%s$' % self.package, out):
-            raise jsonrpc_client_base.AppStartError(
+            raise SnippetNotInstalledError(
                 self._ad, '%s is not installed.' % self.package)
         # Check that the app is instrumented.
         out = self._adb.shell('pm list instrumentation')
@@ -206,7 +227,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
                                  (self.package,
                                   _INSTRUMENTATION_RUNNER_PACKAGE), out)
         if not matched_out:
-            raise jsonrpc_client_base.AppStartError(
+            raise SnippetNotInstrumentedError(
                 self._ad,
                 '%s is installed, but it is not instrumented.' % self.package)
         match = re.search('^instrumentation:(.*)\/(.*) \(target=(.*)\)$',
@@ -217,7 +238,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         if target_name != self.package:
             out = self._adb.shell('pm list package')
             if not utils.grep('^package:%s$' % target_name, out):
-                raise jsonrpc_client_base.AppStartError(
+                raise InstrumentationTargetNotInstalledError(
                     self._ad, 'Instrumentation target %s is not installed.' %
                     target_name)
 
@@ -251,8 +272,8 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
             # call above the truthiness check, or this method will start
             # considering any blank output line to be EOF.
             line = line.strip()
-            if (line.startswith('INSTRUMENTATION_RESULT:') or
-                    line.startswith('SNIPPET ')):
+            if (line.startswith('INSTRUMENTATION_RESULT:')
+                    or line.startswith('SNIPPET ')):
                 self.log.debug(
                     'Accepted line from instrumentation output: "%s"', line)
                 return line

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -78,7 +78,7 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
     def test_check_app_installed_fail_app_not_installed(self):
         sc = self._make_client(MockAdbProxy(apk_not_installed=True))
         expected_msg = '.* %s is not installed.' % MOCK_PACKAGE_NAME
-        with self.assertRaisesRegex(snippet_client.SnippetNotInstalledError,
+        with self.assertRaisesRegex(snippet_client.AppStartPreCheckError,
                                     expected_msg):
             sc._check_app_installed()
 
@@ -86,7 +86,7 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
         sc = self._make_client(MockAdbProxy(apk_not_instrumented=True))
         expected_msg = ('.* %s is installed, but it is not instrumented.' %
                         MOCK_PACKAGE_NAME)
-        with self.assertRaisesRegex(snippet_client.SnippetNotInstrumentedError,
+        with self.assertRaisesRegex(snippet_client.AppStartPreCheckError,
                                     expected_msg):
             sc._check_app_installed()
 
@@ -94,9 +94,8 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
         sc = self._make_client(MockAdbProxy(target_not_installed=True))
         expected_msg = ('.* Instrumentation target %s is not installed.' %
                         MOCK_MISSING_PACKAGE_NAME)
-        with self.assertRaisesRegex(
-                snippet_client.InstrumentationTargetNotInstalledError,
-                expected_msg):
+        with self.assertRaisesRegex(snippet_client.AppStartPreCheckError,
+                                    expected_msg):
             sc._check_app_installed()
 
     @mock.patch('socket.create_connection')

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -78,7 +78,7 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
     def test_check_app_installed_fail_app_not_installed(self):
         sc = self._make_client(MockAdbProxy(apk_not_installed=True))
         expected_msg = '.* %s is not installed.' % MOCK_PACKAGE_NAME
-        with self.assertRaisesRegex(jsonrpc_client_base.AppStartError,
+        with self.assertRaisesRegex(snippet_client.SnippetNotInstalledError,
                                     expected_msg):
             sc._check_app_installed()
 
@@ -86,7 +86,7 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
         sc = self._make_client(MockAdbProxy(apk_not_instrumented=True))
         expected_msg = ('.* %s is installed, but it is not instrumented.' %
                         MOCK_PACKAGE_NAME)
-        with self.assertRaisesRegex(jsonrpc_client_base.AppStartError,
+        with self.assertRaisesRegex(snippet_client.SnippetNotInstrumentedError,
                                     expected_msg):
             sc._check_app_installed()
 
@@ -94,8 +94,9 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
         sc = self._make_client(MockAdbProxy(target_not_installed=True))
         expected_msg = ('.* Instrumentation target %s is not installed.' %
                         MOCK_MISSING_PACKAGE_NAME)
-        with self.assertRaisesRegex(jsonrpc_client_base.AppStartError,
-                                    expected_msg):
+        with self.assertRaisesRegex(
+                snippet_client.InstrumentationTargetNotInstalledError,
+                expected_msg):
             sc._check_app_installed()
 
     @mock.patch('socket.create_connection')
@@ -225,17 +226,19 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
             snippet_client._NOHUP_COMMAND, MOCK_PACKAGE_NAME,
             snippet_client._INSTRUMENTATION_RUNNER_PACKAGE)
         mock_do_start_app.assert_has_calls(
-            [mock.call(cmd_setsid), mock.call(cmd_nohup)])
+            [mock.call(cmd_setsid),
+             mock.call(cmd_nohup)])
 
         # Test both 'setsid' and 'nohup' do not exist
-        client._adb.shell = mock.Mock(side_effect=adb.AdbError(
-            'cmd', 'stdout', 'stderr', 'ret_code'))
+        client._adb.shell = mock.Mock(
+            side_effect=adb.AdbError('cmd', 'stdout', 'stderr', 'ret_code'))
         client = self._make_client()
         client.start_app_and_connect()
         cmd_not_persist = ' am instrument -w -e action start %s/%s' % (
             MOCK_PACKAGE_NAME, snippet_client._INSTRUMENTATION_RUNNER_PACKAGE)
         mock_do_start_app.assert_has_calls([
-            mock.call(cmd_setsid), mock.call(cmd_nohup),
+            mock.call(cmd_setsid),
+            mock.call(cmd_nohup),
             mock.call(cmd_not_persist)
         ])
 
@@ -323,8 +326,7 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
         adb_proxy = adb_proxy or MockAdbProxy()
         ad = mock.Mock()
         ad.adb = adb_proxy
-        return snippet_client.SnippetClient(
-            package=MOCK_PACKAGE_NAME, ad=ad)
+        return snippet_client.SnippetClient(package=MOCK_PACKAGE_NAME, ad=ad)
 
     def _setup_mock_instrumentation_cmd(self, mock_start_standing_subprocess,
                                         resp_lines):


### PR DESCRIPTION
* Always raise the start app error in load_snippet.
* Create more specific error types for load_snippet pre-check failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/419)
<!-- Reviewable:end -->
