### PR TITLE
Add an option to get the stderr of an adb command.

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -177,7 +177,7 @@ class AdbProxy(object):
         logging.debug('cmd: %s, stdout: %s, stderr: %s, ret: %s',
                       cli_cmd_to_string(args), out, err, ret)
         if ret == 0:
-            return out, err
+            return out
         else:
             raise AdbError(cmd=args, stdout=out, stderr=err, ret_code=ret)
 
@@ -199,7 +199,7 @@ class AdbProxy(object):
                     adb_cmd.append(args)
                 else:
                     adb_cmd.extend(args)
-        out, err = self._exec_cmd(
+        out = self._exec_cmd(
             adb_cmd, shell=shell, timeout=timeout, stderr=stderr)
         return out
 

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -138,7 +138,7 @@ class AdbProxy(object):
     def __init__(self, serial=''):
         self.serial = serial
 
-    def _exec_cmd(self, args, shell, timeout, stderr=None):
+    def _exec_cmd(self, args, shell, timeout, stderr):
         """Executes adb commands.
 
         Args:
@@ -148,6 +148,8 @@ class AdbProxy(object):
                 False to invoke it directly. See subprocess.Popen() docs.
             timeout: float, the number of seconds to wait before timing out.
                 If not specified, no timeout takes effect.
+            stderr: a Byte stream, like io.BytesIO, stderr of the command will
+                be written to this object if provided.
 
         Returns:
             The output of the adb command run if exit code is 0.
@@ -287,8 +289,8 @@ class AdbProxy(object):
                     False to invoke it directly. See subprocess.Proc() docs.
                 timeout: float, the number of seconds to wait before timing out.
                     If not specified, no timeout takes effect.
-                return_all: bool, if True, returns both stdout and stderr as
-                    two separate values. Otherwise only return stdout.
+                stderr: a Byte stream, like io.BytesIO, stderr of the command
+                    will be written to this object if provided.
 
             Returns:
                 The output of the adb command run if exit code is 0.

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -42,11 +42,10 @@ MOCK_OPTIONS_INSTRUMENTATION_COMMAND = ('am instrument -r -w -e option1 value1'
                                         '.AndroidJUnitRunner')
 # Mock Shell Command
 MOCK_SHELL_COMMAND = 'ls'
-MOCK_COMMAND_OUTPUT = ('/system/bin/ls'.encode('utf-8'), ''.encode('utf-8'))
+MOCK_COMMAND_OUTPUT = '/system/bin/ls'.encode('utf-8')
 MOCK_DEFAULT_STDOUT = 'out'
 MOCK_DEFAULT_STDERR = 'err'
-MOCK_DEFAULT_COMMAND_OUTPUT = (MOCK_DEFAULT_STDOUT.encode('utf-8'),
-                               MOCK_DEFAULT_STDERR.encode('utf-8'))
+MOCK_DEFAULT_COMMAND_OUTPUT = MOCK_DEFAULT_STDOUT.encode('utf-8')
 MOCK_ADB_SHELL_COMMAND_CHECK = 'adb shell command -v ls'
 
 
@@ -63,7 +62,8 @@ class AdbTest(unittest.TestCase):
         mock_psutil_process.return_value = mock.Mock()
 
         mock_proc.communicate = mock.Mock(
-            return_value=MOCK_DEFAULT_COMMAND_OUTPUT)
+            return_value=(MOCK_DEFAULT_STDOUT.encode('utf-8'),
+                          MOCK_DEFAULT_STDERR.encode('utf-8')))
         mock_proc.returncode = 0
         return (mock_psutil_process, mock_popen)
 
@@ -73,10 +73,9 @@ class AdbTest(unittest.TestCase):
                                          mock_Popen):
         self._mock_process(mock_psutil_process, mock_Popen)
 
-        out, err = adb.AdbProxy()._exec_cmd(
+        out = adb.AdbProxy()._exec_cmd(
             ['fake_cmd'], shell=False, timeout=None, stderr=None)
         self.assertEqual(MOCK_DEFAULT_STDOUT, out.decode('utf-8'))
-        self.assertEqual(MOCK_DEFAULT_STDERR, err.decode('utf-8'))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.subprocess.Popen')
     @mock.patch('mobly.controllers.android_device_lib.adb.psutil.Process')
@@ -96,10 +95,9 @@ class AdbTest(unittest.TestCase):
                                            mock_popen):
         self._mock_process(mock_psutil_process, mock_popen)
 
-        out, err = adb.AdbProxy()._exec_cmd(
+        out = adb.AdbProxy()._exec_cmd(
             ['fake_cmd'], shell=False, timeout=1, stderr=None)
         self.assertEqual(MOCK_DEFAULT_STDOUT, out.decode('utf-8'))
-        self.assertEqual(MOCK_DEFAULT_STDERR, err.decode('utf-8'))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.subprocess.Popen')
     @mock.patch('mobly.controllers.android_device_lib.adb.psutil.Process')

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -74,7 +74,7 @@ class AdbTest(unittest.TestCase):
         self._mock_process(mock_psutil_process, mock_Popen)
 
         out, err = adb.AdbProxy()._exec_cmd(
-            ['fake_cmd'], shell=False, timeout=None)
+            ['fake_cmd'], shell=False, timeout=None, stderr=None)
         self.assertEqual(MOCK_DEFAULT_STDOUT, out.decode('utf-8'))
         self.assertEqual(MOCK_DEFAULT_STDERR, err.decode('utf-8'))
 
@@ -87,7 +87,8 @@ class AdbTest(unittest.TestCase):
 
         with self.assertRaisesRegex(adb.AdbError,
                                     'Error executing adb cmd .*'):
-            adb.AdbProxy()._exec_cmd(['fake_cmd'], shell=False, timeout=None)
+            adb.AdbProxy()._exec_cmd(
+                ['fake_cmd'], shell=False, timeout=None, stderr=None)
 
     @mock.patch('mobly.controllers.android_device_lib.adb.subprocess.Popen')
     @mock.patch('mobly.controllers.android_device_lib.adb.psutil.Process')
@@ -96,7 +97,7 @@ class AdbTest(unittest.TestCase):
         self._mock_process(mock_psutil_process, mock_popen)
 
         out, err = adb.AdbProxy()._exec_cmd(
-            ['fake_cmd'], shell=False, timeout=1)
+            ['fake_cmd'], shell=False, timeout=1, stderr=None)
         self.assertEqual(MOCK_DEFAULT_STDOUT, out.decode('utf-8'))
         self.assertEqual(MOCK_DEFAULT_STDERR, err.decode('utf-8'))
 
@@ -112,7 +113,8 @@ class AdbTest(unittest.TestCase):
         with self.assertRaisesRegex(adb.AdbTimeoutError,
                                     'Timed out executing command "fake_cmd" '
                                     'after 0.1s.'):
-            adb.AdbProxy()._exec_cmd(['fake_cmd'], shell=False, timeout=0.1)
+            adb.AdbProxy()._exec_cmd(
+                ['fake_cmd'], shell=False, timeout=0.1, stderr=None)
 
     @mock.patch('mobly.controllers.android_device_lib.adb.subprocess.Popen')
     @mock.patch('mobly.controllers.android_device_lib.adb.psutil.Process')
@@ -121,7 +123,8 @@ class AdbTest(unittest.TestCase):
         self._mock_process(mock_psutil_process, mock_popen)
         with self.assertRaisesRegex(adb.Error,
                                     'Timeout is not a positive value: -1'):
-            adb.AdbProxy()._exec_cmd(['fake_cmd'], shell=False, timeout=-1)
+            adb.AdbProxy()._exec_cmd(
+                ['fake_cmd'], shell=False, timeout=-1, stderr=None)
 
     def test_exec_adb_cmd(self):
         with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:


### PR DESCRIPTION
Minor refactoring of `adb_test`
Fixes #435

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/437)
<!-- Reviewable:end -->
