### PR TITLE
Change UserData timestamp from a float to an int

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -26,6 +26,7 @@ from mobly import expects
 from mobly import records
 from mobly import signals
 from mobly import runtime_test_info
+from mobly import utils
 
 # Macro strings for test result reporting
 TEST_CASE_TOKEN = '[Test]'
@@ -351,7 +352,7 @@ class BaseTestClass(object):
             content: dict, the data to add to summary file.
         """
         if 'timestamp' not in content:
-            content['timestamp'] = time.time()
+            content['timestamp'] = utils.get_current_epoch_time()
         self.summary_writer.dump(content,
                                  records.TestSummaryEntryType.USER_DATA)
 


### PR DESCRIPTION
Changed UserData 'timestamp' to use the same util as 'Begin Time' and 'End Time'.

Currently, the UserData 'timestamp' looks like so:
`timestamp: 1524253402.126622`
This changes it so it will look like:
`timestamp: 1524253402`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/439)
<!-- Reviewable:end -->
