### PR TITLE
Extend runtime test info for `setup_class` stage.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -624,6 +624,10 @@ class BaseTestClass(object):
         tests = self._get_test_methods(test_names)
         try:
             # Setup for the class.
+            class_record = records.TestResultRecord('setup_class', self.TAG)
+            class_record.test_begin()
+            self.current_test_info = runtime_test_info.RuntimeTestInfo(
+                'setup_class', self.log_path, class_record)
             try:
                 self._setup_class()
             except signals.TestAbortSignal:
@@ -633,9 +637,6 @@ class BaseTestClass(object):
                 # Setup class failed for unknown reasons.
                 # Fail the class and skip all tests.
                 logging.exception('Error in setup_class %s.', self.TAG)
-                class_record = records.TestResultRecord(
-                    'setup_class', self.TAG)
-                class_record.test_begin()
                 class_record.test_error(e)
                 self._exec_procedure_func(self._on_fail, class_record)
                 self.results.add_class_error(class_record)

--- a/mobly/runtime_test_info.py
+++ b/mobly/runtime_test_info.py
@@ -19,9 +19,12 @@ from mobly import utils
 
 
 class RuntimeTestInfo(object):
-    """Container class for runtime information of a test.
+    """Container class for runtime information of a test or test stage.
 
     One object corresponds to one test. This is meant to be a read-only class.
+
+    This also applies to test stages like `setup_class`, which has its own
+    runtime info but is not part of any single test.
 
     Attributes:
         name: string, name of the test.

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -91,6 +91,25 @@ class BaseTestTest(unittest.TestCase):
         self.assertIsNone(actual_record.details)
         self.assertIsNone(actual_record.extras)
 
+    def test_current_test_info_in_setup_class(self):
+        class MockBaseTest(base_test.BaseTestClass):
+            def setup_class(self):
+                asserts.assert_true(
+                    self.current_test_info.name == 'setup_class',
+                    'Got unexpected test name %s.' %
+                    self.current_test_info.name)
+                output_path = self.current_test_info.output_path
+                asserts.assert_true(
+                    os.path.exists(output_path), 'test output path missing')
+                raise Exception(MSG_EXPECTED_EXCEPTION)
+
+        bt_cls = MockBaseTest(self.mock_test_cls_configs)
+        bt_cls.run()
+        actual_record = bt_cls.results.error[0]
+        self.assertEqual(actual_record.test_name, 'setup_class')
+        self.assertEqual(actual_record.details, MSG_EXPECTED_EXCEPTION)
+        self.assertIsNone(actual_record.extras)
+
     def test_self_tests_list(self):
         class MockBaseTest(base_test.BaseTestClass):
             def __init__(self, controllers):


### PR DESCRIPTION
So `BaseTestClass.current_test_info` can be used more consistently throughout the test class.

Fixes #442

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/444)
<!-- Reviewable:end -->
