### PR TITLE
Fix _execute_and_process_stdout.

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -205,7 +205,7 @@ class AdbProxy(object):
             bufsize=1)
         out = '[elided, processed via handler]'
         try:
-            while proc.poll() is None:
+            while True:
                 line = proc.stdout.readline()
                 if line:
                     handler(line)

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -205,6 +205,8 @@ class AdbProxy(object):
             bufsize=1)
         out = '[elided, processed via handler]'
         try:
+            # Even if the process dies, stdout.readline still works
+            # and will continue until it runs out of stdout to process.
             while True:
                 line = proc.stdout.readline()
                 if line:
@@ -212,6 +214,7 @@ class AdbProxy(object):
                 else:
                     break
         finally:
+            # Note, communicate will not contain any buffered output.
             (unexpected_out, err) = proc.communicate()
             if unexpected_out:
                 out = '[unexpected stdout] %s' % unexpected_out


### PR DESCRIPTION
Changes _execute_and_process_stdout to match SnippetClient._read_protocol_line.

This should fix an issue with _execute_and_process_stdout where the last few lines of output were missing. This behaviour is actually implied by the test test_execute_and_process_stdout_when_cmd_exits, which is changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/456)
<!-- Reviewable:end -->
