### PR TITLE
Support alias for test classes when using suite.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -84,8 +84,12 @@ class BaseTestClass(object):
             configs: A config_parser.TestRunConfig object.
         """
         self.tests = []
-        if not self.TAG:
-            self.TAG = self.__class__.__name__
+        self._class_name = self.__class__.__name__
+        if configs.test_class_name_suffix and self.TAG is None:
+            self.TAG = '%s_%s' % (self._class_name,
+                                  configs.test_class_name_suffix)
+        elif self.TAG is None:
+            self.TAG = self._class_name
         # Set params.
         self.log_path = configs.log_path
         self.controller_configs = configs.controller_configs

--- a/mobly/config_parser.py
+++ b/mobly/config_parser.py
@@ -169,6 +169,9 @@ class TestRunConfig(object):
             modules.
         summary_writer: records.TestSummaryWriter, used to write elements to
             the test result summary file.
+        test_class_name_suffix: string, suffix to append to the class name for
+                reporting. This is used for differentiating the same class
+                executed with different parameters in a suite.
     """
 
     def __init__(self):
@@ -178,6 +181,7 @@ class TestRunConfig(object):
         self.user_params = None
         self.register_controller = None
         self.summary_writer = None
+        self.test_class_name_suffix = None
 
     def copy(self):
         """Returns a deep copy of the current config.

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -259,6 +259,11 @@ class TestRunnerTest(unittest.TestCase):
         self.assertEqual(results['Requested'], 2)
         self.assertEqual(results['Executed'], 2)
         self.assertEqual(results['Passed'], 2)
+        # Tag of the test class defaults to the class name.
+        record1 = tr.results.executed[0]
+        record2 = tr.results.executed[1]
+        self.assertEqual(record1.test_class, 'IntegrationTest')
+        self.assertEqual(record1.test_class, 'IntegrationTest')
 
     def test_run_two_test_classes_different_configs_and_aliases(self):
         """Verifies that running more than one test class in one test run with

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -280,11 +280,11 @@ class TestRunnerTest(unittest.TestCase):
         tr.add_test_class(
             config1,
             integration_test.IntegrationTest,
-            class_alias='IntegrationTest-FirstConfig')
+            name_suffix='FirstConfig')
         tr.add_test_class(
             config2,
             integration_test.IntegrationTest,
-            class_alias='IntegrationTest-SecondConfig')
+            name_suffix='SecondConfig')
         tr.run()
         results = tr.results.summary_dict()
         self.assertEqual(results['Requested'], 2)
@@ -294,8 +294,8 @@ class TestRunnerTest(unittest.TestCase):
         self.assertEqual(tr.results.failed[0].details, '10 != 42')
         record1 = tr.results.executed[0]
         record2 = tr.results.executed[1]
-        self.assertEqual(record1.test_class, 'IntegrationTest-FirstConfig')
-        self.assertEqual(record2.test_class, 'IntegrationTest-SecondConfig')
+        self.assertEqual(record1.test_class, 'IntegrationTest_FirstConfig')
+        self.assertEqual(record2.test_class, 'IntegrationTest_SecondConfig')
 
     def test_run_with_abort_all(self):
         mock_test_config = self.base_mock_test_config.copy()

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -260,7 +260,7 @@ class TestRunnerTest(unittest.TestCase):
         self.assertEqual(results['Executed'], 2)
         self.assertEqual(results['Passed'], 2)
 
-    def test_run_two_test_classes_different_configs(self):
+    def test_run_two_test_classes_different_configs_and_aliases(self):
         """Verifies that running more than one test class in one test run with
         different configs works properly.
         """
@@ -272,8 +272,14 @@ class TestRunnerTest(unittest.TestCase):
         config2 = config1.copy()
         config2.user_params['icecream'] = 10
         tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
-        tr.add_test_class(config1, integration_test.IntegrationTest)
-        tr.add_test_class(config2, integration_test.IntegrationTest)
+        tr.add_test_class(
+            config1,
+            integration_test.IntegrationTest,
+            class_alias='IntegrationTest-FirstConfig')
+        tr.add_test_class(
+            config2,
+            integration_test.IntegrationTest,
+            class_alias='IntegrationTest-SecondConfig')
         tr.run()
         results = tr.results.summary_dict()
         self.assertEqual(results['Requested'], 2)
@@ -281,6 +287,10 @@ class TestRunnerTest(unittest.TestCase):
         self.assertEqual(results['Passed'], 1)
         self.assertEqual(results['Failed'], 1)
         self.assertEqual(tr.results.failed[0].details, '10 != 42')
+        record1 = tr.results.executed[0]
+        record2 = tr.results.executed[1]
+        self.assertEqual(record1.test_class, 'IntegrationTest-FirstConfig')
+        self.assertEqual(record2.test_class, 'IntegrationTest-SecondConfig')
 
     def test_run_with_abort_all(self):
         mock_test_config = self.base_mock_test_config.copy()

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -262,8 +262,8 @@ class TestRunnerTest(unittest.TestCase):
         # Tag of the test class defaults to the class name.
         record1 = tr.results.executed[0]
         record2 = tr.results.executed[1]
-        self.assertEqual(record1.test_class, 'IntegrationTest')
-        self.assertEqual(record1.test_class, 'IntegrationTest')
+        self.assertEqual(record1.test_class, 'Integration2Test')
+        self.assertEqual(record2.test_class, 'IntegrationTest')
 
     def test_run_two_test_classes_different_configs_and_aliases(self):
         """Verifies that running more than one test class in one test run with


### PR DESCRIPTION
So the same test class can be run with different configs and reported differently in the same suite.

Aliases are only possible in a suite as they are set when calling `add_test_class`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/467)
<!-- Reviewable:end -->
