### PR TITLE
Use `ro.debuggable` to decide if a device is rootable.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -784,7 +784,6 @@ class AndroidDevice(object):
 
     @property
     def is_rootable(self):
-        """Only debuggable builds are rootable."""
         return self.adb.getprop('ro.debuggable') == '1'
 
     @property

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -436,8 +436,9 @@ class AndroidDevice(object):
         self._log_path = os.path.join(self._log_path_base,
                                       'AndroidDevice%s' % self._serial)
         self._debug_tag = self._serial
-        self.log = AndroidDeviceLoggerAdapter(logging.getLogger(),
-                                              {'tag': self.debug_tag})
+        self.log = AndroidDeviceLoggerAdapter(logging.getLogger(), {
+            'tag': self.debug_tag
+        })
         self.sl4a = None
         self.ed = None
         self._adb_logcat_process = None
@@ -783,15 +784,8 @@ class AndroidDevice(object):
 
     @property
     def is_rootable(self):
-        """If the build type is 'user', the device is not rootable.
-
-        Other possible build types are 'userdebug' and 'eng', both are rootable.
-        We are checking the last four chars of the clean stdout because the
-        stdout of the adb command could be polluted with other info like adb
-        server startup message.
-        """
-        build_type_output = self.adb.getprop('ro.build.type').lower()
-        return build_type_output[-4:] != 'user'
+        """Only debuggable builds are rootable."""
+        return self.adb.getprop('ro.debuggable') == '1'
 
     @property
     def model(self):

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -706,7 +706,8 @@ class AndroidDeviceTest(unittest.TestCase):
             self, MockFastboot, MockAdbProxy):
         mock_serial = '1'
         mock_adb_proxy = MockAdbProxy.return_value
-        mock_adb_proxy.getprop.return_value = 'userdebug'
+        # Set getprop to return '1' to indicate the device is rootable.
+        mock_adb_proxy.getprop.return_value = '1'
         mock_adb_proxy.has_shell_command.side_effect = lambda command: {
             'logpersist.start': True,
             'logpersist.stop': True, }[command]


### PR DESCRIPTION
Replace string check with more reliable ro prop.
Fixes #404

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/471)
<!-- Reviewable:end -->
