### PR TITLE
normalize serial name when creating log file

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -432,7 +432,6 @@ class AndroidDevice(object):
     def normalized_serial(self):
         if self._serial is None:
             return None
-        
         n = self._serial.replace(' ', '_')
         n = n.replace(':', '-')
         return n

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -429,12 +429,20 @@ class AndroidDevice(object):
             via fastboot.
     """
 
+    def normalized_serial(self):
+        if self._serial is None:
+            return None
+        
+        n = self._serial.replace(' ', '_')
+        n = n.replace(':', '-')
+        return n
+
     def __init__(self, serial=''):
         self._serial = str(serial)
         # logging.log_path only exists when this is used in an Mobly test run.
         self._log_path_base = getattr(logging, 'log_path', '/tmp/logs')
         self._log_path = os.path.join(self._log_path_base,
-                                      'AndroidDevice%s' % self._serial)
+                                      'AndroidDevice%s' % self.normalized_serial())
         self._debug_tag = self._serial
         self.log = AndroidDeviceLoggerAdapter(logging.getLogger(), {
             'tag': self.debug_tag


### PR DESCRIPTION
Some android emulators use ip:port as serial name,  

```
E:\ > adb devices
List of devices attached
127.0.0.1:21503 device
127.0.0.1:21513 device
127.0.0.1:21523 device
127.0.0.1:21543 device
127.0.0.1:21553 device
127.0.0.1:21583 device
127.0.0.1:21603 device
127.0.0.1:21613 device
127.0.0.1:21623 device
```

this causes log file not  created on windows such as this log file:

`E:\\tmp\\logs\\mobly\\TestControllerBed\\07-20-2018_15-57-26-037\\AndroidDevice127.0.0.1:21503`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/474)
<!-- Reviewable:end -->
