### PR TITLE
Normalize serial for log name

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -446,8 +446,9 @@ class AndroidDevice(object):
         self._serial = str(serial)
         # logging.log_path only exists when this is used in an Mobly test run.
         self._log_path_base = getattr(logging, 'log_path', '/tmp/logs')
-        self._log_path = os.path.join(self._log_path_base,
-                                      'AndroidDevice%s' % self._normalized_serial)
+        self._log_path = os.path.join(
+            self._log_path_base,
+            'AndroidDevice%s' % self._normalized_serial)
         self._debug_tag = self._serial
         self.log = AndroidDeviceLoggerAdapter(logging.getLogger(), {
             'tag': self.debug_tag

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -433,8 +433,8 @@ class AndroidDevice(object):
     def _normalized_serial(self):
         """Normalized serial name for usage in log filename.
 
-        Some Android emulators use ip:port as their serial names, while on Windows `:` is not
-        valid in filename, it should be sanitized first.
+        Some Android emulators use ip:port as their serial names, while on 
+        Windows `:` is not valid in filename, it should be sanitized first.
         """
         if self._serial is None:
             return None

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -432,7 +432,7 @@ class AndroidDevice(object):
     def _normalized_serial(self):
         """Sanitized serial name for usage in log filename.
 
-        Android emulators use ip:port as their serial names, while on Windows `:` is not
+        Some Android emulators use ip:port as their serial names, while on Windows `:` is not
         valid in filename, it should be sanitized first.
         """
         if self._serial is None:

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -429,7 +429,12 @@ class AndroidDevice(object):
             via fastboot.
     """
 
-    def normalized_serial(self):
+    def _normalized_serial(self):
+        """Sanitized serial name for usage in log filename.
+
+        Android emulators use ip:port as their serial names, while on Windows `:` is not
+        valid in filename, it should be sanitized first.
+        """
         if self._serial is None:
             return None
         n = self._serial.replace(' ', '_')
@@ -441,7 +446,7 @@ class AndroidDevice(object):
         # logging.log_path only exists when this is used in an Mobly test run.
         self._log_path_base = getattr(logging, 'log_path', '/tmp/logs')
         self._log_path = os.path.join(self._log_path_base,
-                                      'AndroidDevice%s' % self.normalized_serial())
+                                      'AndroidDevice%s' % self._normalized_serial())
         self._debug_tag = self._serial
         self.log = AndroidDeviceLoggerAdapter(logging.getLogger(), {
             'tag': self.debug_tag
@@ -1032,7 +1037,7 @@ class AndroidDevice(object):
 
         self._enable_logpersist()
 
-        f_name = 'adblog,%s,%s.txt' % (self.model, self.serial)
+        f_name = 'adblog,%s,%s.txt' % (self.model, self._normalized_serial())
         utils.create_dir(self.log_path)
         logcat_file_path = os.path.join(self.log_path, f_name)
         try:
@@ -1087,7 +1092,7 @@ class AndroidDevice(object):
         else:
             br_path = os.path.join(self.log_path, 'BugReports')
         utils.create_dir(br_path)
-        base_name = ',%s,%s.txt' % (begin_time, self.serial)
+        base_name = ',%s,%s.txt' % (begin_time, self._normalized_serial())
         if new_br:
             base_name = base_name.replace('.txt', '.zip')
         test_name_len = utils.MAX_FILENAME_LEN - len(base_name)

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -429,7 +429,8 @@ class AndroidDevice(object):
             via fastboot.
     """
 
-    def _normalized_serial(self):
+    @property
+    def normalized_serial(self):
         """Sanitized serial name for usage in log filename.
 
         Some Android emulators use ip:port as their serial names, while on Windows `:` is not
@@ -437,16 +438,16 @@ class AndroidDevice(object):
         """
         if self._serial is None:
             return None
-        n = self._serial.replace(' ', '_')
-        n = n.replace(':', '-')
-        return n
+        normalized_serial = self._serial.replace(' ', '_')
+        normalized_serial = normalized_serial.replace(':', '-')
+        return normalized_serial
 
     def __init__(self, serial=''):
         self._serial = str(serial)
         # logging.log_path only exists when this is used in an Mobly test run.
         self._log_path_base = getattr(logging, 'log_path', '/tmp/logs')
         self._log_path = os.path.join(self._log_path_base,
-                                      'AndroidDevice%s' % self._normalized_serial())
+                                      'AndroidDevice%s' % self.normalized_serial)
         self._debug_tag = self._serial
         self.log = AndroidDeviceLoggerAdapter(logging.getLogger(), {
             'tag': self.debug_tag
@@ -1037,7 +1038,7 @@ class AndroidDevice(object):
 
         self._enable_logpersist()
 
-        f_name = 'adblog,%s,%s.txt' % (self.model, self._normalized_serial())
+        f_name = 'adblog,%s,%s.txt' % (self.model, self.normalized_serial)
         utils.create_dir(self.log_path)
         logcat_file_path = os.path.join(self.log_path, f_name)
         try:
@@ -1092,7 +1093,7 @@ class AndroidDevice(object):
         else:
             br_path = os.path.join(self.log_path, 'BugReports')
         utils.create_dir(br_path)
-        base_name = ',%s,%s.txt' % (begin_time, self._normalized_serial())
+        base_name = ',%s,%s.txt' % (begin_time, self.normalized_serial)
         if new_br:
             base_name = base_name.replace('.txt', '.zip')
         test_name_len = utils.MAX_FILENAME_LEN - len(base_name)

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -432,7 +432,6 @@ class AndroidDevice(object):
     def normalized_serial(self):
         if self._serial is None:
             return None
-        
         n = self._serial.replace(' ', '_')
         n = n.replace(':', '-')
         return n

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -430,8 +430,8 @@ class AndroidDevice(object):
     """
 
     @property
-    def normalized_serial(self):
-        """Sanitized serial name for usage in log filename.
+    def _normalized_serial(self):
+        """Normalized serial name for usage in log filename.
 
         Some Android emulators use ip:port as their serial names, while on Windows `:` is not
         valid in filename, it should be sanitized first.
@@ -447,7 +447,7 @@ class AndroidDevice(object):
         # logging.log_path only exists when this is used in an Mobly test run.
         self._log_path_base = getattr(logging, 'log_path', '/tmp/logs')
         self._log_path = os.path.join(self._log_path_base,
-                                      'AndroidDevice%s' % self.normalized_serial)
+                                      'AndroidDevice%s' % self._normalized_serial)
         self._debug_tag = self._serial
         self.log = AndroidDeviceLoggerAdapter(logging.getLogger(), {
             'tag': self.debug_tag
@@ -1038,7 +1038,7 @@ class AndroidDevice(object):
 
         self._enable_logpersist()
 
-        f_name = 'adblog,%s,%s.txt' % (self.model, self.normalized_serial)
+        f_name = 'adblog,%s,%s.txt' % (self.model, self._normalized_serial)
         utils.create_dir(self.log_path)
         logcat_file_path = os.path.join(self.log_path, f_name)
         try:
@@ -1093,7 +1093,7 @@ class AndroidDevice(object):
         else:
             br_path = os.path.join(self.log_path, 'BugReports')
         utils.create_dir(br_path)
-        base_name = ',%s,%s.txt' % (begin_time, self.normalized_serial)
+        base_name = ',%s,%s.txt' % (begin_time, self._normalized_serial)
         if new_br:
             base_name = base_name.replace('.txt', '.zip')
         test_name_len = utils.MAX_FILENAME_LEN - len(base_name)

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -429,12 +429,20 @@ class AndroidDevice(object):
             via fastboot.
     """
 
+    def normalized_serial(self):
+        if self._serial is None:
+            return None
+        
+        n = self._serial.replace(' ', '_')
+        n = n.replace(':', '-')
+        return n
+
     def __init__(self, serial=''):
         self._serial = str(serial)
         # logging.log_path only exists when this is used in an Mobly test run.
         self._log_path_base = getattr(logging, 'log_path', '/tmp/logs')
         self._log_path = os.path.join(self._log_path_base,
-                                      'AndroidDevice%s' % self._serial)
+                                      'AndroidDevice%s' % self.normalized_serial())
         self._debug_tag = self._serial
         self.log = AndroidDeviceLoggerAdapter(logging.getLogger(), {
             'tag': self.debug_tag

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -528,18 +528,19 @@ class AndroidDeviceTest(unittest.TestCase):
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.AdbProxy',
-        return_value=mock_android_device.MockAdbProxy('1'))
+        return_value=mock_android_device.MockAdbProxy('127.0.0.1:5557'))
     @mock.patch(
         'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
-        return_value=mock_android_device.MockFastbootProxy('1'))
+        return_value=mock_android_device.MockFastbootProxy('127.0.0.1:5557'))
     @mock.patch(
         'mobly.utils.start_standing_subprocess', return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
-    def test_AndroidDevice_with_reserved_character_log_path(
+    def test_AndroidDevice_with_reserved_character_in_serial_log_path(
             self, stop_proc_mock, start_proc_mock, FastbootProxy,
             MockAdbProxy):
         ad = android_device.AndroidDevice(serial='127.0.0.1:5557')
-        self.assertFalse(':' in ad.log_path)
+        base_log_path = os.path.basename(ad.log_path)
+        self.assertEqual(base_log_path, 'AndroidDevice127.0.0.1-5557')
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.AdbProxy',

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -532,6 +532,21 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch(
         'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
         return_value=mock_android_device.MockFastbootProxy('1'))
+    @mock.patch(
+        'mobly.utils.start_standing_subprocess', return_value='process')
+    @mock.patch('mobly.utils.stop_standing_subprocess')
+    def test_AndroidDevice_with_reserved_character_log_path(
+            self, stop_proc_mock, start_proc_mock, FastbootProxy,
+            MockAdbProxy):
+        ad = android_device.AndroidDevice(serial='127.0.0.1:5557')
+        self.assertFalse(':' in ad.log_path)
+
+    @mock.patch(
+        'mobly.controllers.android_device_lib.adb.AdbProxy',
+        return_value=mock_android_device.MockAdbProxy('1'))
+    @mock.patch(
+        'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+        return_value=mock_android_device.MockFastbootProxy('1'))
     @mock.patch('mobly.utils.create_dir')
     @mock.patch(
         'mobly.utils.start_standing_subprocess', return_value='process')


### PR DESCRIPTION
Some android emulators use ip:port as serial name,

```
E:\ > adb devices
List of devices attached
127.0.0.1:21503 device
127.0.0.1:21513 device
127.0.0.1:21523 device
127.0.0.1:21543 device
127.0.0.1:21553 device
127.0.0.1:21583 device
127.0.0.1:21603 device
127.0.0.1:21613 device
127.0.0.1:21623 device
```

this causes log file not created on windows such as this log file:

```
E:\\tmp\\logs\\mobly\\TestControllerBed\\07-20-2018_15-57-26-037\\AndroidDevice127.0.0.1:21503
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/475)
<!-- Reviewable:end -->
