### PR TITLE
List adb forwards by devices

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -86,14 +86,25 @@ def list_occupied_adb_ports():
     Returns:
         A list of integers representing occupied host ports.
     """
-    out = AdbProxy().forward('--list')
-    clean_lines = str(out, 'utf-8').strip().split('\n')
+    serials = []
+    dout = AdbProxy().devices()
+    devices_lines = str(dout, 'utf-8').strip().split('\n')
+    for ds in devices_lines[1:]:
+        d = ds.split('\t')[0].strip()
+        serials.append(d)
+
     used_ports = []
-    for line in clean_lines:
-        tokens = line.split(' tcp:')
-        if len(tokens) != 3:
-            continue
-        used_ports.append(int(tokens[1]))
+
+    for serial in serials:
+        out = AdbProxy(serial).forward('--list')
+        clean_lines = str(out, 'utf-8').strip().split('\n')
+
+        for line in clean_lines:
+            tokens = line.split(' tcp:')
+            if len(tokens) != 3:
+                continue
+            used_ports.append(int(tokens[1]))
+
     return used_ports
 
 

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -90,8 +90,12 @@ def list_occupied_adb_ports():
     dout = AdbProxy().devices()
     devices_lines = str(dout, 'utf-8').strip().split('\n')
     for ds in devices_lines[1:]:
-        d = ds.split('\t')[0].strip()
-        serials.append(d)
+        toks = ds.split('\t')
+        if len(toks) != 2:
+            continue
+        d = toks[0].strip()
+        if d != '':
+            serials.append(d)
 
     used_ports = []
 


### PR DESCRIPTION
if multiple android devices are connected, adb forward --list will fail. 
serial name should be specified when exec adb forward --list:

```
adb -s SERIAL_NAME forward --list
```

fixes #477

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/476)
<!-- Reviewable:end -->
