### PR TITLE
Improve boundary clarity of execution stages in logs

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -181,7 +181,7 @@ class BaseTestClass(object):
         self.current_test_info = runtime_test_info.RuntimeTestInfo(
             stage_name, self.log_path, record)
         try:
-            with self.log_test_stage(stage_name):
+            with self._log_test_stage(stage_name):
                 self.setup_generated_tests()
         except Exception as e:
             logging.exception('%s failed for %s.', stage_name, self.TAG)
@@ -206,7 +206,7 @@ class BaseTestClass(object):
         """Proxy function to guarantee the base implementation of setup_class
         is called.
         """
-        with self.log_test_stage(STAGE_NAME_SETUP_CLASS):
+        with self._log_test_stage(STAGE_NAME_SETUP_CLASS):
             self.setup_class()
 
     def setup_class(self):
@@ -228,7 +228,7 @@ class BaseTestClass(object):
         self.current_test_info = runtime_test_info.RuntimeTestInfo(
             stage_name, self.log_path, record)
         try:
-            with self.log_test_stage(stage_name):
+            with self._log_test_stage(stage_name):
                 self.teardown_class()
         except signals.TestAbortAll as e:
             setattr(e, 'results', self.results)
@@ -249,7 +249,7 @@ class BaseTestClass(object):
         """
 
     @contextlib.contextmanager
-    def log_test_stage(self, stage_name):
+    def _log_test_stage(self, stage_name):
         """Logs the begin and end of a test stage.
 
         This context adds two log lines meant for clarifying the boundary of
@@ -277,7 +277,7 @@ class BaseTestClass(object):
         called.
         """
         self.current_test_name = test_name
-        with self.log_test_stage(STAGE_NAME_SETUP_TEST):
+        with self._log_test_stage(STAGE_NAME_SETUP_TEST):
             self.setup_test()
 
     def setup_test(self):
@@ -293,7 +293,7 @@ class BaseTestClass(object):
         """Proxy function to guarantee the base implementation of teardown_test
         is called.
         """
-        with self.log_test_stage(STAGE_NAME_TEARDOWN_TEST):
+        with self._log_test_stage(STAGE_NAME_TEARDOWN_TEST):
             self.teardown_test()
 
     def teardown_test(self):
@@ -392,7 +392,7 @@ class BaseTestClass(object):
         """
         func_name = func.__name__
         procedure_name = func_name[1:] if func_name[0] == '_' else func_name
-        with self.log_test_stage(procedure_name):
+        with self._log_test_stage(procedure_name):
             try:
                 # Pass a copy of the record instead of the actual object so that it
                 # will not be modified.

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -34,9 +34,12 @@ RESULT_LINE_TEMPLATE = TEST_CASE_TOKEN + ' %s %s'
 TEST_STAGE_BEGIN_LOG_TEMPLATE = '[{parent_token}]#{child_token} >>> BEGIN >>>'
 TEST_STAGE_END_LOG_TEMPLATE = '[{parent_token}]#{child_token} <<< END <<<'
 
+# Names of execution stages.
 STAGE_NAME_SETUP_GENERATED_TESTS = 'setup_generated_tests'
 STAGE_NAME_SETUP_CLASS = 'setup_class'
 STAGE_NAME_TEARDOWN_CLASS = 'teardown_class'
+STAGE_NAME_SETUP_TEST = 'setup_test'
+STAGE_NAME_TEARDOWN_TEST = 'teardown_test'
 
 
 class Error(Exception):
@@ -274,7 +277,7 @@ class BaseTestClass(object):
         called.
         """
         self.current_test_name = test_name
-        with self.log_test_stage('setup_test'):
+        with self.log_test_stage(STAGE_NAME_SETUP_TEST):
             self.setup_test()
 
     def setup_test(self):
@@ -290,7 +293,7 @@ class BaseTestClass(object):
         """Proxy function to guarantee the base implementation of teardown_test
         is called.
         """
-        with self.log_test_stage('teardown_test'):
+        with self.log_test_stage(STAGE_NAME_TEARDOWN_TEST):
             self.teardown_test()
 
     def teardown_test(self):
@@ -469,7 +472,7 @@ class BaseTestClass(object):
                 except Exception as e:
                     logging.exception(e)
                     tr_record.test_error()
-                    tr_record.add_error('teardown_test', e)
+                    tr_record.add_error(STAGE_NAME_TEARDOWN_TEST, e)
                     teardown_test_failed = True
                 else:
                     # Check if anything failed by `expects`.

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -31,8 +31,8 @@ from mobly import utils
 TEST_CASE_TOKEN = '[Test]'
 RESULT_LINE_TEMPLATE = TEST_CASE_TOKEN + ' %s %s'
 
-TEST_STAGE_BEGIN_LOG_TEMPLATE = '[{test_name}]#{stage_name} BEGIN >>>'
-TEST_STAGE_END_LOG_TEMPLATE = '[{test_name}]#{stage_name} END   <<<'
+TEST_STAGE_BEGIN_LOG_TEMPLATE = '[{test_name}]#{stage_name} >>> BEGIN >>>'
+TEST_STAGE_END_LOG_TEMPLATE = '[{test_name}]#{stage_name} <<< END <<<'
 
 
 class Error(Exception):

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import collections
+import contextlib
 import copy
 import functools
 import inspect
@@ -29,6 +30,9 @@ from mobly import utils
 # Macro strings for test result reporting
 TEST_CASE_TOKEN = '[Test]'
 RESULT_LINE_TEMPLATE = TEST_CASE_TOKEN + ' %s %s'
+
+TEST_STAGE_BEGIN_LOG_TEMPLATE = '[{test_name}]#{stage_name} BEGIN >>>'
+TEST_STAGE_END_LOG_TEMPLATE = '[{test_name}]#{stage_name} END   <<<'
 
 
 class Error(Exception):
@@ -160,6 +164,26 @@ class BaseTestClass(object):
                 logging.warning('Missing optional user param "%s" in '
                                 'configuration, continue.', name)
 
+    def _setup_generated_tests(self):
+        """Proxy function to guarantee the base implementation of
+        setup_generated_tests is called.
+        """
+        stage_name = 'setup_generated_tests'
+        record = records.TestResultRecord(stage_name, self.TAG)
+        record.test_begin()
+        self.current_test_info = runtime_test_info.RuntimeTestInfo(
+            stage_name, self.log_path, record)
+        try:
+            with self.log_test_stage(stage_name):
+                self.setup_generated_tests()
+        except Exception as e:
+            logging.exception('%s failed for %s.', stage_name, self.TAG)
+            record.test_error(e)
+            self.results.add_class_error(record)
+            self.summary_writer.dump(record.to_dict(),
+                                     records.TestSummaryEntryType.RECORD)
+            return self.results
+
     def setup_generated_tests(self):
         """Preprocesses that need to be done before setup_class.
 
@@ -175,7 +199,8 @@ class BaseTestClass(object):
         """Proxy function to guarantee the base implementation of setup_class
         is called.
         """
-        self.setup_class()
+        with self.log_test_stage('setup_class'):
+            self.setup_class()
 
     def setup_class(self):
         """Setup function that will be called before executing any test in the
@@ -190,15 +215,19 @@ class BaseTestClass(object):
         """Proxy function to guarantee the base implementation of
         teardown_class is called.
         """
-        record = records.TestResultRecord('teardown_class', self.TAG)
+        stage_name = 'teardown_class'
+        record = records.TestResultRecord(stage_name, self.TAG)
         record.test_begin()
+        self.current_test_info = runtime_test_info.RuntimeTestInfo(
+            stage_name, self.log_path, record)
         try:
-            self.teardown_class()
+            with self.log_test_stage(stage_name):
+                self.teardown_class()
         except signals.TestAbortAll as e:
             setattr(e, 'results', self.results)
             raise
         except Exception as e:
-            logging.exception('Error encountered in teardown_class.')
+            logging.exception('Error encountered in %s.', stage_name)
             record.test_error(e)
             record.update_record()
             self.results.add_class_error(record)
@@ -212,12 +241,26 @@ class BaseTestClass(object):
         Implementation is optional.
         """
 
+    @contextlib.contextmanager
+    def log_test_stage(self, stage_name):
+        test_name = self.current_test_info.name
+        if test_name == stage_name:
+            test_name = self.TAG
+        logging.debug(
+            TEST_STAGE_BEGIN_LOG_TEMPLATE.format(
+                test_name=test_name, stage_name=stage_name))
+        yield
+        logging.debug(
+            TEST_STAGE_END_LOG_TEMPLATE.format(
+                test_name=test_name, stage_name=stage_name))
+
     def _setup_test(self, test_name):
         """Proxy function to guarantee the base implementation of setup_test is
         called.
         """
         self.current_test_name = test_name
-        self.setup_test()
+        with self.log_test_stage('setup_test'):
+            self.setup_test()
 
     def setup_test(self):
         """Setup function that will be called every time before executing each
@@ -232,7 +275,8 @@ class BaseTestClass(object):
         """Proxy function to guarantee the base implementation of teardown_test
         is called.
         """
-        self.teardown_test()
+        with self.log_test_stage('teardown_test'):
+            self.teardown_test()
 
     def teardown_test(self):
         """Teardown function that will be called every time a test method has
@@ -250,7 +294,6 @@ class BaseTestClass(object):
                     this test, containing all information of the test execution
                     including exception objects.
         """
-        logging.info(RESULT_LINE_TEMPLATE, record.test_name, record.result)
         self.on_fail(record)
 
     def on_fail(self, record):
@@ -276,7 +319,6 @@ class BaseTestClass(object):
         msg = record.details
         if msg:
             logging.info(msg)
-        logging.info(RESULT_LINE_TEMPLATE, record.test_name, record.result)
         self.on_pass(record)
 
     def on_pass(self, record):
@@ -330,19 +372,20 @@ class BaseTestClass(object):
             tr_record: The TestResultRecord object associated with the test
                 executed.
         """
-        try:
-            # Pass a copy of the record instead of the actual object so that it
-            # will not be modified.
-            func(copy.deepcopy(tr_record))
-        except signals.TestAbortSignal:
-            raise
-        except Exception as e:
-            func_name = func.__name__
-            if func_name.startswith('_'):
-                func_name = func_name[1:]
-            logging.exception('Exception happened when executing %s for %s.',
-                              func_name, self.current_test_name)
-            tr_record.add_error(func_name, e)
+        func_name = func.__name__
+        procedure_name = func_name[1:] if func_name[0] == '_' else func_name
+        with self.log_test_stage(procedure_name):
+            try:
+                # Pass a copy of the record instead of the actual object so that it
+                # will not be modified.
+                func(copy.deepcopy(tr_record))
+            except signals.TestAbortSignal:
+                raise
+            except Exception as e:
+                logging.exception(
+                    'Exception happened when executing %s for %s.',
+                    procedure_name, self.current_test_name)
+                tr_record.add_error(procedure_name, e)
 
     def record_data(self, content):
         """Record an entry in test summary file.
@@ -452,6 +495,8 @@ class BaseTestClass(object):
                 elif tr_record.result == records.TestResultEnums.TEST_RESULT_SKIP:
                     self._exec_procedure_func(self._on_skip, tr_record)
             finally:
+                logging.info(RESULT_LINE_TEMPLATE, tr_record.test_name,
+                             tr_record.result)
                 self.results.add_record(tr_record)
                 self.summary_writer.dump(tr_record.to_dict(),
                                          records.TestSummaryEntryType.RECORD)
@@ -605,18 +650,9 @@ class BaseTestClass(object):
             The test results object of this class.
         """
         # Executes pre-setup procedures, like generating test methods.
-        try:
-            self.setup_generated_tests()
-        except Exception as e:
-            logging.exception('Pre-setup processes failed for %s.', self.TAG)
-            class_record = records.TestResultRecord('setup_generated_tests',
-                                                    self.TAG)
-            class_record.test_begin()
-            class_record.test_error(e)
-            self.results.add_class_error(class_record)
-            self.summary_writer.dump(class_record.to_dict(),
-                                     records.TestSummaryEntryType.RECORD)
-            return self.results
+        generated_test_ret = self._setup_generated_tests()
+        if generated_test_ret is not None:
+            return generated_test_ret
         logging.info('==========> %s <==========', self.TAG)
         # Devise the actual test methods to run in the test class.
         if not test_names:
@@ -644,7 +680,7 @@ class BaseTestClass(object):
             except Exception as e:
                 # Setup class failed for unknown reasons.
                 # Fail the class and skip all tests.
-                logging.exception('Error in setup_class %s.', self.TAG)
+                logging.exception('Error in setup_class of %s.', self.TAG)
                 class_record.test_error(e)
                 self.results.add_class_error(class_record)
                 self.summary_writer.dump(class_record.to_dict(),

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -27,19 +27,19 @@ from mobly import runtime_test_info
 from mobly import signals
 from mobly import utils
 
-# Macro strings for test result reporting
+# Macro strings for test result reporting.
 TEST_CASE_TOKEN = '[Test]'
 RESULT_LINE_TEMPLATE = TEST_CASE_TOKEN + ' %s %s'
 
 TEST_STAGE_BEGIN_LOG_TEMPLATE = '[{parent_token}]#{child_token} >>> BEGIN >>>'
 TEST_STAGE_END_LOG_TEMPLATE = '[{parent_token}]#{child_token} <<< END <<<'
 
-# Names of execution stages.
+# Names of execution stages, in the order they happen during test runs.
 STAGE_NAME_SETUP_GENERATED_TESTS = 'setup_generated_tests'
 STAGE_NAME_SETUP_CLASS = 'setup_class'
-STAGE_NAME_TEARDOWN_CLASS = 'teardown_class'
 STAGE_NAME_SETUP_TEST = 'setup_test'
 STAGE_NAME_TEARDOWN_TEST = 'teardown_test'
+STAGE_NAME_TEARDOWN_CLASS = 'teardown_class'
 
 
 class Error(Exception):

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -1630,6 +1630,35 @@ class BaseTestTest(unittest.TestCase):
         bc.unpack_userparams(arg1="haha")
         self.assertEqual(bc.arg1, "haha")
 
+    def test_setup_generated_tests_failure(self):
+        """Test code path for setup_generated_tests failure.
+
+        When setup_generated_tests fails, pre-execution calculation is
+        incomplete and the number of tests requested is unknown. This is a
+        fatal issue that blocks any test execution in a class.
+
+        A class level error record is generated.
+        Unlike `setup_class` failure, no test is considered "skipped" in this
+        case as execution stage never started.
+        """
+
+        class MockBaseTest(base_test.BaseTestClass):
+            def setup_generated_tests(self):
+                raise Exception(MSG_EXPECTED_EXCEPTION)
+
+            def logic(self, a, b):
+                pass
+
+            def test_foo(self):
+                pass
+
+        bt_cls = MockBaseTest(self.mock_test_cls_configs)
+        bt_cls.run()
+        self.assertEqual(len(bt_cls.results.requested), 0)
+        class_record = bt_cls.results.error[0]
+        self.assertEqual(class_record.test_name, 'setup_generated_tests')
+        self.assertEqual(bt_cls.results.skipped, [])
+
     def test_generate_tests_run(self):
         class MockBaseTest(base_test.BaseTestClass):
             def setup_generated_tests(self):


### PR DESCRIPTION
* Log the begin and end of each execution stage.
* Fix the behavior for when `setup_generated_test` throws.
* Fix an error in test status reported by log lines.

Fixes #420

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/478)
<!-- Reviewable:end -->
