### PR TITLE
Fix max timeout for `CallbackHandler.waitForEvent`.

### DIFF
--- a/mobly/controllers/android_device_lib/callback_handler.py
+++ b/mobly/controllers/android_device_lib/callback_handler.py
@@ -1,11 +1,11 @@
 # Copyright 2017 Google Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -84,7 +84,8 @@ class CallbackHandler(object):
         """
         if timeout:
             if timeout > MAX_TIMEOUT:
-                raise Error(self._ad,
+                raise Error(
+                    self._ad,
                     'Specified timeout %s is longer than max timeout %s.' %
                     (timeout, MAX_TIMEOUT))
         # Convert to milliseconds for java side.
@@ -94,7 +95,8 @@ class CallbackHandler(object):
                 self._id, event_name, timeout_ms)
         except Exception as e:
             if 'EventSnippetException: timeout.' in str(e):
-                raise TimeoutError(self._ad,
+                raise TimeoutError(
+                    self._ad,
                     'Timed out after waiting %ss for event "%s" triggered by'
                     ' %s (%s).' % (timeout, event_name, self._method_name,
                                    self._id))
@@ -134,6 +136,8 @@ class CallbackHandler(object):
             rpc_timeout = deadline - time.time()
             if rpc_timeout < 0:
                 break
+            # A single RPC call cannot exceed MAX_TIMEOUT.
+            rpc_timeout = min(rpc_timeout, MAX_TIMEOUT)
             try:
                 event = self.waitAndGet(event_name, rpc_timeout)
             except TimeoutError:
@@ -142,7 +146,8 @@ class CallbackHandler(object):
                 break
             if predicate(event):
                 return event
-        raise TimeoutError(self._ad,
+        raise TimeoutError(
+            self._ad,
             'Timed out after %ss waiting for an "%s" event that satisfies the '
             'predicate "%s".' % (timeout, event_name, predicate.__name__))
 

--- a/tests/mobly/controllers/android_device_lib/callback_handler_test.py
+++ b/tests/mobly/controllers/android_device_lib/callback_handler_test.py
@@ -73,7 +73,7 @@ class CallbackHandlerTest(unittest.TestCase):
                             'EventSnippet$EventSnippetException: timeout.')
         mock_event_client.eventWaitAndGet = mock.Mock(
             side_effect=jsonrpc_client_base.ApiError(mock.Mock(),
-                java_timeout_msg))
+                                                     java_timeout_msg))
         handler = callback_handler.CallbackHandler(
             callback_id=MOCK_CALLBACK_ID,
             event_client=mock_event_client,
@@ -121,6 +121,27 @@ class CallbackHandlerTest(unittest.TestCase):
         with self.assertRaisesRegex(callback_handler.TimeoutError,
                                     expected_msg):
             handler.waitForEvent('AsyncTaskResult', some_condition, 0.01)
+
+    def test_wait_for_event_max_timeout(self):
+        """waitForEvent should not raise the timeout exceed threshold error.
+        """
+        mock_event_client = mock.Mock()
+        mock_event_client.eventWaitAndGet = mock.Mock(
+            return_value=MOCK_RAW_EVENT)
+        handler = callback_handler.CallbackHandler(
+            callback_id=MOCK_CALLBACK_ID,
+            event_client=mock_event_client,
+            ret_value=None,
+            method_name=None,
+            ad=mock.Mock())
+
+        def some_condition(event):
+            return event.data['successful']
+
+        big_timeout = callback_handler.MAX_TIMEOUT * 2
+        # This line should not raise.
+        event = handler.waitForEvent(
+            'AsyncTaskResult', some_condition, timeout=big_timeout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This method should not be bound by the max timeout of a single Rpc call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/487)
<!-- Reviewable:end -->
