### PR TITLE
Clean up dep requirements in `setup.py`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,8 @@ def main():
         include_package_data=False,
         scripts=['tools/sl4a_shell.py', 'tools/snippet_shell.py'],
         tests_require=[
-            'pytest',
             'mock',
+            'pytest',
             'pytz',
         ],
         install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ from setuptools.command import test
 import sys
 
 install_requires = [
-    'future', 'portpicker', 'psutil>=5.4.4', 'pyyaml', 'pyserial'
+    'future', 'portpicker', 'psutil>=5.4.4', 'pyserial', 'pyyaml',
+    'timeout_decorator'
 ]
 
 if sys.version_info < (3, ):

--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,7 @@ from setuptools.command import test
 import sys
 
 install_requires = [
-    'future',
-    # mock-1.0.1 is the last version compatible with setuptools <17.1,
-    # which is what comes with Ubuntu 14.04 LTS.
-    'mock<=1.0.1',
-    'portpicker',
-    'psutil>=5.4.4',
-    'pytz',
-    'pyyaml',
-    'timeout_decorator',
-    'pyserial'
+    'future', 'portpicker', 'psutil>=5.4.4', 'pyyaml', 'pyserial'
 ]
 
 if sys.version_info < (3, ):
@@ -70,7 +61,11 @@ def main():
         packages=setuptools.find_packages(),
         include_package_data=False,
         scripts=['tools/sl4a_shell.py', 'tools/snippet_shell.py'],
-        tests_require=['pytest'],
+        tests_require=[
+            'pytest',
+            'mock',
+            'pytz',
+        ],
         install_requires=install_requires,
         cmdclass={'test': PyTest},
     )

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -230,7 +230,7 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
         cmd_setsid = '%s am instrument -w -e action start %s/%s' % (
             snippet_client._SETSID_COMMAND, MOCK_PACKAGE_NAME,
             snippet_client._INSTRUMENTATION_RUNNER_PACKAGE)
-        mock_do_start_app.assert_has_calls(mock.call(cmd_setsid))
+        mock_do_start_app.assert_has_calls([mock.call(cmd_setsid)])
 
         # Test 'setsid' does not exist, but 'nohup' exsits
         client = self._make_client()


### PR DESCRIPTION
* Move test-only deps out of package dep list.
* Remove unnecessary deps.

`setuptools` version in ubuntu dist is no longer a concern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/489)
<!-- Reviewable:end -->
