### PR TITLE
Properly record controller info.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -331,7 +331,7 @@ class BaseTestClass(object):
                 module.destroy(self._controller_registry[name])
             except:
                 logging.exception('Exception occurred destroying %s.', name)
-        self._controller_registry = OrderedDict()
+        self._controller_registry = collections.OrderedDict()
         self._controller_modules = {}
 
     def _record_controller_info(self):

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -134,7 +134,8 @@ class BaseTestClass(object):
         self.current_test_name = None
         self._generated_test_table = collections.OrderedDict()
         # Controller object management.
-        self._controller_registry = {}  # controller_name: objects
+        self._controller_registry = collections.OrderedDict(
+        )  # controller_name: objects
         self._controller_modules = {}  # controller_name: module
 
     def __enter__(self):
@@ -330,7 +331,7 @@ class BaseTestClass(object):
                 module.destroy(self._controller_registry[name])
             except:
                 logging.exception('Exception occurred destroying %s.', name)
-        self._controller_registry = {}
+        self._controller_registry = OrderedDict()
         self._controller_modules = {}
 
     def _record_controller_info(self):

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -346,7 +346,9 @@ class BaseTestClass(object):
                                 module_ref_name)
                 continue
             self.results.add_controller_info(
-                self.TAG, module.MOBLY_CONTROLLER_CONFIG_NAME, controller_info)
+                controller_name=module.MOBLY_CONTROLLER_CONFIG_NAME,
+                controller_info=controller_info,
+                test_class=self.TAG)
 
     def _setup_generated_tests(self):
         """Proxy function to guarantee the base implementation of

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -539,15 +539,17 @@ class TestResult(object):
         else:
             self.error.append(record)
 
-    def add_controller_info(self, test_class, controller_name,
-                            controller_info):
+    def add_controller_info(self, controller_name, controller_info,
+                            test_class):
         """Adds controller info to results.
 
+        This can be called multiple times for each
+
         Args:
-            test_class: string, a tag for identifying a class. This should be
-                the test class's own `TAG` attribute.
             controller_name: string, name of the controller.
             controller_info: yaml serializable info about the controller.
+            test_class: string, a tag for identifying a class. This should be
+                the test class's own `TAG` attribute.
         """
         info = controller_info
         try:

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -351,9 +351,6 @@ class TestRunner(object):
                         'Abort all subsequent test classes. Reason: %s', e)
                     raise
         finally:
-            # Write controller info and summary to summary file.
-            summary_writer.dump(self.results.controller_info,
-                                records.TestSummaryEntryType.CONTROLLER_INFO)
             summary_writer.dump(self.results.summary_dict(),
                                 records.TestSummaryEntryType.SUMMARY)
             # Stop and show summary.

--- a/tests/lib/mock_second_controller.py
+++ b/tests/lib/mock_second_controller.py
@@ -1,0 +1,59 @@
+# Copyright 2016 Google Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a second mock third-party controller module used for testing Mobly's
+# handling of multiple controller modules.
+
+import logging
+
+MOBLY_CONTROLLER_CONFIG_NAME = "AnotherMagicDevice"
+
+
+def create(configs):
+    objs = []
+    for c in configs:
+        if isinstance(c, dict):
+            c.pop("serial")
+        objs.append(AnotherMagicDevice(c))
+    return objs
+
+
+def destroy(objs):
+    print("Destroying other magic")
+
+
+def get_info(objs):
+    infos = []
+    for obj in objs:
+        infos.append(obj.who_am_i())
+    return infos
+
+
+class AnotherMagicDevice(object):
+    """This controller supports adding controller's info during test.
+
+    It is used for testing that this info is correctly recorded by Mobly.
+    """
+    def __init__(self, config):
+        self.magic = config
+
+    def get_magic(self):
+        logging.info("My other magic is %s.", self.magic)
+        return self.magic
+
+    def set_magic(self, extra_magic):
+        self.magic['extra_magic'] = extra_magic
+
+    def who_am_i(self):
+        return {"MyOtherMagic": self.magic}

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -57,6 +57,21 @@ class MockEmptyBaseTest(base_test.BaseTestClass):
         pass
 
 
+class ControllerInfoTest(base_test.BaseTestClass):
+    """Registers two different controller types and modifies controller info at
+    runtime.
+    """
+
+    def setup_class(self):
+        self.register_controller(mock_controller)
+        second_controller = self.register_controller(mock_second_controller)[0]
+        # This should appear in recorded controller info.
+        second_controller.set_magic('haha')
+
+    def test_func(self):
+        pass
+
+
 class BaseTestTest(unittest.TestCase):
     def setUp(self):
         self.tmp_dir = tempfile.mkdtemp()
@@ -1799,18 +1814,6 @@ class BaseTestTest(unittest.TestCase):
         mock_test_config.controller_configs[mock_ctrlr_config_name] = my_config
         mock_test_config.controller_configs[
             mock_ctrlr_2_config_name] = copy.copy(my_config)
-
-        class ControllerInfoTest(base_test.BaseTestClass):
-            def setup_class(self):
-                self.register_controller(mock_controller)
-                second_controller = self.register_controller(
-                    mock_second_controller)[0]
-                # This should appear in recorded controller info.
-                second_controller.set_magic('haha')
-
-            def test_func(self):
-                pass
-
         bt_cls = ControllerInfoTest(mock_test_config)
         bt_cls.run()
         info1 = bt_cls.results.controller_info[0]

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -57,21 +57,6 @@ class MockEmptyBaseTest(base_test.BaseTestClass):
         pass
 
 
-class ControllerInfoTest(base_test.BaseTestClass):
-    """Registers two different controller types and modifies controller info at
-    runtime.
-    """
-
-    def setup_class(self):
-        self.register_controller(mock_controller)
-        second_controller = self.register_controller(mock_second_controller)[0]
-        # This should appear in recorded controller info.
-        second_controller.set_magic('haha')
-
-    def test_func(self):
-        pass
-
-
 class BaseTestTest(unittest.TestCase):
     def setUp(self):
         self.tmp_dir = tempfile.mkdtemp()
@@ -1814,6 +1799,22 @@ class BaseTestTest(unittest.TestCase):
         mock_test_config.controller_configs[mock_ctrlr_config_name] = my_config
         mock_test_config.controller_configs[
             mock_ctrlr_2_config_name] = copy.copy(my_config)
+
+        class ControllerInfoTest(base_test.BaseTestClass):
+            """Registers two different controller types and modifies controller
+            info at runtime.
+            """
+
+            def setup_class(self):
+                self.register_controller(mock_controller)
+                second_controller = self.register_controller(
+                    mock_second_controller)[0]
+                # This should appear in recorded controller info.
+                second_controller.set_magic('haha')
+
+            def test_func(self):
+                pass
+
         bt_cls = ControllerInfoTest(mock_test_config)
         bt_cls.run()
         info1 = bt_cls.results.controller_info[0]

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import io
 import os
 import mock
@@ -30,6 +31,7 @@ from mobly import signals
 
 from tests.lib import utils
 from tests.lib import mock_controller
+from tests.lib import mock_second_controller
 
 MSG_EXPECTED_EXCEPTION = "This is an expected exception."
 MSG_EXPECTED_TEST_FAILURE = "This is an expected test failure."
@@ -1784,6 +1786,52 @@ class BaseTestTest(unittest.TestCase):
                 self.assertIsNotNone(c['timestamp'])
         self.assertTrue(hit)
 
+    def test_record_controller_info(self):
+        """Verifies that controller info is correctly recorded.
+
+        1. Info added in test is recorded.
+        2. Info of multiple controller types are recorded.
+        """
+        mock_test_config = self.mock_test_cls_configs.copy()
+        mock_ctrlr_config_name = mock_controller.MOBLY_CONTROLLER_CONFIG_NAME
+        mock_ctrlr_2_config_name = mock_second_controller.MOBLY_CONTROLLER_CONFIG_NAME
+        my_config = [{'serial': 'xxxx', 'magic': 'Magic'}]
+        mock_test_config.controller_configs[mock_ctrlr_config_name] = my_config
+        mock_test_config.controller_configs[
+            mock_ctrlr_2_config_name] = copy.copy(my_config)
+
+        class ControllerInfoTest(base_test.BaseTestClass):
+            def setup_class(self):
+                self.register_controller(mock_controller)
+                second_controller = self.register_controller(
+                    mock_second_controller)[0]
+                # This should appear in recorded controller info.
+                second_controller.set_magic('haha')
+
+            def test_func(self):
+                pass
+
+        bt_cls = ControllerInfoTest(mock_test_config)
+        bt_cls.run()
+        info1 = bt_cls.results.controller_info[0]
+        info2 = bt_cls.results.controller_info[1]
+        self.assertNotEqual(info1.timestamp, info2.timestamp)
+        self.assertEqual(info1.test_class, 'ControllerInfoTest')
+        self.assertEqual(info1.controller_name, 'MagicDevice')
+        self.assertEqual(info1.controller_info, [{
+            'MyMagic': {
+                'magic': 'Magic'
+            }
+        }])
+        self.assertEqual(info2.test_class, 'ControllerInfoTest')
+        self.assertEqual(info2.controller_name, 'AnotherMagicDevice')
+        self.assertEqual(info2.controller_info, [{
+            'MyOtherMagic': {
+                'magic': 'Magic',
+                'extra_magic': 'haha'
+            }
+        }])
+
     def test_register_controller_no_config(self):
         bt_cls = MockEmptyBaseTest(self.mock_test_cls_configs)
         with self.assertRaisesRegex(signals.ControllerError,
@@ -1812,7 +1860,7 @@ class BaseTestTest(unittest.TestCase):
         mock_ctrlrs = bt_cls._controller_registry[registered_name]
         self.assertEqual(mock_ctrlrs[0].magic, 'magic1')
         self.assertEqual(mock_ctrlrs[1].magic, 'magic2')
-        self.assertTrue(bt_cls._controller_destructors[registered_name])
+        self.assertTrue(bt_cls._controller_modules[registered_name])
         expected_msg = 'Controller module .* has already been registered.'
         with self.assertRaisesRegex(signals.ControllerError, expected_msg):
             bt_cls.register_controller(mock_controller)
@@ -1828,7 +1876,7 @@ class BaseTestTest(unittest.TestCase):
             }
             bt_cls = MockEmptyBaseTest(mock_test_config)
             bt_cls.register_controller(mock_controller)
-            self.assertEqual(bt_cls.results.controller_info, {})
+            self.assertEqual(bt_cls.results.controller_info, [])
         finally:
             setattr(mock_controller, 'get_info', get_info)
 

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -416,7 +416,7 @@ class RecordsTest(unittest.TestCase):
     def test_add_controller_info(self):
         tr = records.TestResult()
         self.assertFalse(tr.controller_info)
-        tr.add_controller_info('MyTest', 'MockDevice', ['magicA', 'magicB'])
+        tr.add_controller_info('MockDevice', ['magicA', 'magicB'], 'MyTest')
         self.assertTrue(tr.controller_info[0])
         self.assertEqual(tr.controller_info[0].controller_name, 'MockDevice')
         self.assertEqual(tr.controller_info[0].controller_info,
@@ -426,7 +426,7 @@ class RecordsTest(unittest.TestCase):
     def test_add_controller_info_not_serializable(self, mock_yaml_dump):
         tr = records.TestResult()
         self.assertFalse(tr.controller_info)
-        tr.add_controller_info('MyTest', 'MockDevice', ['magicA', 'magicB'])
+        tr.add_controller_info('MockDevice', ['magicA', 'magicB'], 'MyTest')
         self.assertTrue(tr.controller_info[0])
         self.assertEqual(tr.controller_info[0].controller_name, 'MockDevice')
         self.assertEqual(tr.controller_info[0].controller_info,

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -1,13 +1,13 @@
 # Copyright 2016 Google Inc.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
@@ -46,10 +46,10 @@ class RecordsTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.tn = "test_name"
-        self.details = "Some details about the test execution."
+        self.tn = 'test_name'
+        self.details = 'Some details about the test execution.'
         self.float_extra = 12345.56789
-        self.json_extra = {"ha": "whatever"}
+        self.json_extra = {'ha': 'whatever'}
         self.tmp_path = tempfile.mkdtemp()
 
     def tearDown(self):
@@ -62,8 +62,8 @@ class RecordsTest(unittest.TestCase):
         self.assertEqual(record.result, result)
         self.assertEqual(record.details, details)
         self.assertEqual(record.extras, extras)
-        self.assertTrue(record.begin_time, "begin time should not be empty.")
-        self.assertTrue(record.end_time, "end time should not be empty.")
+        self.assertTrue(record.begin_time, 'begin time should not be empty.')
+        self.assertTrue(record.end_time, 'end time should not be empty.')
         # UID is not used at the moment, should always be None.
         self.assertIsNone(record.uid)
         # Verify to_dict.
@@ -88,7 +88,7 @@ class RecordsTest(unittest.TestCase):
         self.assertDictEqual(actual_d, d)
         # Verify that these code paths do not cause crashes and yield non-empty
         # results.
-        self.assertTrue(str(record), "str of the record should not be empty.")
+        self.assertTrue(str(record), 'str of the record should not be empty.')
         self.assertTrue(repr(record), "the record's repr shouldn't be empty.")
 
     """ Begin of Tests """
@@ -239,17 +239,18 @@ class RecordsTest(unittest.TestCase):
         record1.test_pass(s)
         tr1 = records.TestResult()
         tr1.add_record(record1)
-        tr1.add_controller_info("MockDevice", ["magicA", "magicB"])
+        tr1.add_controller_info('SomeClass', 'MockDevice',
+                                ['magicA', 'magicB'])
         record2 = records.TestResultRecord(self.tn)
         record2.test_begin()
         s = signals.TestPass(self.details, self.json_extra)
         record2.test_pass(s)
         tr2 = records.TestResult()
         tr2.add_record(record2)
-        tr2.add_controller_info("MockDevice", ["magicC"])
+        tr2.add_controller_info('SomeClass', 'MockDevice', ['magicC'])
         tr2 += tr1
         self.assertTrue(tr2.passed, [tr1, tr2])
-        self.assertTrue(tr2.controller_info, {"MockDevice": ["magicC"]})
+        self.assertTrue(tr2.controller_info, {'MockDevice': ['magicC']})
 
     def test_result_add_operator_type_mismatch(self):
         record1 = records.TestResultRecord(self.tn)
@@ -258,9 +259,9 @@ class RecordsTest(unittest.TestCase):
         record1.test_pass(s)
         tr1 = records.TestResult()
         tr1.add_record(record1)
-        expected_msg = "Operand .* of type .* is not a TestResult."
+        expected_msg = 'Operand .* of type .* is not a TestResult.'
         with self.assertRaisesRegex(TypeError, expected_msg):
-            tr1 += "haha"
+            tr1 += 'haha'
 
     def test_result_add_class_error_with_test_signal(self):
         record1 = records.TestResultRecord(self.tn)
@@ -270,7 +271,7 @@ class RecordsTest(unittest.TestCase):
         tr = records.TestResult()
         tr.add_record(record1)
         s = signals.TestFailure(self.details, self.float_extra)
-        record2 = records.TestResultRecord("SomeTest", s)
+        record2 = records.TestResultRecord('SomeTest', s)
         tr.add_class_error(record2)
         self.assertEqual(len(tr.passed), 1)
         self.assertEqual(len(tr.error), 1)
@@ -289,10 +290,10 @@ class RecordsTest(unittest.TestCase):
 
         class SpecialError(Exception):
             def __init__(self, arg1, arg2):
-                self.msg = "%s %s" % (arg1, arg2)
+                self.msg = '%s %s' % (arg1, arg2)
 
-        se = SpecialError("haha", 42)
-        record2 = records.TestResultRecord("SomeTest", se)
+        se = SpecialError('haha', 42)
+        record2 = records.TestResultRecord('SomeTest', se)
         tr.add_class_error(record2)
         self.assertEqual(len(tr.passed), 1)
         self.assertEqual(len(tr.error), 1)
@@ -334,7 +335,7 @@ class RecordsTest(unittest.TestCase):
         """
         record1 = records.TestResultRecord(self.tn)
         record1.test_begin()
-        record1.test_fail(Exception("haha"))
+        record1.test_fail(Exception('haha'))
         tr = records.TestResult()
         tr.add_class_error(record1)
         self.assertFalse(tr.is_all_pass)
@@ -342,7 +343,7 @@ class RecordsTest(unittest.TestCase):
     def test_is_test_executed(self):
         record1 = records.TestResultRecord(self.tn)
         record1.test_begin()
-        record1.test_fail(Exception("haha"))
+        record1.test_fail(Exception('haha'))
         tr = records.TestResult()
         tr.add_record(record1)
         self.assertTrue(tr.is_test_executed(record1.test_name))
@@ -415,20 +416,22 @@ class RecordsTest(unittest.TestCase):
     def test_add_controller_info(self):
         tr = records.TestResult()
         self.assertFalse(tr.controller_info)
-        tr.add_controller_info('MockDevice', ['magicA', 'magicB'])
-        self.assertTrue(tr.controller_info)
-        self.assertEqual(tr.controller_info['MockDevice'],
+        tr.add_controller_info('MyTest', 'MockDevice', ['magicA', 'magicB'])
+        self.assertTrue(tr.controller_info[0])
+        self.assertEqual(tr.controller_info[0].controller_name, 'MockDevice')
+        self.assertEqual(tr.controller_info[0].controller_info,
                          ['magicA', 'magicB'])
 
     @mock.patch('yaml.dump', side_effect=TypeError('ha'))
     def test_add_controller_info_not_serializable(self, mock_yaml_dump):
         tr = records.TestResult()
         self.assertFalse(tr.controller_info)
-        tr.add_controller_info('MockDevice', ['magicA', 'magicB'])
-        self.assertTrue(tr.controller_info)
-        self.assertEqual(tr.controller_info['MockDevice'],
+        tr.add_controller_info('MyTest', 'MockDevice', ['magicA', 'magicB'])
+        self.assertTrue(tr.controller_info[0])
+        self.assertEqual(tr.controller_info[0].controller_name, 'MockDevice')
+        self.assertEqual(tr.controller_info[0].controller_info,
                          "['magicA', 'magicB']")
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -133,7 +133,6 @@ class TestRunnerTest(unittest.TestCase):
                                     records.OUTPUT_FILE_SUMMARY)
         with io.open(summary_path, 'r', encoding='utf-8') as f:
             summary_entries = list(yaml.load_all(f))
-        print(summary_entries)
         self.assertEqual(len(summary_entries), 4)
         # Verify the first entry is the list of test names.
         self.assertEqual(summary_entries[0]['Type'],


### PR DESCRIPTION
* Support multiple groups of controller info in  test result record.
* Record controller info at the end instead of the beginning of a
  test class run.
* Introduce a proper data class for controller info.

This changes public API `mobly.records.TestResult.controller_info`.

Fixes #484 
Fixes #485

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/495)
<!-- Reviewable:end -->
