### PR TITLE
Put back the "adb logcat -c" workaround for Android O

### DIFF
--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -88,7 +88,16 @@ class Logcat(base_service.BaseService):
 
     def clear_adb_log(self):
         # Clears cached adb content.
-        self._ad.adb.logcat('-c')
+        try:
+            self._ad.adb.logcat('-c')
+        except adb.AdbError as e:
+            # On Android O, the clear command fails due to a known bug.
+            # Catching this so we don't crash from this Android issue.
+            if "failed to clear" in e.stderr:
+                self._ad.log.warning(
+                    'Encountered known Android error to clear logcat.')
+            else:
+                raise
 
     def cat_adb_log(self, tag, begin_time):
         """Takes an excerpt of the adb logcat log from a certain time point to

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -433,6 +433,22 @@ class LogcatTest(unittest.TestCase):
         logcat_service = logcat.Logcat(ad)
         logcat_service._enable_logpersist()
 
+    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy')
+    @mock.patch(
+        'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+        return_value=mock_android_device.MockFastbootProxy('1'))
+    def test_logcat_service_clear_adb_log(self, MockFastboot, MockAdbProxy):
+        mock_serial = '1'
+        ad = android_device.AndroidDevice(serial=mock_serial)
+        ad.adb.logcat = mock.MagicMock()
+        ad.adb.logcat.side_effect = adb.AdbError(
+            cmd='cmd',
+            stdout='',
+            stderr='failed to clear "main" log',
+            ret_code=1)
+        logcat_service = logcat.Logcat(ad)
+        logcat_service.clear_adb_log()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#505

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/506)
<!-- Reviewable:end -->
