### PR TITLE
Package sl4a client management into a service.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -27,7 +27,7 @@ from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import errors
 from mobly.controllers.android_device_lib import fastboot
 from mobly.controllers.android_device_lib import service_manager
-from mobly.controllers.android_device_lib import sl4a_client
+from mobly.controllers.android_device_lib.services import sl4a_service
 from mobly.controllers.android_device_lib.services import logcat
 from mobly.controllers.android_device_lib.services import snippet_management_service
 
@@ -401,8 +401,11 @@ class AndroidDevice(object):
     """Class representing an android device.
 
     Each object of this class represents one Android device in Mobly. This class
-    provides various ways, like adb, fastboot, sl4a, and snippets, to control an
-    Android device, whether it's a real device or an emulator instance.
+    provides various ways, like adb, fastboot, and Mobly snippets, to control
+    an Android device, whether it's a real device or an emulator instance.
+
+    You can also register your own services to the device's service manager.
+    See the docs of `service_manager` and `base_service` for details.
 
     Attributes:
         serial: A string that's the serial number of the Androi device.
@@ -417,6 +420,8 @@ class AndroidDevice(object):
         adb: An AdbProxy object used for interacting with the device via adb.
         fastboot: A FastbootProxy object used for interacting with the device
             via fastboot.
+        services: ServiceManager, the manager of long-running services on the
+            device.
     """
 
     def __init__(self, serial=''):
@@ -622,21 +627,8 @@ class AndroidDevice(object):
         self.services.logcat.stop()
 
     def stop_services(self):
-        """Stops long running services on the Android device.
-
-        Stop adb logcat, terminate sl4a sessions if exist, terminate all
-        snippet clients.
-
-        Returns:
-            A dict containing information on the running services before they
-            are torn down. This can be used to restore these services, which
-            includes snippets and sl4a.
-        """
+        """Stops long running services on the Android device."""
         self.services.stop_all()
-        service_info = {}
-        service_info['use_sl4a'] = self.sl4a is not None
-        self._terminate_sl4a()
-        return service_info
 
     @contextlib.contextmanager
     def handle_reboot(self):
@@ -649,27 +641,14 @@ class AndroidDevice(object):
 
         For sample usage, see self.reboot().
         """
-        service_info = self.stop_services()
+        self.stop_services()
         try:
             yield
         finally:
             self.wait_for_boot_completion()
             if self.is_rootable:
                 self.root_adb()
-            self._restore_services(service_info)
-
-    def _restore_services(self, service_info):
-        """Restores services after a device has come back from temporary
-        being offline.
-
-        Args:
-            service_info: A dict containing information on the services to
-                          restore, which could include snippet and sl4a.
-        """
         self.services.start_all()
-        # Restore sl4a if needed.
-        if service_info['use_sl4a']:
-            self.load_sl4a()
 
     @contextlib.contextmanager
     def handle_usb_disconnect(self):
@@ -719,23 +698,10 @@ class AndroidDevice(object):
                   ad.adb.wait_for_device(timeout=SOME_TIMEOUT)
         """
         self.services.pause_all()
-        # Only need to stop dispatcher because it continuously polling device
-        # It's not necessary to stop snippet and sl4a.
-        if self.sl4a:
-            self.sl4a.stop_event_dispatcher()
         try:
             yield
         finally:
-            self._reconnect_to_services()
-
-    def _reconnect_to_services(self):
-        """Reconnects to services after USB reconnected."""
-        self.services.resume_all()
-        # Restore sl4a if needed.
-        if self.sl4a:
-            self.sl4a.restore_app_connection()
-            # Unpack the 'ed' attribute for compatibility.
-            self.ed = self.sl4a.ed
+            self.services.resume_all()
 
     @property
     def build_info(self):
@@ -865,7 +831,11 @@ class AndroidDevice(object):
         self.services.snippets.remove_snippet_client(name)
 
     def load_sl4a(self):
-        """Start sl4a service on the Android device.
+        """.. deprecated:: 1.8
+
+        Register sl4a_service directly instead.
+
+        Start sl4a service on the Android device.
 
         Launch sl4a server if not already running, spin up a session on the
         server, and two connections to this session.
@@ -873,9 +843,9 @@ class AndroidDevice(object):
         Creates an sl4a client (self.sl4a) with one connection, and one
         EventDispatcher obj (self.ed) with the other connection.
         """
-        self.sl4a = sl4a_client.Sl4aClient(ad=self)
-        self.sl4a.start_app_and_connect()
-        # Unpack the 'ed' attribute for compatibility.
+        self.services.register('sl4a', sl4a_service)
+        # Set the attributes for backward compatibility.
+        self.sl4a = self.services.sl4a
         self.ed = self.sl4a.ed
 
     def take_bug_report(self,
@@ -929,17 +899,6 @@ class AndroidDevice(object):
                 ' > "%s"' % full_out_path, shell=True, timeout=timeout)
         self.log.info('Bugreport for %s taken at %s.', test_name,
                       full_out_path)
-
-    def _terminate_sl4a(self):
-        """Terminate the current sl4a session.
-
-        Send terminate signal to sl4a server; stop dispatcher associated with
-        the session. Clear corresponding droids and dispatchers from cache.
-        """
-        if self.sl4a:
-            self.sl4a.stop_app()
-            self.sl4a = None
-            self.ed = None
 
     def run_iperf_client(self, server_host, extra_args=''):
         """Start iperf client on the device.

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -622,7 +622,11 @@ class AndroidDevice(object):
         self.fastboot.serial = new_serial
 
     def start_services(self, clear_log=True):
-        """Starts long running services on the android device, like adb logcat
+        """.. deprecated:: 1.8
+
+        Use service manager `self.services` instead.
+
+        Starts long running services on the android device, like adb logcat
         capture.
         """
         configs = logcat.Config(clear_log=clear_log)
@@ -645,7 +649,11 @@ class AndroidDevice(object):
         self.services.logcat.stop()
 
     def stop_services(self):
-        """Stops long running services on the Android device."""
+        """.. deprecated:: 1.8
+
+        Use service manager `self.services` instead.
+
+        Stops long running services on the Android device."""
         self.services.stop_all()
 
     @contextlib.contextmanager
@@ -861,6 +869,8 @@ class AndroidDevice(object):
         Launch sl4a server if not already running, spin up a session on the
         server, and two connections to this session.
         """
+        self.log.warning('`load_sl4a` is deprecated and scheduled for removal!'
+                         ' Register sl4a as a service instead.')
         self.services.register('sl4a', sl4a_service.Sl4aService)
 
     def take_bug_report(self,

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -861,7 +861,7 @@ class AndroidDevice(object):
         Launch sl4a server if not already running, spin up a session on the
         server, and two connections to this session.
         """
-        self.services.register('sl4a', sl4a_service)
+        self.services.register('sl4a', sl4a_service.Sl4aService)
 
     def take_bug_report(self,
                         test_name,

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -227,6 +227,13 @@ class JsonRpcClientBase(object):
             self._conn.close()
             self._conn = None
 
+    def clear_host_port(self):
+        """Stops the adb port forwarding of the host port used by this client.
+        """
+        if self.host_port:
+            self._adb.forward(['--remove', 'tcp:%d' % self.host_port])
+            self.host_port = None
+
     def _client_send(self, msg):
         """Sends an Rpc message through the connection.
 

--- a/mobly/controllers/android_device_lib/service_manager.py
+++ b/mobly/controllers/android_device_lib/service_manager.py
@@ -33,6 +33,18 @@ class ServiceManager(object):
         self._service_objects = {}
         self._device = device
 
+    def has_service_by_name(self, name):
+        """Checks if the manager has a service registered with a specific name.
+
+        Args:
+            name: string, the name to look for.
+
+        Returns:
+            True if a service is registered with the specified name, False
+            otherwise.
+        """
+        return name in self._service_objects
+
     @property
     def is_any_alive(self):
         """True if any service is alive; False otherwise."""
@@ -123,4 +135,6 @@ class ServiceManager(object):
         Args:
             name: string, the alias a service object was registered under.
         """
-        return self._service_objects[name]
+        if self.has_service_by_name(name):
+            return self._service_objects[name]
+        return self.__getattribute__(name)

--- a/mobly/controllers/android_device_lib/service_manager.py
+++ b/mobly/controllers/android_device_lib/service_manager.py
@@ -14,8 +14,11 @@
 """Module for the manager of services."""
 # TODO(xpconanfan: move the device errors to a more generic location so
 # other device controllers like iOS can share it.
+import inspect
+
 from mobly import expects
 from mobly.controllers.android_device_lib import errors
+from mobly.controllers.android_device_lib.services import base_service
 
 
 class Error(errors.DeviceError):
@@ -65,6 +68,12 @@ class ServiceManager(object):
             configs: (optional) config object to pass to the service class's
                 constructor.
         """
+        if not inspect.isclass(service_class):
+            raise Error(self._device, '"%s" is not a class!' % service_class)
+        if not issubclass(service_class, base_service.BaseService):
+            raise Error(
+                self._device,
+                'Class %s is not a subclass of BaseService!' % service_class)
         if alias in self._service_objects:
             raise Error(
                 self._device,

--- a/mobly/controllers/android_device_lib/services/sl4a_service.py
+++ b/mobly/controllers/android_device_lib/services/sl4a_service.py
@@ -49,7 +49,7 @@ class Sl4aService(base_service.BaseService):
 
     def resume(self):
         # Restore sl4a if needed.
-        if self.is_alive:
+        if not self.is_alive:
             self._sl4a_client.restore_app_connection()
 
     def __getattr__(self, name):

--- a/mobly/controllers/android_device_lib/services/sl4a_service.py
+++ b/mobly/controllers/android_device_lib/services/sl4a_service.py
@@ -1,0 +1,63 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module for the BaseService."""
+
+from mobly.controllers.android_device_lib import sl4a_client
+from mobly.controllers.android_device_lib.services import base_service
+
+
+class Sl4aService(base_service.BaseService):
+    """Base class of a Mobly AndroidDevice service.
+
+    This class defines the interface for Mobly's AndroidDevice service.
+    """
+
+    def __init__(self, device):
+        """Constructor of the class.
+
+        Args:
+          device: the device object this service is associated with.
+          config: optional configuration defined by the author of the service
+              class.
+        """
+        self._device = device
+        self._sl4a_client = None
+
+    @property
+    def is_alive(self):
+        return self._sl4a_client is not None
+
+    def start(self):
+        self._sl4a_client = sl4a_client.Sl4aClient(ad=self._device)
+        self._sl4a_client.start_app_and_connect()
+
+    def stop(self):
+        if self.is_alive:
+            self._sl4a_client.stop_app()
+            self._sl4a_client = None
+
+    def pause(self):
+        # Need to stop dispatcher because it continuously polls the device.
+        # It's not necessary to stop the sl4a client.
+        if self.is_alive:
+            self._sl4a_client.stop_event_dispatcher()
+
+    def resume(self):
+        # Restore sl4a if needed.
+        if self.is_alive:
+            self._sl4a_client.restore_app_connection()
+
+    def __getattr__(self, name):
+        """Forwards the getattr calls to the client itself."""
+        return getattr(self._sl4a_client, name)

--- a/mobly/controllers/android_device_lib/services/sl4a_service.py
+++ b/mobly/controllers/android_device_lib/services/sl4a_service.py
@@ -11,27 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Module for the BaseService."""
+"""Module for the Sl4aService."""
 
 from mobly.controllers.android_device_lib import sl4a_client
 from mobly.controllers.android_device_lib.services import base_service
 
 
 class Sl4aService(base_service.BaseService):
-    """Base class of a Mobly AndroidDevice service.
+    """Service for managing sl4a's client.
 
-    This class defines the interface for Mobly's AndroidDevice service.
+    Direct calls on the service object will forwarded to the client object as
+    syntactic sugar. So `Sl4aService.doFoo()` is equivalent to
+    `Sl4aClient.doFoo()`.
     """
-
     def __init__(self, device):
-        """Constructor of the class.
-
-        Args:
-          device: the device object this service is associated with.
-          config: optional configuration defined by the author of the service
-              class.
-        """
-        self._device = device
+        self._ad = device
         self._sl4a_client = None
 
     @property
@@ -39,7 +33,7 @@ class Sl4aService(base_service.BaseService):
         return self._sl4a_client is not None
 
     def start(self):
-        self._sl4a_client = sl4a_client.Sl4aClient(ad=self._device)
+        self._sl4a_client = sl4a_client.Sl4aClient(ad=self._ad)
         self._sl4a_client.start_app_and_connect()
 
     def stop(self):
@@ -60,4 +54,6 @@ class Sl4aService(base_service.BaseService):
 
     def __getattr__(self, name):
         """Forwards the getattr calls to the client itself."""
-        return getattr(self._sl4a_client, name)
+        if self._sl4a_client:
+            return getattr(self._sl4a_client, name)
+        return self.__getattribute__(name)

--- a/mobly/controllers/android_device_lib/services/sl4a_service.py
+++ b/mobly/controllers/android_device_lib/services/sl4a_service.py
@@ -24,6 +24,7 @@ class Sl4aService(base_service.BaseService):
     syntactic sugar. So `Sl4aService.doFoo()` is equivalent to
     `Sl4aClient.doFoo()`.
     """
+
     def __init__(self, device):
         self._ad = device
         self._sl4a_client = None
@@ -44,13 +45,12 @@ class Sl4aService(base_service.BaseService):
     def pause(self):
         # Need to stop dispatcher because it continuously polls the device.
         # It's not necessary to stop the sl4a client.
-        if self.is_alive:
-            self._sl4a_client.stop_event_dispatcher()
+        self._sl4a_client.stop_event_dispatcher()
+        self._sl4a_client.clear_host_port()
 
     def resume(self):
         # Restore sl4a if needed.
-        if not self.is_alive:
-            self._sl4a_client.restore_app_connection()
+        self._sl4a_client.restore_app_connection()
 
     def __getattr__(self, name):
         """Forwards the getattr calls to the client itself."""

--- a/mobly/controllers/android_device_lib/sl4a_client.py
+++ b/mobly/controllers/android_device_lib/sl4a_client.py
@@ -120,8 +120,7 @@ class Sl4aClient(jsonrpc_client_base.JsonRpcClientBase):
             self._adb.shell('am force-stop com.googlecode.android_scripting')
         finally:
             # Always clean up the adb port
-            if self.host_port:
-                self._adb.forward(['--remove', 'tcp:%d' % self.host_port])
+            self.clear_host_port()
 
     def stop_event_dispatcher(self):
         # Close Event Dispatcher

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -238,13 +238,6 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
             # Always clean up the adb port
             self.clear_host_port()
 
-    def clear_host_port(self):
-        """Stops the adb port forwarding of the host port used by this client.
-        """
-        if self.host_port:
-            self._adb.forward(['--remove', 'tcp:%d' % self.host_port])
-            self.host_port = None
-
     def _start_event_client(self):
         """Overrides superclass."""
         event_client = SnippetClient(package=self.package, ad=self._ad)

--- a/tests/mobly/controllers/android_device_lib/service_manager_test.py
+++ b/tests/mobly/controllers/android_device_lib/service_manager_test.py
@@ -59,6 +59,21 @@ class ServiceManagerTest(unittest.TestCase):
         self.assertTrue(service.is_alive)
         self.assertTrue(manager.is_any_alive)
 
+    def test_register_not_a_class(self):
+        manager = service_manager.ServiceManager(mock.MagicMock())
+        with self.assertRaisesRegex(service_manager.Error,
+                                    '.* is not a class!'):
+            manager.register('mock_service', base_service)
+
+    def test_register_wrong_subclass_type(self):
+        class MyClass(object):
+            pass
+
+        manager = service_manager.ServiceManager(mock.MagicMock())
+        with self.assertRaisesRegex(service_manager.Error,
+                                    '.* is not a subclass of BaseService!'):
+            manager.register('mock_service', MyClass)
+
     def test_register_dup_alias(self):
         manager = service_manager.ServiceManager(mock.MagicMock())
         manager.register('mock_service', MockService)

--- a/tests/mobly/controllers/android_device_lib/services/sl4a_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/sl4a_service_test.py
@@ -18,7 +18,7 @@ from mobly.controllers.android_device_lib.services import sl4a_service
 
 
 @mock.patch('mobly.controllers.android_device_lib.sl4a_client.Sl4aClient')
-class Sl4aTest(unittest.TestCase):
+class Sl4aServiceTest(unittest.TestCase):
     """Tests for the sl4a service."""
 
     def test_instantiation(self, _):

--- a/tests/mobly/controllers/android_device_lib/services/sl4a_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/sl4a_service_test.py
@@ -16,9 +16,11 @@ from future.tests.base import unittest
 
 from mobly.controllers.android_device_lib.services import sl4a_service
 
+
 @mock.patch('mobly.controllers.android_device_lib.sl4a_client.Sl4aClient')
 class Sl4aTest(unittest.TestCase):
     """Tests for the sl4a service."""
+
     def test_instantiation(self, _):
         service = sl4a_service.Sl4aService(mock.MagicMock())
         self.assertFalse(service.is_alive)
@@ -44,6 +46,15 @@ class Sl4aTest(unittest.TestCase):
         service.start()
         service.pause()
         mock_client.stop_event_dispatcher.assert_called_once_with()
+        mock_client.clear_host_port.assert_called_once_with()
+
+    def test_resume(self, mock_class):
+        mock_client = mock_class.return_value
+        service = sl4a_service.Sl4aService(mock.MagicMock())
+        service.start()
+        service.pause()
+        service.resume()
+        mock_client.restore_app_connection.assert_called_once_with()
 
 
 if __name__ == '__main__':

--- a/tests/mobly/controllers/android_device_lib/services/sl4a_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/sl4a_service_test.py
@@ -1,0 +1,50 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+from future.tests.base import unittest
+
+from mobly.controllers.android_device_lib.services import sl4a_service
+
+@mock.patch('mobly.controllers.android_device_lib.sl4a_client.Sl4aClient')
+class Sl4aTest(unittest.TestCase):
+    """Tests for the sl4a service."""
+    def test_instantiation(self, _):
+        service = sl4a_service.Sl4aService(mock.MagicMock())
+        self.assertFalse(service.is_alive)
+
+    def test_start(self, mock_class):
+        mock_client = mock_class.return_value
+        service = sl4a_service.Sl4aService(mock.MagicMock())
+        service.start()
+        mock_client.start_app_and_connect.assert_called_once_with()
+        self.assertTrue(service.is_alive)
+
+    def test_stop(self, mock_class):
+        mock_client = mock_class.return_value
+        service = sl4a_service.Sl4aService(mock.MagicMock())
+        service.start()
+        service.stop()
+        mock_client.stop_app.assert_called_once_with()
+        self.assertFalse(service.is_alive)
+
+    def test_pause(self, mock_class):
+        mock_client = mock_class.return_value
+        service = sl4a_service.Sl4aService(mock.MagicMock())
+        service.start()
+        service.pause()
+        mock_client.stop_event_dispatcher.assert_called_once_with()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/sl4a_shell.py
+++ b/tools/sl4a_shell.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tool to interactively call sl4a methods.
 
 SL4A (Scripting Layer for Android) is an RPC service exposing API calls on
@@ -38,29 +37,32 @@ import argparse
 import logging
 
 from mobly.controllers.android_device_lib import jsonrpc_shell_base
+from mobly.controllers.android_device_lib.services import sl4a_service
 
 
 class Sl4aShell(jsonrpc_shell_base.JsonRpcShellBase):
     def _start_services(self, console_env):
         """Overrides superclass."""
-        self._ad.load_sl4a()
-        console_env['s'] = self._ad.sl4a
+        self._ad.services.register('sl4a', sl4a_service.Sl4aService)
+        console_env['s'] = self._ad.services.sl4a
         console_env['sl4a'] = self._ad.sl4a
         console_env['ed'] = self._ad.ed
 
     def _get_banner(self, serial):
-        lines = ['Connected to %s.' % serial,
-                 'Call methods against:',
-                 '    ad (android_device.AndroidDevice)',
-                 '    sl4a or s (SL4A)',
-                 '    ed (EventDispatcher)']
+        lines = [
+            'Connected to %s.' % serial, 'Call methods against:',
+            '    ad (android_device.AndroidDevice)', '    sl4a or s (SL4A)',
+            '    ed (EventDispatcher)'
+        ]
         return '\n'.join(lines)
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Interactive client for sl4a.')
+    parser = argparse.ArgumentParser(
+        description='Interactive client for sl4a.')
     parser.add_argument(
-        '-s', '--serial',
+        '-s',
+        '--serial',
         help=
         'Device serial to connect to (if more than one device is connected)')
     args = parser.parse_args()


### PR DESCRIPTION
This is the final straw to remove all the private service managing methods in `AndroidDevice`. #505

* Package `sl4a_client` management into a service.
* Fix the zombie host port issue in `sl4a_client`. #512
* Move `clear_host_port` to client base class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/511)
<!-- Reviewable:end -->
