### PR TITLE
Fix wrong asserts in some python tests.

### DIFF
--- a/tests/mobly/base_instrumentation_test_test.py
+++ b/tests/mobly/base_instrumentation_test_test.py
@@ -175,8 +175,8 @@ class BaseInstrumentationTestTest(unittest.TestCase):
             self.assertIsInstance(result.error, signals.TestError)
         else:
             self.assertIsNone(result.error)
-            self.assertEquals(result.completed_and_passed,
-                              expected_completed_and_passed)
+            self.assertEqual(result.completed_and_passed,
+                             expected_completed_and_passed)
         self.assertEqual(len(result.executed), len(expected_executed))
         for actual_test, expected_test in zip(result.executed,
                                               expected_executed):
@@ -189,8 +189,8 @@ class BaseInstrumentationTestTest(unittest.TestCase):
             for actual_test, expected_time in zip(result.executed,
                                                   expected_executed_times):
                 (expected_begin_time, expected_end_time) = expected_time
-                self.assertEquals(actual_test.begin_time, expected_begin_time)
-                self.assertEquals(actual_test.end_time, expected_end_time)
+                self.assertEqual(actual_test.begin_time, expected_begin_time)
+                self.assertEqual(actual_test.end_time, expected_end_time)
 
     def test_run_instrumentation_test_with_invalid_syntax(self):
         instrumentation_output = """\

--- a/tests/mobly/output_test.py
+++ b/tests/mobly/output_test.py
@@ -168,7 +168,7 @@ class OutputTest(unittest.TestCase):
         output_dir1 = logging.log_path
         tr.run()
         output_dir2 = logging.log_path
-        self.assertNotEquals(output_dir1, output_dir2)
+        self.assertNotEqual(output_dir1, output_dir2)
         self.assert_output_logs_exist(output_dir1)
         self.assert_output_logs_exist(output_dir2)
 
@@ -200,7 +200,7 @@ class OutputTest(unittest.TestCase):
         tr._teardown_logger()
         output_dir2 = logging.log_path
 
-        self.assertNotEquals(output_dir1, output_dir2)
+        self.assertNotEqual(output_dir1, output_dir2)
 
         (summary_file_path1, debug_log_path1,
          info_log_path1) = self.get_output_logs(output_dir1)


### PR DESCRIPTION
Fixes part of #519

remaining warning:
mobly/mobly/test_runner.py:181: PytestWarning: cannot collect test class 'TestRunner' because it has a __init__ constructor
  class TestRunner(object):

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/520)
<!-- Reviewable:end -->
