### PR TITLE
Fix pytest init warnings.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [metadata]
 description-file = README.md
+[tool:pytest]
+python_classes =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [metadata]
 description-file = README.md
 [tool:pytest]
-python_classes =
+python_classes = *Test
+python_files = *_test.py
+testpaths = tests/mobly

--- a/tests/lib/mock_instrumentation_test.py
+++ b/tests/lib/mock_instrumentation_test.py
@@ -1,0 +1,46 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from mobly import base_instrumentation_test
+from mobly import config_parser
+from mobly.controllers import android_device
+from mobly.controllers.android_device_lib import adb
+
+# A mock test package for instrumentation.
+MOCK_TEST_PACKAGE = 'com.my.package.test'
+
+
+class MockInstrumentationTest(
+        base_instrumentation_test.BaseInstrumentationTestClass):
+    def __init__(self, tmp_dir, user_params={}):
+        mock_test_run_configs = config_parser.TestRunConfig()
+        mock_test_run_configs.summary_writer = mock.Mock()
+        mock_test_run_configs.log_path = tmp_dir
+        mock_test_run_configs.user_params = user_params
+        mock_test_run_configs.reporter = mock.MagicMock()
+        super(MockInstrumentationTest, self).__init__(mock_test_run_configs)
+
+    def run_mock_instrumentation_test(self, instrumentation_output, prefix):
+        def fake_instrument(package, options=None, runner=None, handler=None):
+            for line in instrumentation_output.splitlines():
+                handler(line)
+            return instrumentation_output
+
+        mock_device = mock.Mock(spec=android_device.AndroidDevice)
+        mock_device.adb = mock.Mock(spec=adb.AdbProxy)
+        mock_device.adb.instrument = fake_instrument
+        return self.run_instrumentation_test(
+            mock_device, MOCK_TEST_PACKAGE, prefix=prefix)

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -48,15 +48,6 @@ class SomeError(Exception):
     """A custom exception class used for tests in this module."""
 
 
-class MockEmptyBaseTest(base_test.BaseTestClass):
-    """Stub used to test functionalities not specific to a class
-    implementation.
-    """
-
-    def test_func(self):
-        pass
-
-
 class BaseTestTest(unittest.TestCase):
     def setUp(self):
         self.tmp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
Fixes #519 

So, I believe the __init__ warning is because pytest is trying to find the test clases or something for some reason. I think it looks for Test* stuff by default, but since we're a test framework, there really isn't a good way to separate our unit tests from out actual test framework. So, just setting what pytest looks for seems suppress the warning for me on both python 2 and 3.

See https://docs.pytest.org/en/latest/reference.html#confval-python_classes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/521)
<!-- Reviewable:end -->
