### PR TITLE
Fix pytest warning when run via setup.py test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ class PyTest(test.test):
 
     def finalize_options(self):
         test.test.finalize_options(self)
-        self.test_args = ['-x', "tests"]
+        self.test_args = ['-x', "tests/mobly"]
         self.test_suite = True
 
     def run_tests(self):


### PR DESCRIPTION
When running the tests via setup.py, there are now pytest warning because it's trying to collect from the lib directory, so specify the tests/mobly directory for the unit tests

Fixes #519

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/524)
<!-- Reviewable:end -->
