### PR TITLE
Introduce a proper execution stage for final clean up.

### DIFF
--- a/mobly/controller_manager.py
+++ b/mobly/controller_manager.py
@@ -17,6 +17,7 @@ import copy
 import logging
 import yaml
 
+from mobly import expects
 from mobly import records
 from mobly import signals
 
@@ -152,10 +153,9 @@ class ControllerManager(object):
         # logging them.
         for name, module in self._controller_modules.items():
             logging.debug('Destroying %s.', name)
-            try:
+            with expects.expect_no_raises(
+                    'Exception occurred destroying %s.' % name):
                 module.destroy(self._controller_objects[name])
-            except:
-                logging.exception('Exception occurred destroying %s.', name)
         self._controller_objects = collections.OrderedDict()
         self._controller_modules = {}
 
@@ -204,8 +204,11 @@ class ControllerManager(object):
         """
         info_records = []
         for controller_module_name in self._controller_objects.keys():
-            record = self._create_controller_info_record(
-                controller_module_name)
-            if record:
-                info_records.append(record)
+            with expects.expect_no_raises(
+                    'Failed to collect controller info from %s' %
+                    controller_module_name):
+                record = self._create_controller_info_record(
+                    controller_module_name)
+                if record:
+                    info_records.append(record)
         return info_records

--- a/tests/mobly/controller_manager_test.py
+++ b/tests/mobly/controller_manager_test.py
@@ -150,6 +150,16 @@ class ControllerManagerTest(unittest.TestCase):
         self.assertEqual(record.test_class, 'SomeClass')
         self.assertEqual(record.controller_name, 'MagicDevice')
 
+    @mock.patch('tests.lib.mock_controller.get_info')
+    def test_get_controller_info_records_error(self, mock_get_info_func):
+        mock_get_info_func.side_effect = Exception('Record info failed.')
+        mock_ctrlr_config_name = mock_controller.MOBLY_CONTROLLER_CONFIG_NAME
+        controller_configs = {mock_ctrlr_config_name: ['magic1', 'magic2']}
+        c_manager = controller_manager.ControllerManager(
+            'SomeClass', controller_configs)
+        c_manager.register_controller(mock_controller)
+        self.assertFalse(c_manager.get_controller_info_records())
+
     def test_get_controller_info_records(self):
         mock_ctrlr_config_name = mock_controller.MOBLY_CONTROLLER_CONFIG_NAME
         controller_configs = {mock_ctrlr_config_name: ['magic1', 'magic2']}
@@ -186,6 +196,18 @@ class ControllerManagerTest(unittest.TestCase):
         objects = c_manager.register_controller(mock_controller)
         c_manager.unregister_controllers()
         mock_destroy_func.assert_called_once_with(objects)
+        self.assertFalse(c_manager._controller_objects)
+        self.assertFalse(c_manager._controller_modules)
+
+    @mock.patch('tests.lib.mock_controller.destroy')
+    def test_unregister_controller_error(self, mock_destroy_func):
+        mock_ctrlr_config_name = mock_controller.MOBLY_CONTROLLER_CONFIG_NAME
+        controller_configs = {mock_ctrlr_config_name: ['magic1', 'magic2']}
+        c_manager = controller_manager.ControllerManager(
+            'SomeClass', controller_configs)
+        c_manager.register_controller(mock_controller)
+        mock_destroy_func.side_effect = Exception('Failed in destroy.')
+        c_manager.unregister_controllers()
         self.assertFalse(c_manager._controller_objects)
         self.assertFalse(c_manager._controller_modules)
 


### PR DESCRIPTION
The final clean up stage includes recording controller info and destroying controller objects, both of which execute user logic which can raise errors.

This change makes the final clean up a proper execution stage to properly capture the errors from these operations.

Fixes #533 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/538)
<!-- Reviewable:end -->
