### PR TITLE
Undefined name: Error() --> Exception()

### DIFF
--- a/mobly/controllers/monsoon.py
+++ b/mobly/controllers/monsoon.py
@@ -526,7 +526,7 @@ class MonsoonData(object):
         hz_str = lines[4].split()[2]
         hz = int(hz_str[:-2])
         voltage_str = lines[2].split()[1]
-        voltage = int(voltage[:-1])
+        voltage = int(voltage_str[:-1])
         lines = lines[6:]
         t = []
         v = []
@@ -690,7 +690,7 @@ class Monsoon(object):
                 prevent tripping Monsoon overvoltage.
         """
         if ramp:
-            self.mon.RampVoltage(mon.start_voltage, volt)
+            self.mon.RampVoltage(self.mon.start_voltage, volt)
         else:
             self.mon.SetVoltage(volt)
 

--- a/mobly/controllers/monsoon.py
+++ b/mobly/controllers/monsoon.py
@@ -55,7 +55,7 @@ def create(configs):
         # Configs is a list of ints representing serials.
         objs = get_instances(configs)
     else:
-        raise Error('No valid config found in: %s' % configs)
+        raise Exception('No valid config found in: %s' % configs)
     return objs
 
 


### PR DESCRIPTION
__Error()__ is an _undefined name_ in this context so this PR recommends using __Exception()__ in its place.

[flake8](http://flake8.pycqa.org) testing of https://github.com/google/mobly on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./mobly/records.py:233:32: F821 undefined name 'unicode'
                self.details = unicode(content)
                               ^
./mobly/controllers/monsoon.py:58:15: F821 undefined name 'Error'
        raise Error('No valid config found in: %s' % configs)
              ^
./mobly/controllers/monsoon.py:529:23: F821 undefined name 'voltage'
        voltage = int(voltage[:-1])
                      ^
./mobly/controllers/monsoon.py:693:34: F821 undefined name 'mon'
            self.mon.RampVoltage(mon.start_voltage, volt)
                                 ^
./tests/mobly/controllers/android_device_test.py:632:13: F821 undefined name 'assertIs'
            assertIs(e, expected_e)
            ^
5     F821 undefined name 'Error'
5
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/548)
<!-- Reviewable:end -->
