### PR TITLE
Append search path to include parent directory.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, u'mobly')
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.pardir))
 
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
This fixes issue #553 where the module index was not being generated by
adding the parent directory to the module search path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/554)
<!-- Reviewable:end -->
