### PR TITLE
Fix Python3 str handling error.

### DIFF
--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -124,7 +124,7 @@ class Logcat(base_service.BaseService):
         except adb.AdbError as e:
             # On Android O, the clear command fails due to a known bug.
             # Catching this so we don't crash from this Android issue.
-            if "failed to clear" in e.stderr:
+            if b'failed to clear' in e.stderr:
                 self._ad.log.warning(
                     'Encountered known Android error to clear logcat.')
             else:

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -465,8 +465,8 @@ class LogcatTest(unittest.TestCase):
         ad.adb.logcat = mock.MagicMock()
         ad.adb.logcat.side_effect = adb.AdbError(
             cmd='cmd',
-            stdout='',
-            stderr='failed to clear "main" log',
+            stdout=b'',
+            stderr=b'failed to clear "main" log',
             ret_code=1)
         logcat_service = logcat.Logcat(ad)
         logcat_service.clear_adb_log()


### PR DESCRIPTION
adb proxy returns byte strings from io, python 3 complains about doing string operation between byte strings and unicode strings, so fix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/555)
<!-- Reviewable:end -->
