### PR TITLE
Add a default timeout for adb getprop calls.

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -33,7 +33,7 @@ ADB_PORT_LOCK = threading.Lock()
 # Qualified class name of the default instrumentation test runner.
 DEFAULT_INSTRUMENTATION_RUNNER = 'com.android.common.support.test.runner.AndroidJUnitRunner'
 
-# Adb getprop call should never take too long
+# Adb getprop call should never take too long.
 DEFAULT_GETPROP_TIMEOUT_SEC = 5
 
 

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -33,6 +33,9 @@ ADB_PORT_LOCK = threading.Lock()
 # Qualified class name of the default instrumentation test runner.
 DEFAULT_INSTRUMENTATION_RUNNER = 'com.android.common.support.test.runner.AndroidJUnitRunner'
 
+# Adb getprop call should never take too long
+DEFAULT_GETPROP_TIMEOUT_SEC = 5
+
 
 class Error(Exception):
     """Base error type for adb proxy module."""
@@ -302,7 +305,9 @@ class AdbProxy(object):
             A string that is the value of the property, or None if the property
             doesn't exist.
         """
-        return self.shell('getprop %s' % prop_name).decode('utf-8').strip()
+        return self.shell(
+            ['getprop', 'prop_name'],
+            timeout=DEFAULT_GETPROP_TIMEOUT_SEC).decode('utf-8').strip()
 
     def has_shell_command(self, command):
         """Checks to see if a given check command exists on the device.

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -447,7 +447,7 @@ class AdbTest(unittest.TestCase):
     def test_getprop(self):
         with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
             mock_exec_cmd.return_value = b'blah'
-            self.assertEqual(adb.AdbProxy().getprop('haha'), b'blah')
+            self.assertEqual(adb.AdbProxy().getprop('haha'), 'blah')
 
     def test_forward(self):
         with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -444,6 +444,11 @@ class AdbTest(unittest.TestCase):
         self.assertEqual(MOCK_DEFAULT_STDERR,
                          stderr_redirect.getvalue().decode('utf-8'))
 
+    def test_getprop(self):
+        with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
+            mock_exec_cmd.return_value = b'blah'
+            self.assertEqual(adb.AdbProxy().getprop('haha'), b'blah')
+
     def test_forward(self):
         with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
             adb.AdbProxy().forward(MOCK_SHELL_COMMAND)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/556)
<!-- Reviewable:end -->
