### PR TITLE
Remove `tests` module from installation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def main():
         license='Apache2.0',
         url='https://github.com/google/mobly',
         download_url='https://github.com/google/mobly/tarball/1.8.1',
-        packages=setuptools.find_packages(),
+        packages=setuptools.find_packages(exclude=['tests']),
         include_package_data=False,
         scripts=['tools/sl4a_shell.py', 'tools/snippet_shell.py'],
         tests_require=[


### PR DESCRIPTION
This change also makes the script paths absolute instead of relative,
which allows Mobly to be installed without being in the base directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/564)
<!-- Reviewable:end -->
