### PR TITLE
Fix assert message to have a single stacktrace

### DIFF
--- a/mobly/asserts.py
+++ b/mobly/asserts.py
@@ -51,6 +51,8 @@ def assert_equal(first, second, msg=None, extras=None):
         if msg:
             my_msg = "%s %s" % (my_msg, msg)
 
+    # This raise statement is outside of the above except statement to prevent
+    # Python3's exception message from having two tracebacks.
     if my_msg is not None:
         raise signals.TestFailure(my_msg, extras=extras)
 

--- a/mobly/asserts.py
+++ b/mobly/asserts.py
@@ -43,18 +43,16 @@ def assert_equal(first, second, msg=None, extras=None):
         extras: An optional field for extra information to be included in
             test result.
     """
+    my_msg = None
     try:
         _pyunit_proxy.assertEqual(first, second)
-    except Exception as e:
-        # We have to catch all here for py2/py3 compatibility.
-        # In py2, assertEqual throws exceptions.AssertionError, which does not
-        # exist in py3. In py3, it throws unittest.case.failureException, which
-        # does not exist in py2. To accommodate using explicit catch complicates
-        # the code like hell, so I opted to catch all instead.
+    except AssertionError as e:
         my_msg = str(e)
         if msg:
             my_msg = "%s %s" % (my_msg, msg)
-        fail(my_msg, extras=extras)
+
+    if my_msg is not None:
+        raise signals.TestFailure(my_msg, extras=extras)
 
 
 def assert_raises(expected_exception, extras=None, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def main():
         license='Apache2.0',
         url='https://github.com/google/mobly',
         download_url='https://github.com/google/mobly/tarball/1.8.1',
-        packages=setuptools.find_packages(exclude=['tests']),
+        packages=setuptools.find_packages(),
         include_package_data=False,
         scripts=['tools/sl4a_shell.py', 'tools/snippet_shell.py'],
         tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def main():
         license='Apache2.0',
         url='https://github.com/google/mobly',
         download_url='https://github.com/google/mobly/tarball/1.8.1',
-        packages=setuptools.find_packages(),
+        packages=setuptools.find_packages(exclude=['tests']),
         include_package_data=False,
         scripts=['tools/sl4a_shell.py', 'tools/snippet_shell.py'],
         tests_require=[


### PR DESCRIPTION
In Python3, the stacktrace is duplicated when an exception is caught and raised as a different Exception object. We can get around this by determining the assertion failed, and re-raising the assertion as a TestFailure.

Also, AssertionError is caught instead of Exception. It is the base class name for the errors pyunit raises in both python2 and python3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/565)
<!-- Reviewable:end -->
