### PR TITLE
Add support for specifying UID for test cases

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -711,6 +711,8 @@ class BaseTestClass(object):
             test_func = functools.partial(test_logic, *args)
             if uid_func is not None:
                 uid = uid_func(*args)
+                if uid is None:
+                    raise Error('%s UID cannot be None.' % root_error_msg)
                 setattr(test_func, 'uid', uid)
             self._generated_test_table[test_name] = test_func
 

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -683,10 +683,13 @@ class BaseTestClass(object):
                 the test logic function.
             arg_sets: a list of tuples, each tuple is a set of arguments to be
                 passed to the test logic function and name function.
-            uid_func: function, the fu
+            uid_func: function, a function that takes the same arguments as the
+                test logic function and returns a string that is the
+                corresponding UID.
         """
         self._assert_function_name_in_stack(STAGE_NAME_SETUP_GENERATED_TESTS)
-        root_error_msg = 'Encountered error during test generation of "%s":' % test_logic.__name__
+        root_error_msg = ('Encountered error during test generation of "%s":'
+                          ) % test_logic.__name__
         for args in arg_sets:
             test_name = name_func(*args)
             if test_name in self.get_existing_test_names():

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -563,21 +563,6 @@ class BaseTestClass(object):
         self.summary_writer.dump(content,
                                  records.TestSummaryEntryType.USER_DATA)
 
-    @staticmethod
-    def _extract_uid(test_method):
-        """Extracts a test's unique identifier (UID) specified by user.
-
-        Args:
-            test_method: function, the test method whose UID to extract.
-
-        Returns:
-            string, the UID as specified by user if one exists; None otherwise.
-        """
-        try:
-            return test_method.uid
-        except AttributeError:
-            pass
-
     def exec_one_test(self, test_name, test_method):
         """Executes one test and update test results.
 
@@ -590,7 +575,7 @@ class BaseTestClass(object):
             test_method: function, The test method to execute.
         """
         tr_record = records.TestResultRecord(test_name, self.TAG)
-        tr_record.UID = BaseTestClass._extract_uid(test_method)
+        tr_record.uid = getattr(test_method, 'uid', None)
         tr_record.test_begin()
         self.current_test_info = runtime_test_info.RuntimeTestInfo(
             test_name, self.log_path, tr_record)
@@ -712,7 +697,7 @@ class BaseTestClass(object):
             if uid_func is not None:
                 uid = uid_func(*args)
                 if uid is None:
-                    raise Error('%s UID cannot be None.' % root_error_msg)
+                    raise ValueError('%s UID cannot be None.' % root_error_msg)
                 setattr(test_func, 'uid', uid)
             self._generated_test_table[test_name] = test_func
 

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -675,6 +675,8 @@ class BaseTestClass(object):
         parameter sets. This way we reduce code repetition and improve test
         scalability.
 
+
+
         Args:
             test_logic: function, the common logic shared by all the generated
                 tests.
@@ -688,20 +690,21 @@ class BaseTestClass(object):
                 corresponding UID.
         """
         self._assert_function_name_in_stack(STAGE_NAME_SETUP_GENERATED_TESTS)
-        root_error_msg = ('Encountered error during test generation of "%s":'
-                          ) % test_logic.__name__
+        root_msg = 'During test generation of "%s":' % test_logic.__name__
         for args in arg_sets:
             test_name = name_func(*args)
             if test_name in self.get_existing_test_names():
                 raise Error(
                     '%s Test name "%s" already exists, cannot be duplicated!' %
-                    (root_error_msg, test_name))
+                    (root_msg, test_name))
             test_func = functools.partial(test_logic, *args)
             if uid_func is not None:
                 uid = uid_func(*args)
                 if uid is None:
-                    raise ValueError('%s UID cannot be None.' % root_error_msg)
-                setattr(test_func, 'uid', uid)
+                    logging.warning('%s UID for arg set %s is None.', root_msg,
+                                    args)
+                else:
+                    setattr(test_func, 'uid', uid)
             self._generated_test_table[test_name] = test_func
 
     def _safe_exec_func(self, func, *args):

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -675,7 +675,8 @@ class BaseTestClass(object):
         parameter sets. This way we reduce code repetition and improve test
         scalability.
 
-
+        Users can provide an optional function to specify the UID of each test.
+        Not all generated tests are required to have UID.
 
         Args:
             test_logic: function, the common logic shared by all the generated
@@ -685,9 +686,9 @@ class BaseTestClass(object):
                 the test logic function.
             arg_sets: a list of tuples, each tuple is a set of arguments to be
                 passed to the test logic function and name function.
-            uid_func: function, a function that takes the same arguments as the
-                test logic function and returns a string that is the
-                corresponding UID.
+            uid_func: function, an optional function that takes the same
+                arguments as the test logic function and returns a string that
+                is the corresponding UID.
         """
         self._assert_function_name_in_stack(STAGE_NAME_SETUP_GENERATED_TESTS)
         root_msg = 'During test generation of "%s":' % test_logic.__name__

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -17,6 +17,7 @@
 import collections
 import copy
 import enum
+import functools
 import io
 import logging
 import sys
@@ -32,6 +33,38 @@ from mobly import utils
 OUTPUT_FILE_INFO_LOG = 'test_log.INFO'
 OUTPUT_FILE_DEBUG_LOG = 'test_log.DEBUG'
 OUTPUT_FILE_SUMMARY = 'test_summary.yaml'
+
+
+class Error(Exception):
+    """Raised for errors in record module members."""
+
+
+def uid(uid):
+    """Decorator specifying the unique identifier (UID) of a test case.
+
+    The UID will be recorded in the test's record when executed by Mobly.
+
+    Note a common UID system is the Universal Unitque Identifier (UUID), but
+    we are not limiting people to use UUID, hence the more generic name `UID`.
+
+    Args:
+        uid: string, the uid for the decorated test function.
+    """
+
+    def decorate(test_func):
+        func_name = test_func.__name__
+        if not func_name.startswith('test_'):
+            raise Error('Cannot apply "uid" decorator to "%s" because it is '
+                        'not a Mobly test method.' % func_name)
+
+        @functools.wraps(test_func)
+        def wrapper(*args, **kwargs):
+            return test_func(*args, **kwargs)
+
+        setattr(wrapper, 'uid', uid)
+        return wrapper
+
+    return decorate
 
 
 class TestSummaryEntryType(enum.Enum):

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -50,6 +50,8 @@ def uid(uid):
     Args:
         uid: string, the uid for the decorated test function.
     """
+    if uid is None:
+        raise Error('UID cannot be None.')
 
     def decorate(test_func):
         func_name = test_func.__name__

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -51,7 +51,7 @@ def uid(uid):
         uid: string, the uid for the decorated test function.
     """
     if uid is None:
-        raise Error('UID cannot be None.')
+        raise ValueError('UID cannot be None.')
 
     def decorate(test_func):
         func_name = test_func.__name__

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -54,11 +54,6 @@ def uid(uid):
         raise ValueError('UID cannot be None.')
 
     def decorate(test_func):
-        func_name = test_func.__name__
-        if not func_name.startswith('test_'):
-            raise Error('Cannot apply "uid" decorator to "%s" because it is '
-                        'not a Mobly test method.' % func_name)
-
         @functools.wraps(test_func)
         def wrapper(*args, **kwargs):
             return test_func(*args, **kwargs)

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -44,6 +44,9 @@ def uid(uid):
 
     The UID will be recorded in the test's record when executed by Mobly.
 
+    If you use any other decorator for the test method, you may want to use
+    this as the outer-most one.
+
     Note a common UID system is the Universal Unitque Identifier (UUID), but
     we are not limiting people to use UUID, hence the more generic name `UID`.
 

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -1925,7 +1925,8 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, "setup_generated_tests")
         self.assertEqual(
             actual_record.details,
-            'Test name "ha" already exists, cannot be duplicated!')
+            'Encountered error during test generation of "logic": Test name '
+            '"ha" already exists, cannot be duplicated!')
         expected_summary = ("Error 1, Executed 0, Failed 0, Passed 0, "
                             "Requested 0, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)
@@ -2047,6 +2048,28 @@ class BaseTestTest(unittest.TestCase):
         expected_msg = ('Failed to collect controller info from '
                         'mock_controller: Some failure')
         self.assertEqual(record.details, expected_msg)
+
+    def test_uid(self):
+        class MockBaseTest(base_test.BaseTestClass):
+            @records.uid('some-uid')
+            def test_func(self):
+                pass
+
+        bt_cls = MockBaseTest(self.mock_test_cls_configs)
+        bt_cls.run()
+        actual_record = bt_cls.results.passed[0]
+        self.assertEqual(actual_record.UID, 'some-uid')
+
+    def test_uid(self):
+        with self.assertRaisesRegex(
+                records.Error,
+                'Cannot apply "uid" decorator to "not_a_test" because it is not a'
+                ' Mobly test method.'):
+
+            class MockBaseTest(base_test.BaseTestClass):
+                @records.uid('some-uid')
+                def not_a_test(self):
+                    pass
 
 
 if __name__ == "__main__":

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -1880,8 +1880,8 @@ class BaseTestTest(unittest.TestCase):
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        self.assertEqual(bt_cls.results.passed[0].UID, 'uid-1-2')
-        self.assertEqual(bt_cls.results.passed[1].UID, 'uid-3-4')
+        self.assertEqual(bt_cls.results.passed[0].uid, 'uid-1-2')
+        self.assertEqual(bt_cls.results.passed[1].uid, 'uid-3-4')
 
     def test_generate_tests_with_none_uid(self):
         class MockBaseTest(base_test.BaseTestClass):
@@ -2105,7 +2105,7 @@ class BaseTestTest(unittest.TestCase):
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
         actual_record = bt_cls.results.passed[0]
-        self.assertEqual(actual_record.UID, 'some-uid')
+        self.assertEqual(actual_record.uid, 'some-uid')
 
     def test_uid_not_specified(self):
         class MockBaseTest(base_test.BaseTestClass):
@@ -2115,7 +2115,7 @@ class BaseTestTest(unittest.TestCase):
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
         actual_record = bt_cls.results.passed[0]
-        self.assertIsNone(actual_record.UID)
+        self.assertIsNone(actual_record.uid)
 
     def test_uid_apply_on_non_test(self):
         with self.assertRaisesRegex(
@@ -2129,7 +2129,7 @@ class BaseTestTest(unittest.TestCase):
                     pass
 
     def test_uid_is_none(self):
-        with self.assertRaisesRegex(records.Error, 'UID cannot be None.'):
+        with self.assertRaisesRegex(ValueError, 'UID cannot be None.'):
 
             class MockBaseTest(base_test.BaseTestClass):
                 @records.uid(None)

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -2060,11 +2060,21 @@ class BaseTestTest(unittest.TestCase):
         actual_record = bt_cls.results.passed[0]
         self.assertEqual(actual_record.UID, 'some-uid')
 
-    def test_uid(self):
+    def test_uid_not_specified(self):
+        class MockBaseTest(base_test.BaseTestClass):
+            def test_func(self):
+                pass
+
+        bt_cls = MockBaseTest(self.mock_test_cls_configs)
+        bt_cls.run()
+        actual_record = bt_cls.results.passed[0]
+        self.assertIsNone(actual_record.UID)
+
+    def test_uid_apply_on_non_test(self):
         with self.assertRaisesRegex(
                 records.Error,
-                'Cannot apply "uid" decorator to "not_a_test" because it is not a'
-                ' Mobly test method.'):
+                'Cannot apply "uid" decorator to "not_a_test" because it is '
+                'not a Mobly test method.'):
 
             class MockBaseTest(base_test.BaseTestClass):
                 @records.uid('some-uid')

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -2120,17 +2120,6 @@ class BaseTestTest(unittest.TestCase):
         actual_record = bt_cls.results.passed[0]
         self.assertIsNone(actual_record.uid)
 
-    def test_uid_apply_on_non_test(self):
-        with self.assertRaisesRegex(
-                records.Error,
-                'Cannot apply "uid" decorator to "not_a_test" because it is '
-                'not a Mobly test method.'):
-
-            class MockBaseTest(base_test.BaseTestClass):
-                @records.uid('some-uid')
-                def not_a_test(self):
-                    pass
-
     def test_uid_is_none(self):
         with self.assertRaisesRegex(ValueError, 'UID cannot be None.'):
 

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -1896,14 +1896,17 @@ class BaseTestTest(unittest.TestCase):
                 return 'test_%s_%s' % (a, b)
 
             def uid_logic(self, a, b):
-                return None
+                if a == 1:
+                    return None
+                return 'uid-3-4'
 
             def logic(self, a, b):
                 pass
 
         bt_cls = MockBaseTest(self.mock_test_cls_configs)
         bt_cls.run()
-        self.assertIn('UID cannot be None', bt_cls.results.error[0].details)
+        self.assertIsNone(bt_cls.results.passed[0].uid)
+        self.assertEqual(bt_cls.results.passed[1].uid, 'uid-3-4')
 
     def test_generate_tests_selected_run(self):
         class MockBaseTest(base_test.BaseTestClass):
@@ -1972,8 +1975,8 @@ class BaseTestTest(unittest.TestCase):
         self.assertEqual(actual_record.test_name, "setup_generated_tests")
         self.assertEqual(
             actual_record.details,
-            'Encountered error during test generation of "logic": Test name '
-            '"ha" already exists, cannot be duplicated!')
+            'During test generation of "logic": Test name "ha" already exists'
+            ', cannot be duplicated!')
         expected_summary = ("Error 1, Executed 0, Failed 0, Passed 0, "
                             "Requested 0, Skipped 0")
         self.assertEqual(bt_cls.results.summary_str(), expected_summary)

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -427,12 +427,12 @@ class RecordsTest(unittest.TestCase):
         self.assertEqual(tr.controller_info[0].controller_info,
                          ['magicA', 'magicB'])
 
-    @records.uid('some-uuid')
-    def test_uid_helper(self):
-        """Dummy test used by `test_uid` for testing the uid decorator."""
-
     def test_uid(self):
-        self.assertEqual(self.test_uid_helper.uid, 'some-uuid')
+        @records.uid('some-uuid')
+        def test_uid_helper():
+            """Dummy test used by `test_uid` for testing the uid decorator."""
+
+        self.assertEqual(test_uid_helper.uid, 'some-uuid')
 
 
 if __name__ == '__main__':

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -427,6 +427,13 @@ class RecordsTest(unittest.TestCase):
         self.assertEqual(tr.controller_info[0].controller_info,
                          ['magicA', 'magicB'])
 
+    @records.uid('some-uuid')
+    def test_uid_helper(self):
+        """Dummy test used by `test_uid` for testing the uid decorator."""
+
+    def test_uid(self):
+        self.assertEqual(self.test_uid_helper.uid, 'some-uuid')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Provide ways for test writers to specify Unique Identifiers (UID) for test cases, including both static and generated tests.
* Also improve error messages of `generate_tests`.

Fixes #338

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/571)
<!-- Reviewable:end -->
