### PR TITLE
Fix windows cbuild pytest pytype error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ def main():
         scripts=['tools/sl4a_shell.py', 'tools/snippet_shell.py'],
         tests_require=[
             'mock',
+            # Needed for supporting Python 2 because this release stopped supporting Python 2.
             'pytest<5.0.0',
             'pytz',
         ],

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ def main():
         scripts=['tools/sl4a_shell.py', 'tools/snippet_shell.py'],
         tests_require=[
             'mock',
-            'pytest',
+            'pytest<5.0.0',
             'pytz',
         ],
         install_requires=install_requires,


### PR DESCRIPTION
~3 days ago, pytest released version 5.0, which apparently breaks our Windows cbuild with pytype errors
http://go/gh/pytest-dev/pytest/releases/tag/5.0.0

This is probably because python 2 doesn't support type annotations, which the new release somehow changes the mock import to use or something. Considering that we still need to support python 2 for a while, don't move to the 5.0.0 release for now.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/590)
<!-- Reviewable:end -->
