### PR TITLE
Add attempts for adb getprop

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -956,6 +956,8 @@ class AndroidDevice(object):
 
     def is_boot_completed(self):
         """Checks if device boot is completed by verifying system property."""
+        # No need to attempt multiple times because `wait_for_boot_completion`
+        # will handle empty string values properly.
         completed = self.adb.getprop('sys.boot_completed')
         if completed == '1':
             self.log.debug('Device boot completed.')

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -35,6 +35,7 @@ DEFAULT_INSTRUMENTATION_RUNNER = 'com.android.common.support.test.runner.Android
 
 # Adb getprop call should never take too long.
 DEFAULT_GETPROP_TIMEOUT_SEC = 5
+DEFAULT_GETPROP_RETRY_SLEEP_SEC = 0.5
 DEFAULT_GETPROPS_ATTEMPTS = 3
 DEFAULT_GETPROPS_RETRY_SLEEP_SEC = 1
 
@@ -325,12 +326,15 @@ class AdbProxy(object):
         """
         if attempts < 1:
             attempts = 1
-        for _ in range(attempts):
+        for attempt in range(attempts):
             output = self.shell(
                 ['getprop', prop_name],
                 timeout=DEFAULT_GETPROP_TIMEOUT_SEC).decode('utf-8').strip()
             if output:
                 return output
+            # Don't call sleep on the last attempt.
+            if attempt < attempts - 1:
+                time.sleep(DEFAULT_GETPROP_RETRY_SLEEP_SEC)
         return ''
 
     def getprops(self, prop_names):

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -124,7 +124,7 @@ class MockAdbProxy(object):
         elif 'which' in params:
             return b''
 
-    def getprop(self, params):
+    def getprop(self, params, attempts=1):
         if params in self.mock_properties:
             return self.mock_properties[params]
 

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -454,6 +454,19 @@ class AdbTest(unittest.TestCase):
                 stderr=None,
                 timeout=adb.DEFAULT_GETPROP_TIMEOUT_SEC)
 
+    def test_getprop_with_extra_attempts_succeed(self):
+        with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
+            mock_exec_cmd.side_effect = [b'', b'', b'blah']
+            self.assertEqual(adb.AdbProxy().getprop('haha', attempts=3),
+                             'blah')
+            self.assertEqual(mock_exec_cmd.call_count, 3)
+
+    def test_getprop_with_extra_attempts_fail(self):
+        with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
+            mock_exec_cmd.return_value = b''
+            self.assertEqual(adb.AdbProxy().getprop('haha', attempts=3), '')
+            self.assertEqual(mock_exec_cmd.call_count, 3)
+
     def test__parse_getprop_output_special_values(self):
         mock_adb_output = (
             b'[selinux.restorecon_recursive]: [/data/misc_ce/10]\n'

--- a/tests/mobly/controllers/android_device_lib/sl4a_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/sl4a_client_test.py
@@ -24,7 +24,6 @@ from mobly.controllers.android_device_lib import sl4a_client
 from tests.lib import jsonrpc_client_test_base
 from tests.lib import mock_android_device
 
-
 class Sl4aClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
     """Unit tests for mobly.controllers.android_device_lib.sl4a_client.
     """

--- a/tests/mobly/controllers/android_device_lib/sl4a_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/sl4a_client_test.py
@@ -24,6 +24,7 @@ from mobly.controllers.android_device_lib import sl4a_client
 from tests.lib import jsonrpc_client_test_base
 from tests.lib import mock_android_device
 
+
 class Sl4aClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
     """Unit tests for mobly.controllers.android_device_lib.sl4a_client.
     """


### PR DESCRIPTION
Apparently, adb getprop will randomly return empty string for build properties, so this adds the ability to retry if necessary to work around that. This seems especially common with android emulators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/593)
<!-- Reviewable:end -->
