### PR TITLE
A pull request to solve the "AdbTimeoutError: Timed out executing command "adb -s d6d5974 shell getprop sys.boot_completed" after 5s. " bug during waiting the device for fully boot up as adb.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -933,7 +933,7 @@ class AndroidDevice(object):
             try:
                 if self.is_boot_completed():
                     return
-            except adb.AdbError:
+            except (adb.AdbError, adb.AdbTimeoutError):
                 # adb shell calls may fail during certain period of booting
                 # process, which is normal. Ignoring these errors.
                 pass

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -904,13 +904,15 @@ class AndroidDeviceTest(unittest.TestCase):
         return_value=mock_android_device.MockFastbootProxy('1'))
     @mock.patch(
         'mobly.controllers.android_device.AndroidDevice.is_boot_completed',
-        side_effect=[False, False, adb.AdbTimeoutError(['adb', 'shell', 'getprop sys.boot_completed'], timeout=5,serial=1), True])
+        side_effect=[False, False, adb.AdbTimeoutError(['adb', 'shell', 'getprop sys.boot_completed'], timeout=5, serial=1), True])
     def test_AndroidDevice_wait_for_completion(self, is_boot_completed, FastbootProxy, MockAdbProxy):
         ad = android_device.AndroidDevice(serial='1')
-        ad.wait_for_boot_completion()
-        # self.asserFalse(ad.isbootloader)
-
-        print('test_AndroidDevice_wait_for_completion_0')
+        raised = False
+        try:
+            ad.wait_for_boot_completion()
+        except (adb.AdbError, adb.AdbTimeoutError):
+            raised = True
+        self.assertFalse(raised, 'adb.AdbError or adb.AdbTimeoutError exception raised but not handled.')
 
 
 if __name__ == '__main__':

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -896,6 +896,22 @@ class AndroidDeviceTest(unittest.TestCase):
         self.assertTrue(ad.services.is_any_alive)
         self.assertFalse(ad.services.mock_service.resume_called)
 
+    @mock.patch(
+        'mobly.controllers.android_device_lib.adb.AdbProxy',
+        return_value=mock_android_device.MockAdbProxy('1'))
+    @mock.patch(
+        'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+        return_value=mock_android_device.MockFastbootProxy('1'))
+    @mock.patch(
+        'mobly.controllers.android_device.AndroidDevice.is_boot_completed',
+        side_effect=[False, False, adb.AdbTimeoutError(['adb', 'shell', 'getprop sys.boot_completed'], timeout=5,serial=1), True])
+    def test_AndroidDevice_wait_for_completion(self, is_boot_completed, FastbootProxy, MockAdbProxy):
+        ad = android_device.AndroidDevice(serial='1')
+        ad.wait_for_boot_completion()
+        # self.asserFalse(ad.isbootloader)
+
+        print('test_AndroidDevice_wait_for_completion_0')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/596)
<!-- Reviewable:end -->
