### PR TITLE
Add retries for adb getprops.

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -332,13 +332,19 @@ class AdbProxy(object):
             A dict containing name-value pairs of the properties requested, if
             they exist.
         """
-        raw_output = self.shell(
-            ['getprop'], timeout=DEFAULT_GETPROP_TIMEOUT_SEC)
-        properties = self._parse_getprop_output(raw_output)
         results = {}
-        for name in prop_names:
-            if name in properties:
-                results[name] = properties[name]
+        for _ in range(3):
+            # The ADB getprop command can randomly return empty string, so try
+            # multiple times. This value should always be non-empty if the device
+            # in a working state.
+            raw_output = self.shell(
+                ['getprop'], timeout=DEFAULT_GETPROP_TIMEOUT_SEC)
+            properties = self._parse_getprop_output(raw_output)
+            if properties:
+                for name in prop_names:
+                    if name in properties:
+                        results[name] = properties[name]
+                break
         return results
 
     def has_shell_command(self, command):

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -335,8 +335,9 @@ class AdbProxy(object):
             A dict containing name-value pairs of the properties requested, if
             they exist.
         """
+        attempts = DEFAULT_GETPROPS_ATTEMPTS
         results = {}
-        for _ in range(DEFAULT_GETPROPS_ATTEMPTS):
+        for attempt in range(attempts):
             # The ADB getprop command can randomly return empty string, so try
             # multiple times. This value should always be non-empty if the device
             # in a working state.
@@ -348,7 +349,9 @@ class AdbProxy(object):
                     if name in properties:
                         results[name] = properties[name]
                 break
-            time.sleep(DEFAULT_GETPROPS_RETRY_SLEEP_SEC)
+            # Don't call sleep on the last attempt.
+            if attempt < attempts - 1:
+                time.sleep(DEFAULT_GETPROPS_RETRY_SLEEP_SEC)
         return results
 
     def has_shell_command(self, command):

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -18,6 +18,7 @@ from past.builtins import basestring
 import logging
 import psutil
 import subprocess
+import time
 import threading
 
 from mobly import utils
@@ -34,6 +35,8 @@ DEFAULT_INSTRUMENTATION_RUNNER = 'com.android.common.support.test.runner.Android
 
 # Adb getprop call should never take too long.
 DEFAULT_GETPROP_TIMEOUT_SEC = 5
+DEFAULT_GETPROPS_ATTEMPTS = 3
+DEFAULT_GETPROPS_RETRY_SLEEP_SEC = 1
 
 
 class Error(Exception):
@@ -333,7 +336,7 @@ class AdbProxy(object):
             they exist.
         """
         results = {}
-        for _ in range(3):
+        for _ in range(DEFAULT_GETPROPS_ATTEMPTS):
             # The ADB getprop command can randomly return empty string, so try
             # multiple times. This value should always be non-empty if the device
             # in a working state.
@@ -345,6 +348,7 @@ class AdbProxy(object):
                     if name in properties:
                         results[name] = properties[name]
                 break
+            time.sleep(DEFAULT_GETPROPS_RETRY_SLEEP_SEC)
         return results
 
     def has_shell_command(self, command):

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -532,6 +532,7 @@ class AdbTest(unittest.TestCase):
                 shell=False,
                 stderr=None,
                 timeout=adb.DEFAULT_GETPROP_TIMEOUT_SEC)
+            mock_sleep.assert_not_called()
 
     @mock.patch('time.sleep', return_value=mock.MagicMock())
     def test_getprops_when_empty_string_randomly_returned(self, mock_sleep):
@@ -550,9 +551,8 @@ class AdbTest(unittest.TestCase):
                 shell=False,
                 stderr=None,
                 timeout=adb.DEFAULT_GETPROP_TIMEOUT_SEC)
-            mock_sleep.assert_has_calls([
-                mock.call(1),
-            ])
+            self.assertEqual(mock_sleep.call_count, 1)
+            mock_sleep.assert_called_with(1)
 
     @mock.patch('time.sleep', return_value=mock.MagicMock())
     def test_getprops_when_empty_string_always_returned(self, mock_sleep):
@@ -566,10 +566,8 @@ class AdbTest(unittest.TestCase):
                 shell=False,
                 stderr=None,
                 timeout=adb.DEFAULT_GETPROP_TIMEOUT_SEC)
-            mock_sleep.assert_has_calls([
-                mock.call(1),
-                mock.call(1),
-            ])
+            self.assertEqual(mock_sleep.call_count, 2)
+            mock_sleep.assert_called_with(1)
 
     def test_forward(self):
         with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -508,7 +508,8 @@ class AdbTest(unittest.TestCase):
         }
         self.assertEqual(parsed_props, expected_output)
 
-    def test_getprops(self):
+    @mock.patch('time.sleep', return_value=mock.MagicMock())
+    def test_getprops(self, mock_sleep):
         with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
             mock_exec_cmd.return_value = (
                 b'\n[sendbug.preferred.domain]: [google.com]\n'
@@ -532,7 +533,8 @@ class AdbTest(unittest.TestCase):
                 stderr=None,
                 timeout=adb.DEFAULT_GETPROP_TIMEOUT_SEC)
 
-    def test_getprops_when_empty_string_randomly_returned(self):
+    @mock.patch('time.sleep', return_value=mock.MagicMock())
+    def test_getprops_when_empty_string_randomly_returned(self, mock_sleep):
         with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
             mock_exec_cmd.side_effect = [
                 b'', (b'\n[ro.build.id]: [AB42]\n'
@@ -548,8 +550,12 @@ class AdbTest(unittest.TestCase):
                 shell=False,
                 stderr=None,
                 timeout=adb.DEFAULT_GETPROP_TIMEOUT_SEC)
+            mock_sleep.assert_has_calls([
+                mock.call(1),
+            ])
 
-    def test_getprops_when_empty_string_always_returned(self):
+    @mock.patch('time.sleep', return_value=mock.MagicMock())
+    def test_getprops_when_empty_string_always_returned(self, mock_sleep):
         with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
             mock_exec_cmd.return_value = b''
             actual_output = adb.AdbProxy().getprops(['ro.build.id'])
@@ -560,6 +566,10 @@ class AdbTest(unittest.TestCase):
                 shell=False,
                 stderr=None,
                 timeout=adb.DEFAULT_GETPROP_TIMEOUT_SEC)
+            mock_sleep.assert_has_calls([
+                mock.call(1),
+                mock.call(1),
+            ])
 
     def test_forward(self):
         with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:


### PR DESCRIPTION
apparently, getprops can also return empty string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/597)
<!-- Reviewable:end -->
