### PR TITLE
Extend build info

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -716,9 +716,23 @@ class AndroidDevice(object):
                            'info.')
             return
         info = {}
-        build_info = self.adb.getprops(['ro.build.id', 'ro.build.type'])
+        build_info = self.adb.getprops([
+            'ro.build.id',
+            'ro.build.type',
+            'ro.build.version.codename',
+            'ro.build.version.sdk',
+            'ro.build.product',
+            'ro.debuggable',
+            'ro.product.name',
+        ])
         info['build_id'] = build_info['ro.build.id']
         info['build_type'] = build_info['ro.build.type']
+        info['build_version_codename'] = build_info.get(
+            'ro.build.version.codename', '')
+        info['build_version_sdk'] = build_info.get('ro.build.version.sdk', '')
+        info['build_product'] = build_info.get('ro.build.product', '')
+        info['debuggable'] = build_info.get('ro.debuggable', '')
+        info['product_name'] = build_info.get('ro.product.name', '')
         return info
 
     @property
@@ -740,7 +754,7 @@ class AndroidDevice(object):
 
     @property
     def is_rootable(self):
-        return self.adb.getprop('ro.debuggable') == '1'
+        return self.build_info['debuggable'] == '1'
 
     @property
     def model(self):
@@ -757,10 +771,10 @@ class AndroidDevice(object):
                 if len(tokens) > 1:
                     return tokens[1].lower()
             return None
-        model = self.adb.getprop('ro.build.product').lower()
+        model = self.build_info['build_product'].lower()
         if model == 'sprout':
             return model
-        return self.adb.getprop('ro.product.name').lower()
+        return self.build_info['product_name'].lower()
 
     def load_config(self, config):
         """Add attributes to the AndroidDevice object based on config.

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -327,8 +327,8 @@ class JsonRpcClientBase(object):
 
     def disable_hidden_api_blacklist(self):
         """If necessary and possible, disables hidden api blacklist."""
-        version_codename = self._ad.adb.getprop('ro.build.version.codename')
-        sdk_version = int(self._ad.adb.getprop('ro.build.version.sdk'))
+        version_codename = self._ad.build_info['build_version_codename']
+        sdk_version = int(self._ad.build_info['build_version_sdk'])
         # we check version_codename in addition to sdk_version because P builds
         # in development report sdk_version 27, but still enforce the blacklist.
         if self._ad.is_rootable and (sdk_version >= 28

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -28,6 +28,7 @@ DEFAULT_MOCK_PROPERTIES = {
     'ro.build.version.codename': 'Z',
     'ro.build.version.sdk': '28',
     'ro.product.name': 'FakeModel',
+    'ro.debuggable': '1',
     'sys.boot_completed': "1",
 }
 

--- a/tests/mobly/controllers/android_device_lib/sl4a_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/sl4a_client_test.py
@@ -66,6 +66,11 @@ class Sl4aClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
             installed_packages=['com.googlecode.android_scripting'])
         ad = mock.Mock()
         ad.adb = adb_proxy
+        ad.build_info = {
+            'build_version_codename':
+            ad.adb.getprop('ro.build.version.codename'),
+            'build_version_sdk': ad.adb.getprop('ro.build.version.sdk'),
+        }
         return sl4a_client.Sl4aClient(ad=ad)
 
     def _setup_mock_instrumentation_cmd(self, mock_start_standing_subprocess,

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -452,6 +452,11 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
                                     MOCK_PACKAGE_NAME)])
         ad = mock.Mock()
         ad.adb = adb_proxy
+        ad.build_info = {
+            'build_version_codename':
+            ad.adb.getprop('ro.build.version.codename'),
+            'build_version_sdk': ad.adb.getprop('ro.build.version.sdk'),
+        }
         return snippet_client.SnippetClient(package=MOCK_PACKAGE_NAME, ad=ad)
 
     def _setup_mock_instrumentation_cmd(self, mock_start_standing_subprocess,


### PR DESCRIPTION
Part 1 of two PRs, this moves a bunch of properties from getprop to getprops from inside the build_info value

The second PR will cache the build_info values to reduce adb commands

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/599)
<!-- Reviewable:end -->
