### PR TITLE
Cache build info

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -441,7 +441,7 @@ class AndroidDevice(object):
             'tag': self.debug_tag
         })
         self._build_info = None
-        self._rebooting = False
+        self._is_rebooting = False
         self.adb = adb.AdbProxy(serial)
         self.fastboot = fastboot.FastbootProxy(serial)
         if not self.is_bootloader and self.is_rootable:
@@ -641,7 +641,7 @@ class AndroidDevice(object):
         For sample usage, see self.reboot().
         """
         self.services.stop_all()
-        self._rebooting = True
+        self._is_rebooting = True
         # On rooted devices, it's possible to modify system properties, but
         # doing so requires the device to reboot. So, invalidate the build_info
         # cache.
@@ -651,7 +651,7 @@ class AndroidDevice(object):
         finally:
             self.wait_for_boot_completion()
             self._build_info = None
-            self._rebooting = False
+            self._is_rebooting = False
             if self.is_rootable:
                 self.root_adb()
         self.services.start_all()
@@ -724,7 +724,7 @@ class AndroidDevice(object):
             self.log.error('Device is in fastboot mode, could not get build '
                            'info.')
             return
-        if self._build_info is None or self._rebooting:
+        if self._build_info is None or self._is_rebooting:
             info = {}
             build_info = self.adb.getprops([
                 'ro.build.id',

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -655,12 +655,11 @@ class AndroidDevice(object):
         self.services.stop_all()
         # On rooted devices, system properties may change on reboot, so disable
         # the `build_info` cache by setting `_is_rebooting` to True and
-        # repopulated it after reboot.
+        # repopulate it after reboot.
         # Note, this logic assumes that instance variable assignment in Python
         # is atomic; otherwise, `threading` data structures would be necessary.
-        # Additionally, nesting calls to `handle_reboot` while changing
-        # read only property values during reboot will also result in stale
-        # values.
+        # Additionally, nesting calls to `handle_reboot` while changing the
+        # read-only property values during reboot will result in stale values.
         self._is_rebooting = True
         try:
             yield
@@ -668,13 +667,13 @@ class AndroidDevice(object):
             self.wait_for_boot_completion()
             # On boot completion, invalidate the `build_info` cache since any
             # value it had from before boot completion is potentially invalid.
-            # If the value gets set before the final invalidation and setting
-            # `_is_rebooting` to True, then that's okay because the device has
-            # finished rebooting at that point, and values at that point are
-            # valid.
+            # If the value gets set after the final invalidation and before
+            # setting`_is_rebooting` to True, then that's okay because the
+            # device has finished rebooting at that point, and values at that
+            # point should be valid.
             # If the reboot fails for some reason, then `_is_rebooting` is never
             # set to False, which means the `build_info` cache remains disabled
-            # until the next reboot, which is relatively okay because the
+            # until the next reboot. This is relatively okay because the
             # `build_info` cache is only minimizes adb commands.
             self._build_info = None
             self._is_rebooting = False

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -87,8 +87,9 @@ class MockAdbProxy(object):
         self.serial = serial
         self.fail_br = fail_br
         self.fail_br_before_N = fail_br_before_N
+        self.getprops_call_count = 0
         if mock_properties is None:
-            self.mock_properties = DEFAULT_MOCK_PROPERTIES
+            self.mock_properties = DEFAULT_MOCK_PROPERTIES.copy()
         else:
             self.mock_properties = mock_properties
         if installed_packages is None:
@@ -129,6 +130,7 @@ class MockAdbProxy(object):
             return self.mock_properties[params]
 
     def getprops(self, params):
+        self.getprops_call_count = self.getprops_call_count + 1
         return self.mock_properties
 
     def bugreport(self, args, shell=False, timeout=None):

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -277,6 +277,8 @@ class AndroidDeviceTest(unittest.TestCase):
         self.assertEqual(build_info['build_product'], 'FakeModel')
         self.assertEqual(build_info['product_name'], 'FakeModel')
         self.assertEqual(build_info['debuggable'], '1')
+        self.assertEqual(
+            len(build_info), len(android_device.CACHED_SYSTEM_PROPS))
 
     @mock.patch(
         'mobly.controllers.android_device_lib.adb.AdbProxy',


### PR DESCRIPTION
Part 2 of https://github.com/google/mobly/pull/599
This caches build_info, which will minimize adb property calls from mobly itself

which is another way to fix the issue from https://github.com/google/mobly/pull/593
with https://github.com/google/mobly/pull/597
since Mobly would no longer be doing adb getprop <property> calls for /system/build.prop properties

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/600)
<!-- Reviewable:end -->
