### PR TITLE
Make `take_bug_reports` consistent with its singular version.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -406,10 +406,10 @@ def take_bug_reports(ads, test_name=None, begin_time=None, destination=None):
         destination: string, path to the directory where the bugreport
             should be saved.
     """
-    if begin_time:
-        begin_time = mobly_logger.normalize_log_line_timestamp(str(begin_time))
-    else:
+    if begin_time is None:
         begin_time = mobly_logger.get_log_file_timestamp()
+    else:
+        begin_time = mobly_logger.normalize_log_line_timestamp(str(begin_time))
 
     def take_br(test_name, begin_time, ad, destination):
         ad.take_bug_report(test_name=test_name,

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -400,24 +400,23 @@ def take_bug_reports(ads, test_name=None, begin_time=None, destination=None):
     Args:
         ads: A list of AndroidDevice instances.
         test_name: Name of the test method that triggered this bug report.
+            If None, the default name "bugreport" will be used.
         begin_time: timestamp taken when the test started, can be either
-            string or int.
+            string or int. If None, the current time will be used.
         destination: string, path to the directory where the bugreport
             should be saved.
     """
-    _begin_time = None
     if begin_time:
-        _begin_time = mobly_logger.normalize_log_line_timestamp(
-            str(begin_time))
+        begin_time = mobly_logger.normalize_log_line_timestamp(str(begin_time))
     else:
-        _begin_time = mobly_logger.get_log_file_timestamp()
+        begin_time = mobly_logger.get_log_file_timestamp()
 
     def take_br(test_name, begin_time, ad, destination):
         ad.take_bug_report(test_name=test_name,
                            begin_time=begin_time,
                            destination=destination)
 
-    args = [(test_name, _begin_time, ad, destination) for ad in ads]
+    args = [(test_name, begin_time, ad, destination) for ad in ads]
     utils.concurrent_exec(take_br, args)
 
 

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -389,7 +389,7 @@ def get_device(ads, **kwargs):
         raise Error('More than one device matched: %s' % serials)
 
 
-def take_bug_reports(ads, test_name, begin_time, destination=None):
+def take_bug_reports(ads, test_name=None, begin_time=None, destination=None):
     """Takes bug reports on a list of android devices.
 
     If you want to take a bug report, call this function with a list of
@@ -405,14 +405,19 @@ def take_bug_reports(ads, test_name, begin_time, destination=None):
         destination: string, path to the directory where the bugreport
             should be saved.
     """
-    begin_time = mobly_logger.normalize_log_line_timestamp(str(begin_time))
+    _begin_time = None
+    if begin_time:
+        _begin_time = mobly_logger.normalize_log_line_timestamp(
+            str(begin_time))
+    else:
+        _begin_time = mobly_logger.get_log_file_timestamp()
 
     def take_br(test_name, begin_time, ad, destination):
         ad.take_bug_report(test_name=test_name,
                            begin_time=begin_time,
                            destination=destination)
 
-    args = [(test_name, begin_time, ad, destination) for ad in ads]
+    args = [(test_name, _begin_time, ad, destination) for ad in ads]
     utils.concurrent_exec(take_br, args)
 
 
@@ -897,9 +902,7 @@ class AndroidDevice(object):
         if test_name is None:
             test_name = DEFAULT_BUG_REPORT_NAME
         if begin_time is None:
-            epoch_time = utils.get_current_epoch_time()
-            timestamp = mobly_logger.epoch_to_log_line_timestamp(epoch_time)
-            begin_time = mobly_logger.normalize_log_line_timestamp(timestamp)
+            begin_time = mobly_logger.get_log_file_timestamp()
 
         new_br = True
         try:

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -229,6 +229,20 @@ class AndroidDeviceTest(unittest.TestCase):
             begin_time='sometime',
             destination=None)
 
+    @mock.patch('mobly.logger.get_log_file_timestamp')
+    def test_take_bug_reports_with_none_values(self,
+                                               get_log_file_timestamp_mock):
+        mock_timestamp = '07-22-2019_17-55-30-765'
+        get_log_file_timestamp_mock.return_value = mock_timestamp
+        ads = mock_android_device.get_mock_ads(3)
+        android_device.take_bug_reports(ads)
+        ads[0].take_bug_report.assert_called_once_with(
+            test_name=None, begin_time=mock_timestamp, destination=None)
+        ads[1].take_bug_report.assert_called_once_with(
+            test_name=None, begin_time=mock_timestamp, destination=None)
+        ads[2].take_bug_report.assert_called_once_with(
+            test_name=None, begin_time=mock_timestamp, destination=None)
+
     # Tests for android_device.AndroidDevice class.
     # These tests mock out any interaction with the OS and real android device
     # in AndroidDeivce.
@@ -413,39 +427,32 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
                 return_value=mock_android_device.MockFastbootProxy('1'))
     @mock.patch('mobly.utils.create_dir')
-    @mock.patch('mobly.utils.get_current_epoch_time')
-    @mock.patch('mobly.logger.epoch_to_log_line_timestamp')
+    @mock.patch('mobly.logger.get_log_file_timestamp')
     def test_AndroidDevice_take_bug_report_without_args(
-            self, epoch_to_log_line_timestamp_mock,
-            get_current_epoch_time_mock, create_dir_mock, FastbootProxy,
+            self, get_log_file_timestamp_mock, create_dir_mock, FastbootProxy,
             MockAdbProxy):
-        get_current_epoch_time_mock.return_value = 1557446629606
-        epoch_to_log_line_timestamp_mock.return_value = '05-09 17:03:49.606'
+        get_log_file_timestamp_mock.return_value = '07-22-2019_17-53-34-450'
         mock_serial = '1'
         ad = android_device.AndroidDevice(serial=mock_serial)
         output_path = ad.take_bug_report()
         expected_path = os.path.join(logging.log_path,
                                      'AndroidDevice%s' % ad.serial,
                                      'BugReports')
-        create_dir_mock.assert_called_with(expected_path)
-        epoch_to_log_line_timestamp_mock.assert_called_once_with(1557446629606)
         self.assertEqual(
             output_path,
-            os.path.join(expected_path, 'bugreport,05-09_17-03-49.606,1.zip'))
+            os.path.join(expected_path,
+                         'bugreport,07-22-2019_17-53-34-450,1.zip'))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy('1'))
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
                 return_value=mock_android_device.MockFastbootProxy('1'))
     @mock.patch('mobly.utils.create_dir')
-    @mock.patch('mobly.utils.get_current_epoch_time')
-    @mock.patch('mobly.logger.epoch_to_log_line_timestamp')
+    @mock.patch('mobly.logger.get_log_file_timestamp')
     def test_AndroidDevice_take_bug_report_with_only_test_name(
-            self, epoch_to_log_line_timestamp_mock,
-            get_current_epoch_time_mock, create_dir_mock, FastbootProxy,
+            self, get_log_file_timestamp_mock, create_dir_mock, FastbootProxy,
             MockAdbProxy):
-        get_current_epoch_time_mock.return_value = 1557446629606
-        epoch_to_log_line_timestamp_mock.return_value = '05-09 17:03:49.606'
+        get_log_file_timestamp_mock.return_value = '07-22-2019_17-53-34-450'
         mock_serial = '1'
         ad = android_device.AndroidDevice(serial=mock_serial)
         output_path = ad.take_bug_report(test_name='test_something')
@@ -453,11 +460,10 @@ class AndroidDeviceTest(unittest.TestCase):
                                      'AndroidDevice%s' % ad.serial,
                                      'BugReports')
         create_dir_mock.assert_called_with(expected_path)
-        epoch_to_log_line_timestamp_mock.assert_called_once_with(1557446629606)
         self.assertEqual(
             output_path,
             os.path.join(expected_path,
-                         'test_something,05-09_17-03-49.606,1.zip'))
+                         'test_something,07-22-2019_17-53-34-450,1.zip'))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy(1))


### PR DESCRIPTION
Also simplify the timestamp generation logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/602)
<!-- Reviewable:end -->
