### PR TITLE
Guarantee service start/stop order in AndroidDevice.

### DIFF
--- a/mobly/controllers/android_device_lib/service_manager.py
+++ b/mobly/controllers/android_device_lib/service_manager.py
@@ -128,7 +128,7 @@ class ServiceManager(object):
 
         Services will be stopped in the reverse order they were registered.
         """
-        for alias, service in reversed(self._service_objects.items()):
+        for alias, service in reversed(list(self._service_objects.items())):
             if service.is_alive:
                 with expects.expect_no_raises('Failed to stop service "%s".' %
                                               alias):
@@ -139,7 +139,7 @@ class ServiceManager(object):
 
         Services will be paused in the reverse order they were registered.
         """
-        for alias, service in reversed(self._service_objects.items()):
+        for alias, service in reversed(list(self._service_objects.items())):
             with expects.expect_no_raises('Failed to pause service "%s".' %
                                           alias):
                 service.pause()

--- a/mobly/controllers/android_device_lib/service_manager.py
+++ b/mobly/controllers/android_device_lib/service_manager.py
@@ -128,6 +128,8 @@ class ServiceManager(object):
 
         Services will be stopped in the reverse order they were registered.
         """
+        # OrdereDict#items does not return a sequence in Python 3.4, so we have
+        # to do a list conversion here.
         for alias, service in reversed(list(self._service_objects.items())):
             if service.is_alive:
                 with expects.expect_no_raises('Failed to stop service "%s".' %
@@ -139,6 +141,8 @@ class ServiceManager(object):
 
         Services will be paused in the reverse order they were registered.
         """
+        # OrdereDict#items does not return a sequence in Python 3.4, so we have
+        # to do a list conversion here.
         for alias, service in reversed(list(self._service_objects.items())):
             with expects.expect_no_raises('Failed to pause service "%s".' %
                                           alias):

--- a/tests/mobly/controllers/android_device_lib/service_manager_test.py
+++ b/tests/mobly/controllers/android_device_lib/service_manager_test.py
@@ -185,11 +185,17 @@ class ServiceManagerTest(unittest.TestCase):
         manager.register('mock_service2', MockService, start_service=False)
         service1 = manager.mock_service1
         service2 = manager.mock_service2
+        mock_call_tracker = mock.Mock()
+        mock_call_tracker.start1 = service1.start_func
+        mock_call_tracker.start2 = service2.start_func
         manager.start_all()
         self.assertTrue(service1.is_alive)
         self.assertTrue(service2.is_alive)
         self.assertEqual(service1.start_func.call_count, 1)
         self.assertEqual(service2.start_func.call_count, 1)
+        self.assertEqual(mock_call_tracker.mock_calls,
+                         [mock.call.start1(None),
+                          mock.call.start2(None)])
 
     def test_start_all_with_already_started_services(self):
         manager = service_manager.ServiceManager(mock.MagicMock())
@@ -224,9 +230,15 @@ class ServiceManagerTest(unittest.TestCase):
         manager.register('mock_service2', MockService)
         service1 = manager.mock_service1
         service2 = manager.mock_service2
+        mock_call_tracker = mock.Mock()
+        mock_call_tracker.stop1 = service1.stop_func
+        mock_call_tracker.stop2 = service2.stop_func
         manager.stop_all()
         self.assertFalse(service1.is_alive)
         self.assertFalse(service2.is_alive)
+        self.assertEqual(
+            mock_call_tracker.mock_calls,
+            [mock.call.stop2(), mock.call.stop1()])
         self.assertEqual(service1.start_func.call_count, 1)
         self.assertEqual(service2.start_func.call_count, 1)
         self.assertEqual(service1.stop_func.call_count, 1)
@@ -286,7 +298,13 @@ class ServiceManagerTest(unittest.TestCase):
         manager.register('mock_service2', MockService)
         service1 = manager.mock_service1
         service2 = manager.mock_service2
+        mock_call_tracker = mock.Mock()
+        mock_call_tracker.pause1 = service1.pause_func
+        mock_call_tracker.pause2 = service2.pause_func
         manager.pause_all()
+        self.assertEqual(
+            mock_call_tracker.mock_calls,
+            [mock.call.pause2(), mock.call.pause1()])
         self.assertEqual(service1.pause_func.call_count, 1)
         self.assertEqual(service2.pause_func.call_count, 1)
         self.assertEqual(service1.resume_func.call_count, 0)
@@ -314,8 +332,14 @@ class ServiceManagerTest(unittest.TestCase):
         manager.register('mock_service2', MockService)
         service1 = manager.mock_service1
         service2 = manager.mock_service2
+        mock_call_tracker = mock.Mock()
+        mock_call_tracker.resume1 = service1.resume_func
+        mock_call_tracker.resume2 = service2.resume_func
         manager.pause_all()
         manager.resume_all()
+        self.assertEqual(
+            mock_call_tracker.mock_calls,
+            [mock.call.resume1(), mock.call.resume2()])
         self.assertEqual(service1.pause_func.call_count, 1)
         self.assertEqual(service2.pause_func.call_count, 1)
         self.assertEqual(service1.resume_func.call_count, 1)


### PR DESCRIPTION
* Make sure the services start in the order they are registered in, and stop in the reverse order.
* Make sure logcat is the first service to be registered.
* Make sure logcat service is registered (not necessarily started) by default in AndroidDevice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/607)
<!-- Reviewable:end -->
