### PR TITLE
Set default logging values for test runner.

### DIFF
--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -311,6 +311,10 @@ class TestRunner(object):
         if not self._test_run_infos:
             raise Error('No tests to execute.')
 
+        if self._log_path is None:
+            raise Error(
+                'Must call `run` from within the `mobly_logger` context.')
+
         summary_writer = records.TestSummaryWriter(
             os.path.join(self._log_path, records.OUTPUT_FILE_SUMMARY))
         try:

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -28,6 +28,7 @@ from mobly import config_parser
 from mobly import logger
 from mobly import records
 from mobly import signals
+from mobly import utils
 
 
 class Error(Exception):
@@ -216,7 +217,15 @@ class TestRunner(object):
         self.results = records.TestResult()
         self._test_run_infos = []
 
-        self._log_path = None
+        # Set default logging values. Necessary if `run` is used outside of the
+        # `mobly_logger` context.
+        self._update_log_path()
+
+    def _update_log_path(self):
+        """Updates the logging values with the current timestamp."""
+        self._start_time = logger.get_log_file_timestamp()
+        self._log_path = os.path.join(self._log_dir, self._test_bed_name,
+                                      self._start_time)
 
     @contextlib.contextmanager
     def mobly_logger(self, alias='latest'):
@@ -230,9 +239,7 @@ class TestRunner(object):
         Yields:
             The host file path where the logs for the test run are stored.
         """
-        self._start_time = logger.get_log_file_timestamp()
-        self._log_path = os.path.join(self._log_dir, self._test_bed_name,
-                                      self._start_time)
+        self._update_log_path()
         logger.setup_test_logger(self._log_path,
                                  self._test_bed_name,
                                  alias=alias)
@@ -240,7 +247,6 @@ class TestRunner(object):
             yield self._log_path
         finally:
             logger.kill_test_logger(logging.getLogger())
-            self._log_path = None
 
     def add_test_class(self, config, test_class, tests=None, name_suffix=None):
         """Adds tests to the execution plan of this TestRunner.
@@ -311,9 +317,9 @@ class TestRunner(object):
         if not self._test_run_infos:
             raise Error('No tests to execute.')
 
-        if self._log_path is None:
-            raise Error(
-                'Must call `run` from within the `mobly_logger` context.')
+        # Ensure the log path exists. Necessary if `run` is used outside of the
+        # `mobly_logger` context.
+        utils.create_dir(self._log_path)
 
         summary_writer = records.TestSummaryWriter(
             os.path.join(self._log_path, records.OUTPUT_FILE_SUMMARY))

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -266,12 +266,11 @@ class TestRunnerTest(unittest.TestCase):
 
     def test_run_no_mobly_logger_context(self):
         tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
+        self.base_mock_test_config.controller_configs[
+            mock_controller.MOBLY_CONTROLLER_CONFIG_NAME] = '*'
         tr.add_test_class(self.base_mock_test_config,
                           integration_test.IntegrationTest)
-        with self.assertRaisesRegex(
-                test_runner.Error,
-                'Must call `run` from within the `mobly_logger` context.'):
-            tr.run()
+        tr.run()
 
     @mock.patch('mobly.test_runner._find_test_class',
                 return_value=type('SampleTest', (), {}))

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -264,6 +264,15 @@ class TestRunnerTest(unittest.TestCase):
         with self.assertRaisesRegex(test_runner.Error, 'No tests to execute.'):
             tr.run()
 
+    def test_run_no_mobly_logger_context(self):
+        tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
+        tr.add_test_class(self.base_mock_test_config,
+                          integration_test.IntegrationTest)
+        with self.assertRaisesRegex(
+                test_runner.Error,
+                'Must call `run` from within the `mobly_logger` context.'):
+            tr.run()
+
     @mock.patch('mobly.test_runner._find_test_class',
                 return_value=type('SampleTest', (), {}))
     @mock.patch('mobly.test_runner.config_parser.load_test_config_file',

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -148,6 +148,37 @@ class TestRunnerTest(unittest.TestCase):
         self.assertEqual(summary_entries[3]['Type'],
                          records.TestSummaryEntryType.SUMMARY.value)
 
+    def test_run(self):
+        tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
+        self.base_mock_test_config.controller_configs[
+            mock_controller.MOBLY_CONTROLLER_CONFIG_NAME] = '*'
+        with tr.mobly_logger():
+            tr.add_test_class(self.base_mock_test_config,
+                              integration_test.IntegrationTest)
+            tr.run()
+        results = tr.results.summary_dict()
+        self.assertEqual(results['Requested'], 1)
+        self.assertEqual(results['Executed'], 1)
+        self.assertEqual(results['Passed'], 1)
+        self.assertEqual(len(tr.results.executed), 1)
+        record = tr.results.executed[0]
+        self.assertEqual(record.test_class, 'IntegrationTest')
+
+    def test_run_without_mobly_logger_context(self):
+        tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
+        self.base_mock_test_config.controller_configs[
+            mock_controller.MOBLY_CONTROLLER_CONFIG_NAME] = '*'
+        tr.add_test_class(self.base_mock_test_config,
+                          integration_test.IntegrationTest)
+        tr.run()
+        results = tr.results.summary_dict()
+        self.assertEqual(results['Requested'], 1)
+        self.assertEqual(results['Executed'], 1)
+        self.assertEqual(results['Passed'], 1)
+        self.assertEqual(len(tr.results.executed), 1)
+        record = tr.results.executed[0]
+        self.assertEqual(record.test_class, 'IntegrationTest')
+
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy(1))
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
@@ -188,6 +219,7 @@ class TestRunnerTest(unittest.TestCase):
         self.assertEqual(results['Requested'], 2)
         self.assertEqual(results['Executed'], 2)
         self.assertEqual(results['Passed'], 2)
+        self.assertEqual(len(tr.results.executed), 2)
         # Tag of the test class defaults to the class name.
         record1 = tr.results.executed[0]
         record2 = tr.results.executed[1]
@@ -220,6 +252,7 @@ class TestRunnerTest(unittest.TestCase):
         self.assertEqual(results['Passed'], 1)
         self.assertEqual(results['Failed'], 1)
         self.assertEqual(tr.results.failed[0].details, '10 != 42')
+        self.assertEqual(len(tr.results.executed), 2)
         record1 = tr.results.executed[0]
         record2 = tr.results.executed[1]
         self.assertEqual(record1.test_class, 'IntegrationTest_FirstConfig')
@@ -263,14 +296,6 @@ class TestRunnerTest(unittest.TestCase):
         tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
         with self.assertRaisesRegex(test_runner.Error, 'No tests to execute.'):
             tr.run()
-
-    def test_run_no_mobly_logger_context(self):
-        tr = test_runner.TestRunner(self.log_dir, self.test_bed_name)
-        self.base_mock_test_config.controller_configs[
-            mock_controller.MOBLY_CONTROLLER_CONFIG_NAME] = '*'
-        tr.add_test_class(self.base_mock_test_config,
-                          integration_test.IntegrationTest)
-        tr.run()
 
     @mock.patch('mobly.test_runner._find_test_class',
                 return_value=type('SampleTest', (), {}))


### PR DESCRIPTION
If an end user calls run without calling mobly_logger, then test runner fails with:

```
tests/mobly/test_runner_test.py:273: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
mobly/test_runner.py:315: in run
    os.path.join(self._log_path, records.OUTPUT_FILE_SUMMARY))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

a = None, p = ('test_summary.yaml',), path = None, b = 'test_summary.yaml'

    def join(a, *p):
        """Join two or more pathname components, inserting '/' as needed.
        If any component is an absolute path, all previous path components
        will be discarded.  An empty last part will result in a path that
        ends with a separator."""
        path = a
        for b in p:
            if b.startswith('/'):
                path = b
>           elif path == '' or path.endswith('/'):
E           AttributeError: 'NoneType' object has no attribute 'endswith'

../lib/python2.7/posixpath.py:70: AttributeError
```

which is unhelpful...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/612)
<!-- Reviewable:end -->
