### PR TITLE
Remove context behavior of `base_test`

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -114,12 +114,6 @@ class BaseTestClass(object):
             class_name=self.TAG, controller_configs=configs.controller_configs)
         self.controller_configs = self._controller_manager.controller_configs
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        self._safe_exec_func(self.clean_up)
-
     def unpack_userparams(self,
                           req_param_names=None,
                           opt_param_names=None,

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -874,18 +874,3 @@ class BaseTestClass(object):
                 self.results.add_class_error(record)
                 self.summary_writer.dump(record.to_dict(),
                                          records.TestSummaryEntryType.RECORD)
-
-    def clean_up(self):
-        """.. deprecated:: 1.8.1
-
-        Use `teardown_class` instead.
-
-        A function that is executed upon completion of all tests selected in
-        the test class.
-
-        This function should clean up objects initialized in the constructor by
-        user.
-
-        Generally this should not be used as nothing should be instantiated
-        from the constructor of a test class.
-        """

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -190,10 +190,12 @@ class TestRunner(object):
         self.results: The test result object used to record the results of
             this test run.
     """
+
     class _TestRunInfo(object):
         """Identifies one test class to run, which tests to run, and config to
         run it with.
         """
+
         def __init__(self,
                      config,
                      test_class,
@@ -294,15 +296,15 @@ class TestRunner(object):
             test_class: class, test class to execute.
             tests: Optional list of test names within the class to execute.
         """
-        with test_class(config) as test_instance:
-            logging.debug('Executing test class "%s" with config: %s',
-                          test_class.__name__, config)
-            try:
-                cls_result = test_instance.run(tests)
-                self.results += cls_result
-            except signals.TestAbortAll as e:
-                self.results += e.results
-                raise e
+        test_instance = test_class(config)
+        logging.debug('Executing test class "%s" with config: %s',
+                      test_class.__name__, config)
+        try:
+            cls_result = test_instance.run(tests)
+            self.results += cls_result
+        except signals.TestAbortAll as e:
+            self.results += e.results
+            raise e
 
     def run(self):
         """Executes tests.


### PR DESCRIPTION
* Remove the context behavior of `base_test`, which has been a no-op.
* Remove deprecated `clean_up` method.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/616)
<!-- Reviewable:end -->
