### PR TITLE
Standardize filenames for logcat and bugreport.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -996,6 +996,7 @@ class AndroidDevice(object):
         full_out_path = os.path.join(br_path, filename)
         # in case device restarted, wait for adb interface to return
         self.wait_for_boot_completion()
+        self.log.debug('Start taking bugreport.')
         if new_br:
             out = self.adb.shell('bugreportz', timeout=timeout).decode('utf-8')
             if not out.startswith('OK'):
@@ -1008,8 +1009,7 @@ class AndroidDevice(object):
             self.adb.bugreport(' > "%s"' % full_out_path,
                                shell=True,
                                timeout=timeout)
-        self.log.info('Bugreport for %s taken at %s.', test_name,
-                      full_out_path)
+        self.log.debug('Bugreport taken at %s.', full_out_path)
         return full_out_path
 
     def run_iperf_client(self, server_host, extra_args=''):

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -960,8 +960,6 @@ class AndroidDevice(object):
 
         Args:
             test_name: Name of the test method that triggered this bug report.
-                If not set, then this will default to
-                android_device.DEFAULT_BUG_REPORT_NAME.
             begin_time: Timestamp of when the test started. If not set, then
                 this will default to the current time.
             timeout: float, the number of seconds to wait for bugreport to
@@ -970,11 +968,11 @@ class AndroidDevice(object):
                 should be saved.
 
         Returns:
-          A string containing the absolute path to the bug report on the host
-          machine.
+            A string that is the absolute path to the bug report on the host.
         """
-        if test_name is None:
-            test_name = DEFAULT_BUG_REPORT_NAME
+        prefix = DEFAULT_BUG_REPORT_NAME
+        if test_name:
+            prefix = '%s,%s' % (DEFAULT_BUG_REPORT_NAME, test_name)
         if begin_time is None:
             begin_time = mobly_logger.get_log_file_timestamp()
 
@@ -987,20 +985,17 @@ class AndroidDevice(object):
                 new_br = False
         except adb.AdbError:
             new_br = False
-        if destination:
-            br_path = utils.abs_path(destination)
-        else:
-            br_path = os.path.join(self.log_path, 'BugReports')
+
+        if destination is None:
+            destination = os.path.join(self.log_path, 'BugReports')
+        br_path = utils.abs_path(destination)
         utils.create_dir(br_path)
-        base_name = ',%s,%s.txt' % (begin_time, self._normalized_serial)
+        filename = self.generate_filename(prefix, begin_time, 'txt')
         if new_br:
-            base_name = base_name.replace('.txt', '.zip')
-        test_name_len = utils.MAX_FILENAME_LEN - len(base_name)
-        out_name = test_name[:test_name_len] + base_name
-        full_out_path = os.path.join(br_path, out_name.replace(' ', r'\ '))
+            filename = filename.replace('.txt', '.zip')
+        full_out_path = os.path.join(br_path, filename)
         # in case device restarted, wait for adb interface to return
         self.wait_for_boot_completion()
-        self.log.info('Taking bugreport for %s.', test_name)
         if new_br:
             out = self.adb.shell('bugreportz', timeout=timeout).decode('utf-8')
             if not out.startswith('OK'):

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -78,6 +78,7 @@ def list_adb_devices():
 
 class MockAdbProxy(object):
     """Mock class that swaps out calls to adb with mock calls."""
+
     def __init__(self,
                  serial='',
                  fail_br=False,
@@ -138,9 +139,9 @@ class MockAdbProxy(object):
         return self.mock_properties
 
     def bugreport(self, args, shell=False, timeout=None):
-        expected = os.path.join(logging.log_path,
-                                'AndroidDevice%s' % self.serial, 'BugReports',
-                                'test_something,sometime,%s' % self.serial)
+        expected = os.path.join(
+            logging.log_path, 'AndroidDevice%s' % self.serial, 'BugReports',
+            'bugreport,test_something,%s,fakemodel,sometime' % self.serial)
         if expected not in args:
             raise Error('"Expected "%s", got "%s"' % (expected, args))
 
@@ -148,6 +149,7 @@ class MockAdbProxy(object):
         """All calls to the none-existent functions in adb proxy would
         simply return the adb command string.
         """
+
         def adb_call(*args, **kwargs):
             arg_str = ' '.join(str(elem) for elem in args)
             return arg_str
@@ -157,6 +159,7 @@ class MockAdbProxy(object):
 
 class MockFastbootProxy(object):
     """Mock class that swaps out calls to adb with mock calls."""
+
     def __init__(self, serial):
         self.serial = serial
 

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -588,7 +588,8 @@ class AndroidDeviceTest(unittest.TestCase):
         create_dir_mock.assert_called_with(expected_path)
         self.assertEqual(
             output_path,
-            os.path.join(expected_path, 'test_something,sometime,1.zip'))
+            os.path.join(expected_path,
+                         'bugreport,test_something,1,fakemodel,sometime.zip'))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy('1',
@@ -627,7 +628,7 @@ class AndroidDeviceTest(unittest.TestCase):
         self.assertEqual(
             output_path,
             os.path.join(expected_path,
-                         'bugreport,07-22-2019_17-53-34-450,1.zip'))
+                         'bugreport,1,fakemodel,07-22-2019_17-53-34-450.zip'))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy('1'))
@@ -648,8 +649,10 @@ class AndroidDeviceTest(unittest.TestCase):
         create_dir_mock.assert_called_with(expected_path)
         self.assertEqual(
             output_path,
-            os.path.join(expected_path,
-                         'test_something,07-22-2019_17-53-34-450,1.zip'))
+            os.path.join(
+                expected_path,
+                'bugreport,test_something,1,fakemodel,07-22-2019_17-53-34-450.zip'
+            ))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy(1))
@@ -666,8 +669,8 @@ class AndroidDeviceTest(unittest.TestCase):
                                      'BugReports')
         create_dir_mock.assert_called_with(expected_path)
         self.assertEqual(
-            output_path, os.path.join(expected_path,
-                                      'bugreport,sometime,1.zip'))
+            output_path,
+            os.path.join(expected_path, 'bugreport,1,fakemodel,sometime.zip'))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy(1))
@@ -685,7 +688,8 @@ class AndroidDeviceTest(unittest.TestCase):
         create_dir_mock.assert_called_with(expected_path)
         self.assertEqual(
             output_path,
-            os.path.join(expected_path, 'test_something,sometime,1.zip'))
+            os.path.join(expected_path,
+                         'bugreport,test_something,1,fakemodel,sometime.zip'))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy('1'))
@@ -704,7 +708,8 @@ class AndroidDeviceTest(unittest.TestCase):
         create_dir_mock.assert_called_with(expected_path)
         self.assertEqual(
             output_path,
-            os.path.join(expected_path, 'test_something,sometime,1.zip'))
+            os.path.join(expected_path,
+                         'bugreport,test_something,1,fakemodel,sometime.zip'))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy(
@@ -728,7 +733,8 @@ class AndroidDeviceTest(unittest.TestCase):
         create_dir_mock.assert_called_with(expected_path)
         self.assertEqual(
             output_path,
-            os.path.join(expected_path, 'test_something,sometime,1.txt'))
+            os.path.join(expected_path,
+                         'bugreport,test_something,1,fakemodel,sometime.txt'))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy('1'))


### PR DESCRIPTION
Use the new filename generation func for consistent names in output files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/635)
<!-- Reviewable:end -->
