### PR TITLE
Fix take_bug_report int issue.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -345,7 +345,6 @@ def get_devices(ads, **kwargs):
     Raises:
         Error: No devices are matched.
     """
-
     def _get_device_filter(ad):
         for k, v in kwargs.items():
             if not hasattr(ad, k):
@@ -450,7 +449,6 @@ class AndroidDevice(object):
         services: ServiceManager, the manager of long-running services on the
             device.
     """
-
     def __init__(self, serial=''):
         self._serial = str(serial)
         # logging.log_path only exists when this is used in an Mobly test run.
@@ -990,7 +988,7 @@ class AndroidDevice(object):
             destination = os.path.join(self.log_path, 'BugReports')
         br_path = utils.abs_path(destination)
         utils.create_dir(br_path)
-        filename = self.generate_filename(prefix, begin_time, 'txt')
+        filename = self.generate_filename(prefix, str(begin_time), 'txt')
         if new_br:
             filename = filename.replace('.txt', '.zip')
         full_out_path = os.path.join(br_path, filename)
@@ -1117,7 +1115,6 @@ class AndroidDeviceLoggerAdapter(logging.LoggerAdapter):
     Then each log line added by my_log will have a prefix
     '[AndroidDevice|<tag>]'
     """
-
     def process(self, msg, kwargs):
         msg = _DEBUG_PREFIX_TEMPLATE % (self.extra['tag'], msg)
         return (msg, kwargs)

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -45,7 +45,6 @@ class AndroidDeviceTest(unittest.TestCase):
     """This test class has unit tests for the implementation of everything
     under mobly.controllers.android_device.
     """
-
     def setUp(self):
         # Set log_path to logging since mobly logger setup is not called.
         if not hasattr(logging, 'log_path'):
@@ -229,6 +228,16 @@ class AndroidDeviceTest(unittest.TestCase):
             test_name='test_something',
             begin_time='sometime',
             destination=None)
+
+    def test_take_bug_reports_with_int_begin_time(self):
+        ads = mock_android_device.get_mock_ads(3)
+        android_device.take_bug_reports(ads, 'test_something', 123)
+        ads[0].take_bug_report.assert_called_once_with(
+            test_name='test_something', begin_time='123', destination=None)
+        ads[1].take_bug_report.assert_called_once_with(
+            test_name='test_something', begin_time='123', destination=None)
+        ads[2].take_bug_report.assert_called_once_with(
+            test_name='test_something', begin_time='123', destination=None)
 
     @mock.patch('mobly.logger.get_log_file_timestamp')
     def test_take_bug_reports_with_none_values(self,
@@ -671,6 +680,24 @@ class AndroidDeviceTest(unittest.TestCase):
         self.assertEqual(
             output_path,
             os.path.join(expected_path, 'bugreport,1,fakemodel,sometime.zip'))
+
+    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
+                return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+                return_value=mock_android_device.MockFastbootProxy(1))
+    @mock.patch('mobly.utils.create_dir')
+    def test_AndroidDevice_take_bug_report_with_int_begin_time(
+            self, create_dir_mock, FastbootProxy, MockAdbProxy):
+        mock_serial = '1'
+        ad = android_device.AndroidDevice(serial=mock_serial)
+        output_path = ad.take_bug_report(begin_time=123)
+        expected_path = os.path.join(logging.log_path,
+                                     'AndroidDevice%s' % ad.serial,
+                                     'BugReports')
+        create_dir_mock.assert_called_with(expected_path)
+        self.assertEqual(
+            output_path,
+            os.path.join(expected_path, 'bugreport,1,fakemodel,123.zip'))
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy(1))


### PR DESCRIPTION
take_bug_reports works with string times (i.e. record.begin_time), take_bug_report should also to be consistent

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/638)
<!-- Reviewable:end -->
