### PR TITLE
Guarantees the test stage end message is always logged.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -400,10 +400,12 @@ class BaseTestClass(object):
         logging.debug(
             TEST_STAGE_BEGIN_LOG_TEMPLATE.format(parent_token=parent_token,
                                                  child_token=stage_name))
-        yield
-        logging.debug(
-            TEST_STAGE_END_LOG_TEMPLATE.format(parent_token=parent_token,
-                                               child_token=stage_name))
+        try:
+            yield
+        finally:
+            logging.debug(
+                TEST_STAGE_END_LOG_TEMPLATE.format(parent_token=parent_token,
+                                                   child_token=stage_name))
 
     def _setup_test(self, test_name):
         """Proxy function to guarantee the base implementation of setup_test is

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -2128,6 +2128,23 @@ class BaseTestTest(unittest.TestCase):
                 def not_a_test(self):
                     pass
 
+    def test_log_stage_always_logs_end_statement(self):
+        instance = base_test.BaseTestClass(mock.Mock())
+        instance.current_test_info = mock.Mock()
+        instance.current_test_info.name = 'TestClass'
+
+        class RecoverableError(Exception):
+            pass
+
+        with mock.patch('mobly.base_test.logging') as logging_patch:
+            try:
+                with instance._log_test_stage('stage'):
+                    raise RecoverableError('Force stage to fail.')
+            except RecoverableError:
+                pass
+
+        logging_patch.debug.assert_called_with('[TestClass]#stage <<< END <<<')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Without this try/finally statement, a raised error within the context
causes the ending log line to not be logged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/639)
<!-- Reviewable:end -->
