### PR TITLE
Allow overriding props with setters via config in `AndroidDevice`.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -336,6 +336,7 @@ def get_devices(ads, **kwargs):
     Raises:
         Error: No devices are matched.
     """
+
     def _get_device_filter(ad):
         for k, v in kwargs.items():
             if not hasattr(ad, k):
@@ -437,6 +438,7 @@ class AndroidDevice(object):
         services: ServiceManager, the manager of long-running services on the
             device.
     """
+
     def __init__(self, serial=''):
         self._serial = str(serial)
         # logging.log_path only exists when this is used in an Mobly test run.
@@ -839,7 +841,7 @@ class AndroidDevice(object):
             Error: The config is trying to overwrite an existing attribute.
         """
         for k, v in config.items():
-            if hasattr(self, k):
+            if hasattr(self, k) and k not in _ANDROID_DEVICE_SETTABLE_PROPS:
                 raise DeviceError(
                     self,
                     ('Attribute %s already exists with value %s, cannot set '
@@ -1089,6 +1091,11 @@ class AndroidDevice(object):
         return self.__getattribute__(name)
 
 
+# Properties in AndroidDevice that have setters.
+# This line has to live below the AndroidDevice code.
+_ANDROID_DEVICE_SETTABLE_PROPS = utils.get_settable_properties(AndroidDevice)
+
+
 class AndroidDeviceLoggerAdapter(logging.LoggerAdapter):
     """A wrapper class that adds a prefix to each log line.
 
@@ -1103,6 +1110,7 @@ class AndroidDeviceLoggerAdapter(logging.LoggerAdapter):
     Then each log line added by my_log will have a prefix
     '[AndroidDevice|<tag>]'
     """
+
     def process(self, msg, kwargs):
         msg = _DEBUG_PREFIX_TEMPLATE % (self.extra['tag'], msg)
         return (msg, kwargs)

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -549,6 +549,21 @@ def cli_cmd_to_string(args):
     return ' '.join([pipes.quote(arg) for arg in args])
 
 
+def get_settable_properties(cls):
+    """Gets the settable properties of a class.
+
+    Only returns the explicitly defined properties with setters.
+
+    Args:
+        cls: A class in Python.
+    """
+    results = []
+    for attr, value in vars(cls).items():
+        if isinstance(value, property) and value.fset is not None:
+            results.append(attr)
+    return results
+
+
 def find_subclasses_in_module(base_classes, module):
     """Finds the subclasses of the given classes in the given module.
 

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -45,6 +45,7 @@ class AndroidDeviceTest(unittest.TestCase):
     """This test class has unit tests for the implementation of everything
     under mobly.controllers.android_device.
     """
+
     def setUp(self):
         # Set log_path to logging since mobly logger setup is not called.
         if not hasattr(logging, 'log_path'):
@@ -274,6 +275,39 @@ class AndroidDeviceTest(unittest.TestCase):
         self.assertEqual(ad.log_path, expected_lp)
         self.assertIsNotNone(ad.services.logcat)
         self.assertIsNotNone(ad.services.snippets)
+
+    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
+                return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+                return_value=mock_android_device.MockFastbootProxy(1))
+    @mock.patch('mobly.utils.create_dir')
+    def test_AndroidDevice_load_config(self, create_dir_mock, FastbootProxy,
+                                       MockAdbProxy):
+        mock_serial = '1'
+        config = {
+            'space': 'the final frontier',
+            'number': 1,
+            'debug_tag': 'my_tag'
+        }
+        ad = android_device.AndroidDevice(serial=mock_serial)
+        ad.load_config(config)
+        self.assertEqual(ad.space, 'the final frontier')
+        self.assertEqual(ad.number, 1)
+        self.assertEqual(ad.debug_tag, 'my_tag')
+
+    @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
+                return_value=mock_android_device.MockAdbProxy(1))
+    @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+                return_value=mock_android_device.MockFastbootProxy(1))
+    @mock.patch('mobly.utils.create_dir')
+    def test_AndroidDevice_load_config_dup(self, create_dir_mock,
+                                           FastbootProxy, MockAdbProxy):
+        mock_serial = '1'
+        config = {'serial': 'new_serial'}
+        ad = android_device.AndroidDevice(serial=mock_serial)
+        with self.assertRaisesRegex(android_device.DeviceError,
+                                    'Attribute serial already exists with'):
+            ad.load_config(config)
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy('1'))

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -43,6 +43,7 @@ class UtilsTest(unittest.TestCase):
     """This test class has unit tests for the implementation of everything
     under mobly.utils.
     """
+
     def setUp(self):
         system = platform.system()
         self.tmp_dir = tempfile.mkdtemp()
@@ -246,6 +247,30 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(utils.cli_cmd_to_string(cmd), '\'"adb"\' \'a b\' c//')
         cmd = 'adb -s meme do something ab_cd'
         self.assertEqual(utils.cli_cmd_to_string(cmd), cmd)
+
+    def test_get_settable_properties(self):
+        class SomeClass(object):
+            regular_attr = 'regular_attr'
+            _foo = 'foo'
+            _bar = 'bar'
+
+            @property
+            def settable_prop(self):
+                return self._foo
+
+            @settable_prop.setter
+            def settable_prop(self, new_foo):
+                self._foo = new_foo
+
+            @property
+            def readonly_prop(self):
+                return self._bar
+
+            def func(self):
+                """Func should not be considered as a settable prop."""
+
+        actual = utils.get_settable_properties(SomeClass)
+        self.assertEqual(actual, ['settable_prop'])
 
     def test_find_subclasses_in_module_when_one_subclass(self):
         subclasses = utils.find_subclasses_in_module([base_test.BaseTestClass],


### PR DESCRIPTION
This enables users to set props like `debug_tag` in testbed configs.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/644)
<!-- Reviewable:end -->
