### PR TITLE
Change test case filter to use callable() instead of inspect.ismethod()

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -737,7 +737,7 @@ class BaseTestClass(object):
             A list of strings, each is a test method name.
         """
         test_names = []
-        for name, _ in inspect.getmembers(self, inspect.ismethod):
+        for name, _ in inspect.getmembers(self, callable):
             if name.startswith('test_'):
                 test_names.append(name)
         return test_names + list(self._generated_test_table.keys())


### PR DESCRIPTION
There are several test decorators in ACTS that generate functions from bound methods. Calling inspect.ismethod() on these decorated tests would return False, even though they are valid test cases. Using callable() instead would allow these tests to be included.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/648)
<!-- Reviewable:end -->
