### PR TITLE
Defaults the controller and user_params to empty dictionaries in TestRunConfig.

### DIFF
--- a/mobly/config_parser.py
+++ b/mobly/config_parser.py
@@ -182,8 +182,8 @@ class TestRunConfig(object):
         # Deprecated, use 'testbed_name'
         self.test_bed_name = None
         self.testbed_name = None
-        self.controller_configs = None
-        self.user_params = None
+        self.controller_configs = {}
+        self.user_params = {}
         self.summary_writer = None
         self.test_class_name_suffix = None
 

--- a/tests/mobly/config_parser_test.py
+++ b/tests/mobly/config_parser_test.py
@@ -61,6 +61,20 @@ class OutputTest(unittest.TestCase):
         self.assertNotIn('summary_writer', str(config))
         self.assertNotIn('register_controller', str(config))
 
+    def test_run_config_controller_configs_is_already_initialized(self):
+        config = config_parser.TestRunConfig()
+        expected_value = 'SOME_VALUE'
+        self.assertEqual(
+            config.controller_configs.get('NON_EXISTENT_KEY', expected_value),
+            expected_value)
+
+    def test_run_config_user_params_is_already_initialized(self):
+        config = config_parser.TestRunConfig()
+        expected_value = 'SOME_VALUE'
+        self.assertEqual(
+            config.user_params.get('NON_EXISTENT_KEY', expected_value),
+            expected_value)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Defaults the controller and user_params to empty dictionaries in TestRunConfig.

These defaults prevent users from needing to check if they are None
first, in case the runner left these values unset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/654)
<!-- Reviewable:end -->
