### PR TITLE
Change MISMATCHED_API_ID from 'Mismatched API id.' to 'RPC request-re…

### DIFF
--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -90,7 +90,7 @@ class ProtocolError(Error):
     """Raised when there is some error in exchanging data with server."""
     NO_RESPONSE_FROM_HANDSHAKE = 'No response from handshake.'
     NO_RESPONSE_FROM_SERVER = 'No response from server.'
-    MISMATCHED_API_ID = 'Mismatched API id.'
+    MISMATCHED_API_ID = 'RPC request-response ID mismatch.'
 
 
 class JsonRpcCommand(object):


### PR DESCRIPTION
…sponse ID mismatch.' for clarity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/657)
<!-- Reviewable:end -->
