### PR TITLE
Rewrite logcat's create_output_excerpts to avoid dangling excerpts.

### DIFF
--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -97,10 +97,11 @@ class LogcatTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
     @mock.patch('mobly.logger.get_log_file_timestamp')
-    def test_start_and_stop(self, get_timestamp_mock, stop_proc_mock,
-                            start_proc_mock, create_dir_mock, FastbootProxy,
-                            MockAdbProxy):
+    def test_start_and_stop(self, get_timestamp_mock, open_logcat_mock,
+                            stop_proc_mock, start_proc_mock, create_dir_mock,
+                            FastbootProxy, MockAdbProxy):
         """Verifies the steps of collecting adb logcat on an AndroidDevice
         object, including various function calls and the expected behaviors of
         the calls.
@@ -139,12 +140,13 @@ class LogcatTest(unittest.TestCase):
     @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
                 return_value=mock_android_device.MockFastbootProxy('1'))
     @mock.patch('mobly.utils.create_dir')
-    @mock.patch('io.open')
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
-    def test_update_config(self, stop_proc_mock, start_proc_mock, io_mock,
-                           create_dir_mock, FastbootProxy, MockAdbProxy):
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
+    def test_update_config(self, open_logcat_mock, stop_proc_mock,
+                           start_proc_mock, create_dir_mock, FastbootProxy,
+                           MockAdbProxy):
         mock_serial = '1'
         ad = android_device.AndroidDevice(serial=mock_serial)
         logcat_service = logcat.Logcat(ad)
@@ -173,9 +175,10 @@ class LogcatTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
-    def test_update_config_while_running(self, stop_proc_mock, start_proc_mock,
-                                         create_dir_mock, FastbootProxy,
-                                         MockAdbProxy):
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
+    def test_update_config_while_running(self, open_logcat_mock, stop_proc_mock,
+                                         start_proc_mock, create_dir_mock,
+                                         FastbootProxy, MockAdbProxy):
         mock_serial = '1'
         ad = android_device.AndroidDevice(serial=mock_serial)
         logcat_service = logcat.Logcat(ad)
@@ -197,12 +200,13 @@ class LogcatTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
     @mock.patch(
         'mobly.controllers.android_device_lib.services.logcat.Logcat.clear_adb_log',
         return_value=mock_android_device.MockAdbProxy('1'))
-    def test_pause_and_resume(self, clear_adb_mock, stop_proc_mock,
-                              start_proc_mock, create_dir_mock, FastbootProxy,
-                              MockAdbProxy):
+    def test_pause_and_resume(self, clear_adb_mock, open_logcat_mock,
+                              stop_proc_mock, start_proc_mock, create_dir_mock,
+                              FastbootProxy, MockAdbProxy):
         mock_serial = '1'
         ad = android_device.AndroidDevice(serial=mock_serial)
         logcat_service = logcat.Logcat(ad, logcat.Config(clear_log=True))
@@ -237,7 +241,10 @@ class LogcatTest(unittest.TestCase):
         mock_serial = '1'
         ad = android_device.AndroidDevice(serial=mock_serial)
         logcat_service = logcat.Logcat(ad)
-        logcat_service.start()
+        logcat_service._start()
+        with open(logcat_service.adb_logcat_file_path, 'a') as f:
+            f.write('')
+        logcat_service._open_logcat_file()
         FILE_CONTENT = 'Some log.\n'
         with open(logcat_service.adb_logcat_file_path, 'a') as f:
             f.write(FILE_CONTENT)
@@ -278,11 +285,12 @@ class LogcatTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
     @mock.patch('mobly.logger.get_log_file_timestamp')
     def test_take_logcat_with_extra_params(self, get_timestamp_mock,
-                                           stop_proc_mock, start_proc_mock,
-                                           create_dir_mock, FastbootProxy,
-                                           MockAdbProxy):
+                                           open_logcat_mock, stop_proc_mock,
+                                           start_proc_mock, create_dir_mock,
+                                           FastbootProxy, MockAdbProxy):
         """Verifies the steps of collecting adb logcat on an AndroidDevice
         object, including various function calls and the expected behaviors of
         the calls.
@@ -328,10 +336,12 @@ class LogcatTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
     @mock.patch('mobly.logger.get_log_line_timestamp',
                 return_value=MOCK_ADB_LOGCAT_END_TIME)
-    def test_cat_adb_log(self, mock_timestamp_getter, stop_proc_mock,
-                         start_proc_mock, FastbootProxy, MockAdbProxy):
+    def test_cat_adb_log(self, mock_timestamp_getter, open_logcat_mock,
+                         stop_proc_mock, start_proc_mock, FastbootProxy,
+                         MockAdbProxy):
         """Verifies that AndroidDevice.cat_adb_log loads the correct adb log
         file, locates the correct adb log lines within the given time range,
         and writes the lines to the correct output file.
@@ -367,11 +377,13 @@ class LogcatTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
     @mock.patch('mobly.logger.get_log_line_timestamp',
                 return_value=MOCK_ADB_LOGCAT_END_TIME)
     def test_cat_adb_log_with_unicode(self, mock_timestamp_getter,
-                                      stop_proc_mock, start_proc_mock,
-                                      FastbootProxy, MockAdbProxy):
+                                      open_logcat_mock, stop_proc_mock,
+                                      start_proc_mock, FastbootProxy,
+                                      MockAdbProxy):
         """Verifies that AndroidDevice.cat_adb_log loads the correct adb log
         file, locates the correct adb log lines within the given time range,
         and writes the lines to the correct output file.

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -242,8 +242,12 @@ class LogcatTest(unittest.TestCase):
         ad = android_device.AndroidDevice(serial=mock_serial)
         logcat_service = logcat.Logcat(ad)
         logcat_service._start()
+        # Generate logs before the file pointer is created.
+        # This message will not be captured in the excerpt.
+        NOT_IN_EXCERPT = 'Not in excerpt.\n'
         with open(logcat_service.adb_logcat_file_path, 'a') as f:
-            f.write('')
+            f.write(NOT_IN_EXCERPT)
+        # With the file pointer created, generate logs and make an excerpt.
         logcat_service._open_logcat_file()
         FILE_CONTENT = 'Some log.\n'
         with open(logcat_service.adb_logcat_file_path, 'a') as f:
@@ -259,6 +263,7 @@ class LogcatTest(unittest.TestCase):
         self.assertEqual(actual_path1, expected_path1)
         self.assertTrue(os.path.exists(expected_path1))
         self.AssertFileContains(FILE_CONTENT, expected_path1)
+        self.AssertFileDoesNotContain(NOT_IN_EXCERPT, expected_path1)
         # Generate some new logs and do another excerpt.
         FILE_CONTENT = 'Some more logs!!!\n'
         with open(logcat_service.adb_logcat_file_path, 'a') as f:

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -855,9 +855,10 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
     def test_AndroidDevice_change_log_path_with_service(
-            self, stop_proc_mock, start_proc_mock, creat_dir_mock,
-            FastbootProxy, MockAdbProxy):
+            self, open_logcat_mock, stop_proc_mock, start_proc_mock,
+            creat_dir_mock, FastbootProxy, MockAdbProxy):
         ad = android_device.AndroidDevice(serial='1')
         ad.services.logcat.start()
         new_log_path = tempfile.mkdtemp()
@@ -911,9 +912,10 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
     def test_AndroidDevice_update_serial_with_service_running(
-            self, stop_proc_mock, start_proc_mock, creat_dir_mock,
-            FastbootProxy, MockAdbProxy):
+            self, open_logcat_mock, stop_proc_mock, start_proc_mock,
+            creat_dir_mock, FastbootProxy, MockAdbProxy):
         ad = android_device.AndroidDevice(serial='1')
         ad.services.logcat.start()
         expected_msg = '.* Cannot change device serial number when there is service running.'
@@ -1053,7 +1055,8 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch(
         'mobly.controllers.android_device_lib.snippet_client.SnippetClient')
     @mock.patch('mobly.utils.get_available_host_port')
-    def test_AndroidDevice_snippet_cleanup(self, MockGetPort,
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
+    def test_AndroidDevice_snippet_cleanup(self, open_logcat_mock, MockGetPort,
                                            MockSnippetClient, MockFastboot,
                                            MockAdbProxy):
         ad = android_device.AndroidDevice(serial='1')
@@ -1093,9 +1096,11 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
-    def test_AndroidDevice_handle_usb_disconnect(self, stop_proc_mock,
-                                                 start_proc_mock,
-                                                 FastbootProxy, MockAdbProxy):
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
+    def test_AndroidDevice_handle_usb_disconnect(self, open_logcat_mock,
+                                                 stop_proc_mock,
+                                                 start_proc_mock, FastbootProxy,
+                                                 MockAdbProxy):
         class MockService(base_service.BaseService):
             def __init__(self, device, configs=None):
                 self._alive = False
@@ -1137,8 +1142,10 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
-    def test_AndroidDevice_handle_reboot(self, stop_proc_mock, start_proc_mock,
-                                         FastbootProxy, MockAdbProxy):
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
+    def test_AndroidDevice_handle_reboot(self, open_logcat_mock, stop_proc_mock,
+                                         start_proc_mock, FastbootProxy,
+                                         MockAdbProxy):
         class MockService(base_service.BaseService):
             def __init__(self, device, configs=None):
                 self._alive = False
@@ -1180,9 +1187,10 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
     def test_AndroidDevice_handle_reboot_changes_build_info(
-            self, stop_proc_mock, start_proc_mock, FastbootProxy,
-            MockAdbProxy):
+            self, open_logcat_mock, stop_proc_mock, start_proc_mock,
+            FastbootProxy, MockAdbProxy):
         ad = android_device.AndroidDevice(serial='1')
         with ad.handle_reboot():
             ad.adb.mock_properties['ro.build.type'] = 'user'
@@ -1199,9 +1207,10 @@ class AndroidDeviceTest(unittest.TestCase):
     @mock.patch('mobly.utils.start_standing_subprocess',
                 return_value='process')
     @mock.patch('mobly.utils.stop_standing_subprocess')
+    @mock.patch.object(logcat.Logcat, '_open_logcat_file')
     def test_AndroidDevice_handle_reboot_changes_build_info_with_caching(
-            self, stop_proc_mock, start_proc_mock, FastbootProxy,
-            MockAdbProxy):
+            self, open_logcat_mock, stop_proc_mock, start_proc_mock,
+            FastbootProxy, MockAdbProxy):
         ad = android_device.AndroidDevice(serial='1')  # Call getprops 1.
         rootable_states = [ad.is_rootable]
         with ad.handle_reboot():


### PR DESCRIPTION
Instead of clearing the logcat buffer and restarting the logcat process each time an
excerpt is taken, the excerpt lines are copied over from a continuously streamed file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/658)
<!-- Reviewable:end -->
