### PR TITLE
Properly handle service re-start and resume in `AndroidDevice`.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -649,6 +649,7 @@ class AndroidDevice(object):
 
         For sample usage, see self.reboot().
         """
+        live_service_names = self.services.list_live_services()
         self.services.stop_all()
         # On rooted devices, system properties may change on reboot, so disable
         # the `build_info` cache by setting `_is_rebooting` to True and
@@ -676,7 +677,7 @@ class AndroidDevice(object):
             self._is_rebooting = False
             if self.is_rootable:
                 self.root_adb()
-        self.services.start_all()
+        self.services.start_services(live_service_names)
 
     @contextlib.contextmanager
     def handle_usb_disconnect(self):
@@ -725,11 +726,12 @@ class AndroidDevice(object):
                   # context
                   ad.adb.wait_for_device(timeout=SOME_TIMEOUT)
         """
+        live_service_names = self.services.list_live_services()
         self.services.pause_all()
         try:
             yield
         finally:
-            self.services.resume_all()
+            self.services.resume_services(live_service_names)
 
     @property
     def build_info(self):

--- a/mobly/controllers/android_device_lib/service_manager.py
+++ b/mobly/controllers/android_device_lib/service_manager.py
@@ -180,7 +180,8 @@ class ServiceManager(object):
     def start_services(self, service_alises):
         """Starts the specified services.
 
-        Services will be resumed in the order specified by the input list.
+        Services will be started in the order specified by the input list.
+        No-op for services that are already running.
 
         Args:
             service_alises: list of strings, the aliases of services to start.
@@ -234,6 +235,7 @@ class ServiceManager(object):
         """Resumes the specified services.
 
         Services will be resumed in the order specified by the input list.
+        No-op for services that are already running.
 
         Args:
             service_alises: list of strings, the names of services to start.


### PR DESCRIPTION
Only re-start and resume the services that were alive before the reboot/disconnect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/662)
<!-- Reviewable:end -->
