### PR TITLE
Do not check if a service is `alive` in `resume_services`.

### DIFF
--- a/mobly/controllers/android_device_lib/service_manager.py
+++ b/mobly/controllers/android_device_lib/service_manager.py
@@ -235,7 +235,6 @@ class ServiceManager(object):
         """Resumes the specified services.
 
         Services will be resumed in the order specified by the input list.
-        No-op for services that are already running.
 
         Args:
             service_alises: list of strings, the names of services to start.

--- a/mobly/controllers/android_device_lib/service_manager.py
+++ b/mobly/controllers/android_device_lib/service_manager.py
@@ -247,8 +247,7 @@ class ServiceManager(object):
                     'No service is registered under the name "%s", cannot resume.'
                     % name)
             service = self._service_objects[name]
-            if not service.is_alive:
-                service.resume()
+            service.resume()
 
     def __getattr__(self, name):
         """Syntactic sugar to enable direct access of service objects by alias.


### PR DESCRIPTION
A paused service may still be alive, which means we should still call `resume` on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/663)
<!-- Reviewable:end -->
