### PR TITLE
Use errno instead of os.errno in utils.create_dir

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -17,6 +17,7 @@ from past.builtins import basestring
 import base64
 import concurrent.futures
 import datetime
+import errno
 import inspect
 import io
 import logging
@@ -100,7 +101,7 @@ def create_dir(path):
             os.makedirs(full_path)
         except OSError as e:
             # ignore the error for dir already exist.
-            if e.errno != os.errno.EEXIST:
+            if e.errno != errno.EEXIST:
                 raise
 
 


### PR DESCRIPTION
os.errno is no longer supported in Python 3.7+, resulting in attribute errors during exception handling in utils.create_dir. Replacing this with the builtin errno module would ensure compatibility with all supported Python versions (3.4.1+).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/667)
<!-- Reviewable:end -->
