### PR TITLE
Fix adb service can NOT start in mobly when debugging with Intelij IDEA on gLinux.

### DIFF
--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -292,7 +292,7 @@ class Logcat(base_service.BaseService):
             logcat_file_path = os.path.join(self._ad.log_path, f_name)
             self.adb_logcat_file_path = logcat_file_path
         utils.create_dir(os.path.dirname(self.adb_logcat_file_path))
-        cmd = '"%s" -s %s logcat -v threadtime -T 1 %s >> "%s"' % (
+        cmd = '\'%s\' -s %s logcat -v threadtime -T 1 %s >> \'%s\'' % (
             adb.ADB, self._ad.serial, self._config.logcat_params,
             self.adb_logcat_file_path)
         process = utils.start_standing_subprocess(cmd, shell=True)

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -117,9 +117,9 @@ class LogcatTest(unittest.TestCase):
             logging.log_path, 'AndroidDevice%s' % ad.serial,
             'logcat,%s,fakemodel,123.txt' % ad.serial)
         create_dir_mock.assert_called_with(os.path.dirname(expected_log_path))
-        adb_cmd = '"adb" -s %s logcat -v threadtime -T 1  >> %s'
+        adb_cmd = '\'adb\' -s %s logcat -v threadtime -T 1  >> %s'
         start_proc_mock.assert_called_with(
-            adb_cmd % (ad.serial, '"%s"' % expected_log_path), shell=True)
+            adb_cmd % (ad.serial, '\'%s\'' % expected_log_path), shell=True)
         self.assertEqual(logcat_service.adb_logcat_file_path,
                          expected_log_path)
         expected_msg = (
@@ -160,8 +160,8 @@ class LogcatTest(unittest.TestCase):
         logcat_service.start()
         self.assertTrue(logcat_service._adb_logcat_process)
         create_dir_mock.assert_has_calls([mock.call('some/path')])
-        expected_adb_cmd = ('"adb" -s 1 logcat -v threadtime -T 1 -a -b -c >> '
-                            '"some/path/log.txt"')
+        expected_adb_cmd = ('\'adb\' -s 1 logcat -v threadtime -T 1 -a -b -c >> '
+                            '\'some/path/log.txt\'')
         start_proc_mock.assert_called_with(expected_adb_cmd, shell=True)
         self.assertEqual(logcat_service.adb_logcat_file_path,
                          'some/path/log.txt')
@@ -313,9 +313,9 @@ class LogcatTest(unittest.TestCase):
             logging.log_path, 'AndroidDevice%s' % ad.serial,
             'logcat,%s,fakemodel,123.txt' % ad.serial)
         create_dir_mock.assert_called_with(os.path.dirname(expected_log_path))
-        adb_cmd = '"adb" -s %s logcat -v threadtime -T 1 -b radio >> %s'
+        adb_cmd = '\'adb\' -s %s logcat -v threadtime -T 1 -b radio >> %s'
         start_proc_mock.assert_called_with(
-            adb_cmd % (ad.serial, '"%s"' % expected_log_path), shell=True)
+            adb_cmd % (ad.serial, '\'%s\'' % expected_log_path), shell=True)
         self.assertEqual(logcat_service.adb_logcat_file_path,
                          expected_log_path)
         logcat_service.stop()


### PR DESCRIPTION
When 'debugging' Mobly PY test with Intelij IDEA on gLinux,
logcat service in Mobly can NOT start with the following error
  b'/bin/sh: /path/to/adb -s 9C041FQC200408 logcat -v threadtime -T 1  >>
  /path/to/logcat,9C041FQC200408,sunfish,03-17-2020_10-29-23-299.txt: No such file or directory\n'
and end the test with 'Timeout while waiting for logcat file to be created.' error.
(mobly.controllers.android_device_lib.services.logcat.Error)
But the same Mobly PY test can run correctly with normal python run or
'run' with Intelij IDEA.

I provide my solution as
add single quote instead of double quote,
  \'%s\' -s %s logcat -v threadtime -T 1 %s >> \'%s\'
it's reasonable to use single quote here to avoid
substitution, expansion or word splitting for file name and adb path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/668)
<!-- Reviewable:end -->
