### PR TITLE
Fix unit test failure due to the lack of `fastboot` mock.

### DIFF
--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -799,10 +799,13 @@ class AndroidDeviceTest(unittest.TestCase):
 
     @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
                 return_value=mock_android_device.MockAdbProxy('1'))
+    @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+                return_value=mock_android_device.MockFastbootProxy('1'))
     @mock.patch('mobly.utils.create_dir')
     @mock.patch('mobly.logger.get_log_file_timestamp')
     def test_AndroidDevice_take_screenshot(self, get_log_file_timestamp_mock,
-                                           create_dir_mock, MockAdbProxy):
+                                           create_dir_mock, FastbootProxy,
+                                           MockAdbProxy):
         get_log_file_timestamp_mock.return_value = '07-22-2019_17-53-34-450'
         mock_serial = '1'
         ad = android_device.AndroidDevice(serial=mock_serial)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/672)
<!-- Reviewable:end -->
