### PR TITLE
Add extra log for debug when UnicodeDecodeError happened

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -21,7 +21,6 @@ import os
 import re
 import shutil
 import time
-import warnings
 
 from mobly import logger as mobly_logger
 from mobly import runtime_test_info
@@ -192,9 +191,9 @@ def parse_device_list(device_list_str, key):
     """
     try:
         clean_lines = new_str(device_list_str, 'utf-8').strip().split('\n')
-    except UnicodeDecodeError as e:
-        warnings.warn("unicode decode error, origin str: {}".format(device_list_str))
-        raise e
+    except UnicodeDecodeError:
+        logging.warning("unicode decode error, origin str: %s", device_list_str)
+        raise
     results = []
     for line in clean_lines:
         tokens = line.strip().split('\t')

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -21,6 +21,7 @@ import os
 import re
 import shutil
 import time
+import warnings
 
 from mobly import logger as mobly_logger
 from mobly import runtime_test_info
@@ -189,7 +190,11 @@ def parse_device_list(device_list_str, key):
     Returns:
         A list of android device serial numbers.
     """
-    clean_lines = new_str(device_list_str, 'utf-8').strip().split('\n')
+    try:
+        clean_lines = new_str(device_list_str, 'utf-8').strip().split('\n')
+    except UnicodeDecodeError as e:
+        warnings.warn("unicode decode error, origin str: {}".format(device_list_str))
+        raise e
     results = []
     for line in clean_lines:
         tokens = line.strip().split('\t')

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -1298,6 +1298,18 @@ class AndroidDeviceTest(unittest.TestCase):
             'adb.AdbError or adb.AdbTimeoutError exception raised but not handled.'
         )
 
+    def test_AndroidDevice_parse_parse_device_list_when_decode_error(self):
+        gbk_str = b'\xc4\xe3\xba\xc3'
+        raised = False
+        try:
+            android_device.parse_device_list(gbk_str, "somekey")
+        except UnicodeDecodeError:
+            raised = True
+        self.assertTrue(
+            raised,
+            'did not raise an exception when parsing gbk bytes'
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi
This patch mainly related to some encoding/decoding things.
When I run mobly without fastboot or adb installed, mobly will correctly raise an error, everything is fine under English env.

But if we use Windows (gbk) + other languages (Chinese? etc.), because of calling command via subprocess, stdout/stderr may contains some unexpected words in specfic language, not utf8. These words will cause decode error.

```text
File "f:\workspace\github\mobly\mobly\controllers\android_device.py", line 797, in is_rootable
    return not self.is_bootloader and self.build_info['debuggable'] == '1'
  File "f:\workspace\github\mobly\mobly\controllers\android_device.py", line 782, in is_bootloader
    return self.serial in list_fastboot_devices()
  File "f:\workspace\github\mobly\mobly\controllers\android_device.py", line 243, in list_fastboot_devices
    return parse_device_list(out, 'fastboot')
  File "f:\workspace\github\mobly\mobly\controllers\android_device.py", line 197, in parse_device_list
    raise e
  File "f:\workspace\github\mobly\mobly\controllers\android_device.py", line 194, in parse_device_list
    clean_lines = new_str(device_list_str, 'utf-8').strip().split('\n')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb2 in position 11: invalid start byte
[SampleTestBed] 07-16 16:00:54.935 ERROR Error in HelloWorldTest#setup_class.
```

It raises an unicode expection but actually it caused by some lost deps. It's a little confused for debug. After 30 mins review finally I realized that I forgot my fastboot.

This patch will simply print out its origin value to stderr before `new_str`. Looks like:

```text
[SampleTestBed] 07-16 16:00:54.873 INFO ==========> HelloWorldTest <==========
f:\workspace\github\mobly\mobly\controllers\android_device.py:196: UserWarning: unicode decode error, origin str: b"'fastboot' \xb2\xbb\xca\xc7\xc4\xda\xb2\xbf\xbb\xf
2\xcd\xe2\xb2\xbf\xc3\xfc\xc1\xee\xa3\xac\xd2\xb2\xb2\xbb\xca\xc7\xbf\xc9\xd4\xcb\xd0\xd0\xb5\xc4\xb3\xcc\xd0\xf2\r\n\xbb\xf2\xc5\xfa\xb4\xa6\xc0\xed\xce\xc4\xbc\xfe\
xa1\xa3\r\n"
  warnings.warn("unicode decode error, origin str: {}".format(device_list_str))

``` 

Maybe not the best design but at least I can know something wrong when I calling fastboot via command line.
Just an idea/draft so feel free to edit these.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/674)
<!-- Reviewable:end -->
