### PR TITLE
Add fallback for jrpc client connection when failing to connect.

### DIFF
--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -55,6 +55,7 @@ except ImportError:
 
 import json
 import socket
+import sys
 import threading
 
 from mobly.controllers.android_device_lib import callback_handler
@@ -217,11 +218,16 @@ class JsonRpcClientBase(object):
             socket.timeout: Raised when the socket waits to long for connection.
             ProtocolError: Raised when there is an error in the protocol.
         """
+        # socket.create_connection throws different exceptions in Python 2/3
+        ExceptionAlias = socket.error
+        if sys.version_info >= (3, 0):
+          ExceptionAlias = ConnectionRefusedError
+
         self._counter = self._id_counter()
         try:
           self._conn = socket.create_connection(('localhost', self.host_port),
                                                 _SOCKET_CONNECTION_TIMEOUT)
-        except ConnectionRefusedError as err:
+        except ExceptionAlias as err:
           # Retry using '127.0.0.1' for IPv4 enabled machines that only resolve
           # 'localhost' to '[::1]'.
           self.log.debug('Failed to connect to localhost, trying 127.0.0.1: {}'

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -222,7 +222,9 @@ class JsonRpcClientBase(object):
           self._conn = socket.create_connection(('localhost', self.host_port),
                                                 _SOCKET_CONNECTION_TIMEOUT)
         except ConnectionRefusedError as err:
-          self.log.error('Failled to connect to localhost, trying 127.0.0.1: {}'
+          # Retry using '127.0.0.1' for IPv4 enabled machines that only resolve
+          # 'localhost' to '[::1]'.
+          self.log.debug('Failed to connect to localhost, trying 127.0.0.1: {}'
                          .format(str(err)))
           self._conn = socket.create_connection(('127.0.0.1', self.host_port),
                                                 _SOCKET_CONNECTION_TIMEOUT)

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -218,8 +218,15 @@ class JsonRpcClientBase(object):
             ProtocolError: Raised when there is an error in the protocol.
         """
         self._counter = self._id_counter()
-        self._conn = socket.create_connection(('localhost', self.host_port),
-                                              _SOCKET_CONNECTION_TIMEOUT)
+        try:
+          self._conn = socket.create_connection(('localhost', self.host_port),
+                                                _SOCKET_CONNECTION_TIMEOUT)
+        except ConnectionRefusedError as err:
+          self.log.error('Failled to connect to localhost, trying 127.0.0.1: {}'
+                         .format(str(err)))
+          self._conn = socket.create_connection(('127.0.0.1', self.host_port),
+                                                _SOCKET_CONNECTION_TIMEOUT)
+
         self._conn.settimeout(_SOCKET_READ_TIMEOUT)
         self._client = self._conn.makefile(mode='brw')
 

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -219,6 +219,7 @@ class JsonRpcClientBase(object):
             ProtocolError: Raised when there is an error in the protocol.
         """
         # socket.create_connection throws different exceptions in Python 2/3
+        # TODO: Use ConnectionRefusedError directly once PY2 is deprecated.
         ExceptionAlias = socket.error
         if sys.version_info >= (3, 0):
           ExceptionAlias = ConnectionRefusedError


### PR DESCRIPTION
The ADB proxy server may be listening on 127.0.0.1 on machines where
localhost resolves to [::1], which will raise a 'ConnectionRefusedError'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/678)
<!-- Reviewable:end -->
