### PR TITLE
Drop Python 2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/mobly/asserts.py
+++ b/mobly/asserts.py
@@ -20,14 +20,7 @@ from mobly import signals
 
 # Have an instance of unittest.TestCase so we could reuse some logic from
 # python's own unittest.
-# _ProxyTest is required because py2 does not allow instantiating
-# unittest.TestCase directly.
-class _ProxyTest(unittest.TestCase):
-    def runTest(self):
-        pass
-
-
-_pyunit_proxy = _ProxyTest()
+_pyunit_proxy = unittest.TestCase()
 
 
 def assert_equal(first, second, msg=None, extras=None):

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str as new_str
-from past.builtins import basestring
-
 import contextlib
 import logging
 import os
@@ -108,7 +105,7 @@ def create(configs):
     elif isinstance(configs[0], dict):
         # Configs is a list of dicts.
         ads = get_instances_with_configs(configs)
-    elif isinstance(configs[0], basestring):
+    elif isinstance(configs[0], str):
         # Configs is a list of strings representing serials.
         ads = get_instances(configs)
     else:
@@ -190,7 +187,7 @@ def parse_device_list(device_list_str, key):
         A list of android device serial numbers.
     """
     try:
-        clean_lines = new_str(device_list_str, 'utf-8').strip().split('\n')
+        clean_lines = str(device_list_str, 'utf-8').strip().split('\n')
     except UnicodeDecodeError:
         logging.warning("unicode decode error, origin str: %s", device_list_str)
         raise
@@ -222,7 +219,7 @@ def list_adb_devices_by_usb_id():
         none.
     """
     out = adb.AdbProxy().devices(['-l'])
-    clean_lines = new_str(out, 'utf-8').strip().split('\n')
+    clean_lines = str(out, 'utf-8').strip().split('\n')
     results = []
     for line in clean_lines:
         tokens = line.strip().split()
@@ -1046,7 +1043,7 @@ class AndroidDevice(object):
             results: results have data flow information
         """
         out = self.adb.shell('iperf3 -c %s %s' % (server_host, extra_args))
-        clean_out = new_str(out, 'utf-8').strip().split('\n')
+        clean_out = str(out, 'utf-8').strip().split('\n')
         if 'error' in clean_out[0].lower():
             return False, clean_out
         return True, clean_out

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -12,17 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str
-from past.builtins import basestring
-
 import logging
-import psutil
 import re
 import subprocess
-import time
 import threading
+import time
 
 from mobly import utils
+import psutil
 
 # Command to use for running ADB commands.
 ADB = 'adb'
@@ -263,7 +260,7 @@ class AdbProxy(object):
                 adb_cmd.extend(['-s', self.serial])
             adb_cmd.append(name)
             if args:
-                if isinstance(args, basestring):
+                if isinstance(args, str):
                     adb_cmd.append(args)
                 else:
                     adb_cmd.extend(args)

--- a/mobly/controllers/monsoon.py
+++ b/mobly/controllers/monsoon.py
@@ -15,8 +15,6 @@
 (http://msoon.com/LabEquipment/PowerMonitor/).
 """
 
-from past.builtins import basestring
-
 import fcntl
 import io
 import logging

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from past.builtins import basestring
-
 import base64
 import concurrent.futures
 import datetime
@@ -24,16 +22,16 @@ import logging
 import os
 import pipes
 import platform
-import portpicker
 import random
 import re
-import signal
 import string
 import subprocess
 import sys
 import threading
 import time
 import traceback
+
+import portpicker
 
 # File name length is limited to 255 chars on some OS, so we need to make sure
 # the file names we output fits within the limit.
@@ -572,7 +570,7 @@ def cli_cmd_to_string(args):
     Returns:
         String representation of the command.
     """
-    if isinstance(args, basestring):
+    if isinstance(args, str):
         # Return directly if it's already a string.
         return args
     return ' '.join([pipes.quote(arg) for arg in args])


### PR DESCRIPTION
Python 2 is no longer supported, let's only run unit tests in py3.
https://pythonclock.org/

1. Drop py2 in Travis CI
2. Drop Python 2 compatibility and fix import order in mobly/utils.py.
3. Drop Python 2 compatibility in mobly/controllers/android_device.py.
4. Drop Python 2 compatibility and fix import order in mobly/controllers/android_device_lib/adb.py.
5. Remove unused import of past.builtins.basestring in mobly/controllers/monsoon.py.
6. Remove Python 2 workarounds in mobly/asserts.py.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/679)
<!-- Reviewable:end -->
