### PR TITLE
Use an empty string as the default TestRunConfig.log_path. This fixes…

### DIFF
--- a/mobly/config_parser.py
+++ b/mobly/config_parser.py
@@ -178,7 +178,7 @@ class TestRunConfig(object):
     """
 
     def __init__(self):
-        self.log_path = None
+        self.log_path = ''
         # Deprecated, use 'testbed_name'
         self.test_bed_name = None
         self.testbed_name = None


### PR DESCRIPTION
… an issue When using the --list_tests flag. In that codepath os.path.join is called on this value which has not been set by a TestRunner, resulting in the error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/680)
<!-- Reviewable:end -->
