### PR TITLE
Add not None check in Logcat.create_output_excerpts.

### DIFF
--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -139,7 +139,9 @@ class Logcat(base_service.BaseService):
         excerpt_file_path = os.path.join(dest_path, filename)
         with io.open(excerpt_file_path, 'w', encoding='utf-8',
                      errors='replace') as out:
-            while True:
+            # Devices may accidentally go offline during test,
+            # check not None before readline().
+            while self._adb_logcat_file_obj:
                 line = self._adb_logcat_file_obj.readline()
                 if not line:
                     break


### PR DESCRIPTION
Sometimes, devices may accidentally go offline during test with "device 'UUID' not found" error.    
In this scenario,     
you will got "'NoneType' object has no attribute 'readline'" AttributeError     
when you call `create_output_excerpts` in `teardown_test()`.

This PR checks `_adb_logcat_file_obj` is not None before calling `readline()`.    
An empty excerpt would be created at excerpt_file_path if device offline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/681)
<!-- Reviewable:end -->
