### PR TITLE
Sets default not to do verbose logging

### DIFF
--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -70,10 +70,6 @@ _SOCKET_CONNECTION_TIMEOUT = 60
 # Maximum time to wait for a response message on the socket.
 _SOCKET_READ_TIMEOUT = callback_handler.MAX_TIMEOUT
 
-# Logging RPC response with full string or truncated by given length
-_VERBOSE_LOGGING = False
-MAX_RPC_RETURN_VALUE_LENGTH = 1024
-
 
 class Error(errors.DeviceError):
     pass
@@ -143,7 +139,7 @@ class JsonRpcClientBase(object):
         self._lock = threading.Lock()
         self._event_client = None
         self.verbose_logging = False   # Logging RPC response with full string or truncated by given length
-        self._max_rpc_return_value_length = 1024
+        self.max_rpc_return_value_length = 1024
 
     def __del__(self):
         self.disconnect()
@@ -389,11 +385,17 @@ class JsonRpcClientBase(object):
             i += 1
 
     def set_snippet_client_verbose_logging(self, verbose=False):
-        # type: (bool) -> None
         """Switches verbose logging. True for logging full RPC response.
 
+        By default it will only write max_rpc_return_value_length for Rpc return
+        strings. If you need to see full message returned from Rpc, please turn
+        on verbose logging.
+
+        max_rpc_return_value_length will set to 1024 by default, the length
+        contains full Rpc response in Json format, included 1st element "id".
+
         Args:
-            verbose: bool, True for full logging full RPC response in DEBUG level.
+            verbose: bool. If True, turns on verbose logging, if False turns off
         """
         self._ad.log.info('Set verbose logging to %s.', verbose)
         self.verbose_logging = verbose

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -70,6 +70,10 @@ _SOCKET_CONNECTION_TIMEOUT = 60
 # Maximum time to wait for a response message on the socket.
 _SOCKET_READ_TIMEOUT = callback_handler.MAX_TIMEOUT
 
+# Logging RPC response with full string or truncated by given length
+_VERBOSE_LOGGING = False
+MAX_RPC_RETURN_VALUE_LENGTH = 1024
+
 
 class Error(errors.DeviceError):
     pass
@@ -292,7 +296,9 @@ class JsonRpcClientBase(object):
         """
         try:
             response = self._client.readline()
-            self.log.debug('Snippet received: %s', response)
+            self.log.debug('Snippet received: %s',
+                           response if _VERBOSE_LOGGING else
+                           response[:MAX_RPC_RETURN_VALUE_LENGTH])
             return response
         except socket.error as e:
             raise Error(
@@ -377,3 +383,13 @@ class JsonRpcClientBase(object):
         while True:
             yield i
             i += 1
+
+    def set_verbose_logging(self, verbose: bool = False):
+        """Switches verbose logging. True for logging full RPC response.
+
+        Args:
+            verbose: bool, True for full logging full RPC response in DEBUG level.
+        """
+        self._ad.log.info('Set verbose logging to %s.', bool)
+        global _VERBOSE_LOGGING
+        _VERBOSE_LOGGING = verbose

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -142,6 +142,8 @@ class JsonRpcClientBase(object):
         self._counter = None
         self._lock = threading.Lock()
         self._event_client = None
+        self.verbose_logging = False   # Logging RPC response with full string or truncated by given length
+        self._max_rpc_return_value_length = 1024
 
     def __del__(self):
         self.disconnect()
@@ -296,9 +298,11 @@ class JsonRpcClientBase(object):
         """
         try:
             response = self._client.readline()
-            self.log.debug('Snippet received: %s',
-                           response if _VERBOSE_LOGGING else
-                           response[:MAX_RPC_RETURN_VALUE_LENGTH])
+            if self.verbose_logging:
+                self.log.debug('Snippet received: %s', response)
+            else:
+                self.log.debug('Snippet received: %s',
+                               response[:self._max_rpc_return_value_length])
             return response
         except socket.error as e:
             raise Error(
@@ -384,12 +388,12 @@ class JsonRpcClientBase(object):
             yield i
             i += 1
 
-    def set_verbose_logging(self, verbose: bool = False):
+    def set_snippet_client_verbose_logging(self, verbose=False):
+        # type: (bool) -> None
         """Switches verbose logging. True for logging full RPC response.
 
         Args:
             verbose: bool, True for full logging full RPC response in DEBUG level.
         """
-        self._ad.log.info('Set verbose logging to %s.', bool)
-        global _VERBOSE_LOGGING
-        _VERBOSE_LOGGING = verbose
+        self._ad.log.info('Set verbose logging to %s.', verbose)
+        self.verbose_logging = verbose

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -70,8 +70,9 @@ _SOCKET_CONNECTION_TIMEOUT = 60
 # Maximum time to wait for a response message on the socket.
 _SOCKET_READ_TIMEOUT = callback_handler.MAX_TIMEOUT
 
-# Maximum logging length of Rpc response in DEBUG level.
-_MAX_RPC_RETURN_LENGTH_IN_DEBUG_LOG = 1024
+# Maximum logging length of Rpc response in DEBUG level when verbose logging is
+# off.
+_MAX_RPC_RESP_LOGGING_LENGTH = 1024
 
 
 class Error(errors.DeviceError):
@@ -297,14 +298,14 @@ class JsonRpcClientBase(object):
         try:
             response = self._client.readline()
             response_log = str(response)
-            if self.verbose_logging or\
-                _MAX_RPC_RETURN_LENGTH_IN_DEBUG_LOG >= len(response):
+            if self.verbose_logging or _MAX_RPC_RESP_LOGGING_LENGTH >= len(
+                response):
               self.log.debug('Snippet received: %s', response)
             else:
               self.log.debug(
                   'Snippet received: %s...(%d bytes are truncated)',
-                  response_log[:_MAX_RPC_RETURN_LENGTH_IN_DEBUG_LOG],
-                  len(response) - _MAX_RPC_RETURN_LENGTH_IN_DEBUG_LOG)
+                  response_log[:_MAX_RPC_RESP_LOGGING_LENGTH],
+                  len(response) - _MAX_RPC_RESP_LOGGING_LENGTH)
             return response
         except socket.error as e:
             raise Error(
@@ -390,7 +391,7 @@ class JsonRpcClientBase(object):
             yield i
             i += 1
 
-    def set_snippet_client_verbose_logging(self, verbose=True):
+    def set_snippet_client_verbose_logging(self, verbose):
         """Switches verbose logging. True for logging full RPC response.
 
         By default it will only write max_rpc_return_value_length for Rpc return

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -298,7 +298,7 @@ class JsonRpcClientBase(object):
                 self.log.debug('Snippet received: %s', response)
             else:
                 self.log.debug('Snippet received: %s',
-                               response[:self._max_rpc_return_value_length])
+                               response[:int(self.max_rpc_return_value_length)])
             return response
         except socket.error as e:
             raise Error(

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -298,14 +298,16 @@ class JsonRpcClientBase(object):
         try:
             response = self._client.readline()
             response_log = str(response)
-            if self.verbose_logging or _MAX_RPC_RESP_LOGGING_LENGTH >= len(
-                response):
-              self.log.debug('Snippet received: %s', response)
+            if self.verbose_logging:
+                self.log.debug('Snippet received: %s', response)
             else:
-              self.log.debug(
-                  'Snippet received: %s...(%d bytes are truncated)',
-                  response_log[:_MAX_RPC_RESP_LOGGING_LENGTH],
-                  len(response) - _MAX_RPC_RESP_LOGGING_LENGTH)
+                if _MAX_RPC_RESP_LOGGING_LENGTH >= len(response):
+                    self.log.debug('Snippet received: %s', response)
+                else:
+                    self.log.debug(
+                        'Snippet received: %s... %d chars are truncated',
+                        response_log[:_MAX_RPC_RESP_LOGGING_LENGTH],
+                        len(response) - _MAX_RPC_RESP_LOGGING_LENGTH)
             return response
         except socket.error as e:
             raise Error(

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -294,11 +294,12 @@ class JsonRpcClientBase(object):
         """
         try:
             response = self._client.readline()
+            response_log = str(response)
             if self.verbose_logging:
                 self.log.debug('Snippet received: %s', response)
             else:
                 self.log.debug('Snippet received: %s',
-                               response[:int(self.max_rpc_return_value_length)])
+                               response_log[:self.max_rpc_return_value_length])
             return response
         except socket.error as e:
             raise Error(

--- a/tests/lib/jsonrpc_client_test_base.py
+++ b/tests/lib/jsonrpc_client_test_base.py
@@ -39,9 +39,9 @@ class JsonRpcClientTestBase(unittest.TestCase):
         b'{"id": 0, "result": 123, "error": null, "status": 1, "uid": 1, '
         b'"callback": "1-0"}')
     MOCK_RESP_WITH_ERROR = b'{"id": 0, "error": 1, "status": 1, "uid": 1}'
-    MOCK_REST_LONG_STRINGS = bytes((
-        '{"id": 0, "result": "' + 'Very long long long long response. ' * 40 +
-        '", "error": null, "status": 0, "callback": null}').encode('utf-8'))
+    MOCK_RESP_FLEXIABLE_RESULT_LENGTH = (
+        '{"id": 0, "result": "%s", "error": null, "status": 0, "callback": null}'
+    )
 
     class MockSocketFile(object):
         def __init__(self, resp):

--- a/tests/lib/jsonrpc_client_test_base.py
+++ b/tests/lib/jsonrpc_client_test_base.py
@@ -39,6 +39,9 @@ class JsonRpcClientTestBase(unittest.TestCase):
         b'{"id": 0, "result": 123, "error": null, "status": 1, "uid": 1, '
         b'"callback": "1-0"}')
     MOCK_RESP_WITH_ERROR = b'{"id": 0, "error": 1, "status": 1, "uid": 1}'
+    MOCK_REST_LONG_STRINGS = bytes((
+        '{"id": 0, "result": "' + 'Very long long long long response. ' * 40 +
+        '", "error": null, "status": 0, "callback": null}').encode('utf-8'))
 
     class MockSocketFile(object):
         def __init__(self, resp):

--- a/tests/lib/jsonrpc_client_test_base.py
+++ b/tests/lib/jsonrpc_client_test_base.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import random
+import string
 from builtins import str
 
 import mock
@@ -72,3 +73,13 @@ class JsonRpcClientTestBase(unittest.TestCase):
         fake_conn.makefile.return_value = fake_file
         mock_create_connection.return_value = fake_conn
         return fake_file
+
+    def generate_rpc_response(self, response_length=1024):
+        # TODO: Py2 deprecation
+        # .encode('utf-8') is for py2 compatibility, after py2 deprecation, it
+        # could be modified to byte('xxxxx', 'utf-8')
+        return bytes((self.MOCK_RESP_FLEXIABLE_RESULT_LENGTH % ''.join(
+            random.choice(string.ascii_lowercase)
+            for i in range(response_length -
+                           len(self.MOCK_RESP_FLEXIABLE_RESULT_LENGTH) + 2))
+                      ).encode('utf-8'))

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
@@ -268,7 +268,7 @@ class JsonRpcClientBaseTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
             # DEBUG level log should truncated by given length.
             client.log.debug.assert_called_with(
                 'Snippet received: %s',
-                self.MOCK_REST_LONG_STRINGS[:int(test_length)])
+                str(self.MOCK_REST_LONG_STRINGS)[:int(test_length)])
 
 
 if __name__ == '__main__':

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
@@ -20,10 +20,10 @@ import socket
 import random
 import string
 
-from absl.testing import parameterized
 from future.tests.base import unittest
 
 from mobly.controllers.android_device_lib import jsonrpc_client_base
+from parameterized import parameterized
 from tests.lib import jsonrpc_client_test_base
 
 
@@ -33,8 +33,7 @@ class FakeRpcClient(jsonrpc_client_base.JsonRpcClientBase):
             app_name='FakeRpcClient', ad=mock.Mock())
 
 
-class JsonRpcClientBaseTest(parameterized.TestCase,
-                            jsonrpc_client_test_base.JsonRpcClientTestBase):
+class JsonRpcClientBaseTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
     """Unit tests for mobly.controllers.android_device_lib.jsonrpc_client_base.
     """
 
@@ -233,19 +232,14 @@ class JsonRpcClientBaseTest(parameterized.TestCase,
 
         self.assertEqual(next(client._counter), 10)
 
-    @parameterized.named_parameters(
-        {
-            'testcase_name': 'long_response',
-            'total_length': 4000
-        }, {
-            'testcase_name': 'fit_legnth_response',
-            'total_length': 1024
-        }, {
-            'testcase_name': 'short_response',
-            'total_length': 100
-        })
+    @parameterized.expand([
+        ("long_response", 4000),
+        ("fit_legnth_response", 1024),
+        ("short_response", 100),
+    ])
     @mock.patch('socket.create_connection')
-    def test_rpc_verbose_logging(self, mock_create_connection, total_length):
+    def test_rpc_verbose_logging(self, name, total_length,
+                                 mock_create_connection):
         """Test rpc response fully write into DEBUG level log by default."""
         # TODO: Py2 deprecation
         # .encode('utf-8') is for py2 compatibility, after py2 deprecation, it
@@ -270,19 +264,14 @@ class JsonRpcClientBaseTest(parameterized.TestCase,
         client.log.debug.assert_called_with('Snippet received: %s',
                                             mock_testing_rest_bytes)
 
-    @parameterized.named_parameters(
-        {
-            'testcase_name': 'long_response',
-            'total_length': 4000
-        }, {
-            'testcase_name': 'fit_legnth_response',
-            'total_length': 1024
-        }, {
-            'testcase_name': 'short_response',
-            'total_length': 100
-        })
+    @parameterized.expand([
+        ("long_response", 4000),
+        ("fit_legnth_response", 1024),
+        ("short_response", 100),
+    ])
     @mock.patch('socket.create_connection')
-    def test_rpc_truncated_logging(self, mock_create_connection, total_length):
+    def test_rpc_truncated_logging(self, title, total_length,
+                                   mock_create_connection):
         """Test rpc response truncated with given length in DEBUG level log.
         """
         # TODO: Py2 deprecation
@@ -296,7 +285,7 @@ class JsonRpcClientBaseTest(parameterized.TestCase,
             (self.MOCK_RESP_FLEXIABLE_RESULT_LENGTH %
              json_result_str).encode('utf-8'))
 
-        target_log_len = jsonrpc_client_base._MAX_RPC_RETURN_LENGTH_IN_DEBUG_LOG
+        target_log_len = jsonrpc_client_base._MAX_RPC_RESP_LOGGING_LENGTH
 
         fake_file = self.setup_mock_socket_file(mock_create_connection)
         fake_file.resp = mock_testing_rest_bytes

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
@@ -17,9 +17,6 @@ from builtins import str
 import json
 import mock
 import socket
-import random
-import string
-
 from future.tests.base import unittest
 
 from mobly.controllers.android_device_lib import jsonrpc_client_base
@@ -232,80 +229,83 @@ class JsonRpcClientBaseTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
 
         self.assertEqual(next(client._counter), 10)
 
-    @parameterized.expand([
-        ("long_response", 4000),
-        ("fit_legnth_response", 1024),
-        ("short_response", 100),
-    ])
     @mock.patch('socket.create_connection')
-    def test_rpc_verbose_logging(self, name, total_length,
-                                 mock_create_connection):
-        """Test rpc response fully write into DEBUG level log by default."""
-        # TODO: Py2 deprecation
-        # .encode('utf-8') is for py2 compatibility, after py2 deprecation, it
-        # could be modified to byte('xxxxx', 'utf-8')
-        json_result_str = ''.join(
-            random.choice(string.ascii_lowercase)
-            for i in range(total_length -
-                           len(self.MOCK_RESP_FLEXIABLE_RESULT_LENGTH) + 2))
-        mock_testing_rest_bytes = bytes(
-            (self.MOCK_RESP_FLEXIABLE_RESULT_LENGTH %
-             json_result_str).encode('utf-8'))
-
+    def test_rpc_verbose_logging_with_long_string(self,
+                                                  mock_create_connection):
+        """Test rpc response fully write into DEBUG level log."""
         fake_file = self.setup_mock_socket_file(mock_create_connection)
-        fake_file.resp = mock_testing_rest_bytes
+        testing_rpc_response = self.generate_rpc_response(4000)
+        fake_file.resp = testing_rpc_response
 
         client = FakeRpcClient()
         client.connect()
 
         response = client._client_receive()
-        self.assertEqual(response, mock_testing_rest_bytes)
+        self.assertEqual(response, testing_rpc_response)
 
         client.log.debug.assert_called_with('Snippet received: %s',
-                                            mock_testing_rest_bytes)
+                                            testing_rpc_response)
 
-    @parameterized.expand([
-        ("long_response", 4000),
-        ("fit_legnth_response", 1024),
-        ("short_response", 100),
-    ])
     @mock.patch('socket.create_connection')
-    def test_rpc_truncated_logging(self, title, total_length,
-                                   mock_create_connection):
-        """Test rpc response truncated with given length in DEBUG level log.
-        """
-        # TODO: Py2 deprecation
-        # .encode('utf-8') is for py2 compatibility, after py2 deprecation, it
-        # could be modified to byte('xxxxx', 'utf-8')
-        json_result_str = ''.join(
-            random.choice(string.ascii_lowercase)
-            for i in range(total_length -
-                           len(self.MOCK_RESP_FLEXIABLE_RESULT_LENGTH) + 2))
-        mock_testing_rest_bytes = bytes(
-            (self.MOCK_RESP_FLEXIABLE_RESULT_LENGTH %
-             json_result_str).encode('utf-8'))
-
-        target_log_len = jsonrpc_client_base._MAX_RPC_RESP_LOGGING_LENGTH
-
+    def test_rpc_truncated_logging_short_response(self,
+                                                  mock_create_connection):
+        """Test rpc response will full logged when length is short."""
         fake_file = self.setup_mock_socket_file(mock_create_connection)
-        fake_file.resp = mock_testing_rest_bytes
+        testing_rpc_response = self.generate_rpc_response(
+            int(jsonrpc_client_base._MAX_RPC_RESP_LOGGING_LENGTH / 2))
+        fake_file.resp = testing_rpc_response
+
         client = FakeRpcClient()
         client.connect()
+
         client.set_snippet_client_verbose_logging(False)
-
         response = client._client_receive()
-        # Response should contain full response.
-        self.assertEqual(response, mock_testing_rest_bytes)
 
-        if len(response) <= target_log_len:
-            client.log.debug.assert_called_with('Snippet received: %s',
-                                                response)
-        else:
-            # DEBUG level log should truncated by given length.
-            client.log.debug.assert_called_with(
-                'Snippet received: %s...(%d bytes are truncated)',
-                str(mock_testing_rest_bytes)[:target_log_len],
-                len(response) - target_log_len)
+        self.assertEqual(response, testing_rpc_response)
+        client.log.debug.assert_called_with('Snippet received: %s',
+                                            testing_rpc_response)
+
+    @mock.patch('socket.create_connection')
+    def test_rpc_truncated_logging_fit_size_response(self,
+                                                     mock_create_connection):
+        """Test rpc response will full logged when length is equal to threshold.
+        """
+        fake_file = self.setup_mock_socket_file(mock_create_connection)
+        testing_rpc_response = self.generate_rpc_response(
+            jsonrpc_client_base._MAX_RPC_RESP_LOGGING_LENGTH)
+        fake_file.resp = testing_rpc_response
+
+        client = FakeRpcClient()
+        client.connect()
+
+        client.set_snippet_client_verbose_logging(False)
+        response = client._client_receive()
+
+        self.assertEqual(response, testing_rpc_response)
+        client.log.debug.assert_called_with('Snippet received: %s',
+                                            testing_rpc_response)
+
+    @mock.patch('socket.create_connection')
+    def test_rpc_truncated_logging_long_response(self, mock_create_connection):
+        """Test rpc response truncated with given length in DEBUG level log."""
+        fake_file = self.setup_mock_socket_file(mock_create_connection)
+        resp_len = jsonrpc_client_base._MAX_RPC_RESP_LOGGING_LENGTH * 40
+        testing_rpc_response = self.generate_rpc_response(resp_len)
+        fake_file.resp = testing_rpc_response
+
+        client = FakeRpcClient()
+        client.connect()
+
+        client.set_snippet_client_verbose_logging(False)
+        response = client._client_receive()
+
+        self.assertEqual(response, testing_rpc_response)
+        # DEBUG level log should truncated by given length.
+        client.log.debug.assert_called_with(
+            'Snippet received: %s... %d chars are truncated',
+            str(testing_rpc_response)
+            [:jsonrpc_client_base._MAX_RPC_RESP_LOGGING_LENGTH],
+            resp_len - jsonrpc_client_base._MAX_RPC_RESP_LOGGING_LENGTH)
 
 
 if __name__ == '__main__':

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
@@ -20,7 +20,6 @@ import socket
 from future.tests.base import unittest
 
 from mobly.controllers.android_device_lib import jsonrpc_client_base
-from parameterized import parameterized
 from tests.lib import jsonrpc_client_test_base
 
 


### PR DESCRIPTION
Do not do verbose logging in RPC return messages.
Verbose logging could be enabled by user if you want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/683)
<!-- Reviewable:end -->
