### PR TITLE
Make snippet response logging length can be restricted.

### DIFF
--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -61,8 +61,13 @@ import threading
 from mobly.controllers.android_device_lib import callback_handler
 from mobly.controllers.android_device_lib import errors
 
+import six
+
 # UID of the 'unknown' jsonrpc session. Will cause creation of a new session.
 UNKNOWN_UID = -1
+
+# Maximum length of the snippet response to log. Full logging by default.
+SNIPPET_RESPONSE_LOGGING_LENGTH_LIMITATION = six.MAXSIZE
 
 # Maximum time to wait for the socket to open on the device.
 _SOCKET_CONNECTION_TIMEOUT = 60
@@ -292,7 +297,10 @@ class JsonRpcClientBase(object):
         """
         try:
             response = self._client.readline()
-            self.log.debug('Snippet received: %s', response)
+            response_log = str(response)
+            self.log.debug(
+                'Snippet received: %s',
+                response_log[:SNIPPET_RESPONSE_LOGGING_LENGTH_LIMITATION])
             return response
         except socket.error as e:
             raise Error(

--- a/tests/lib/jsonrpc_client_test_base.py
+++ b/tests/lib/jsonrpc_client_test_base.py
@@ -27,6 +27,9 @@ class JsonRpcClientTestBase(unittest.TestCase):
     MOCK_RESP = (
         b'{"id": 0, "result": 123, "error": null, "status": 1, "uid": 1, '
         b'"callback": null}')
+    MOCK_RESP_WITH_LONG_RESULT = (
+        '{"id": 0, "result": "' + 'long_result' * 100 + '", "error": null, '
+        '"status": 1, "uid": 1, "callback": null}').encode('utf-8')
     MOCK_RESP_WITHOUT_CALLBACK = (
         b'{"id": 0, "result": 123, "error": null, "status": 1, "uid": 1}')
     MOCK_RESP_TEMPLATE = (


### PR DESCRIPTION
A revised version of PR 683.     
We keep the behavior as-is and make snippet response logging length can be restricted.    
User can set `jsonrpc_client_base.SNIPPET_RESPONSE_LOGGING_LENGTH_LIMITATION` through module wide variable.    

This is similar to usage of `adb.DEFAULT_GETPROP_TIMEOUT_SEC`:    
https://github.com/google/mobly/blob/master/mobly/controllers/android_device_lib/adb.py#38

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/684)
<!-- Reviewable:end -->
