### PR TITLE
Reduce unused variable in _client_receive.

### DIFF
--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -297,7 +297,6 @@ class JsonRpcClientBase(object):
         """
         try:
             response = self._client.readline()
-            response_log = str(response)
             if self.verbose_logging:
                 self.log.debug('Snippet received: %s', response)
             else:
@@ -306,7 +305,7 @@ class JsonRpcClientBase(object):
                 else:
                     self.log.debug(
                         'Snippet received: %s... %d chars are truncated',
-                        response_log[:_MAX_RPC_RESP_LOGGING_LENGTH],
+                        str(response)[:_MAX_RPC_RESP_LOGGING_LENGTH],
                         len(response) - _MAX_RPC_RESP_LOGGING_LENGTH)
             return response
         except socket.error as e:

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -305,7 +305,7 @@ class JsonRpcClientBase(object):
                 else:
                     self.log.debug(
                         'Snippet received: %s... %d chars are truncated',
-                        str(response)[:_MAX_RPC_RESP_LOGGING_LENGTH],
+                        response[:_MAX_RPC_RESP_LOGGING_LENGTH],
                         len(response) - _MAX_RPC_RESP_LOGGING_LENGTH)
             return response
         except socket.error as e:

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
@@ -302,7 +302,7 @@ class JsonRpcClientBaseTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
         # DEBUG level log should truncated by given length.
         client.log.debug.assert_called_with(
             'Snippet received: %s... %d chars are truncated',
-            str(testing_rpc_response)
+            testing_rpc_response
             [:jsonrpc_client_base._MAX_RPC_RESP_LOGGING_LENGTH],
             resp_len - jsonrpc_client_base._MAX_RPC_RESP_LOGGING_LENGTH)
 


### PR DESCRIPTION
 - Convert response to str when it needed. Since it will be use only once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/686)
<!-- Reviewable:end -->
