### PR TITLE
Use an empty string as the default `TestRunConfig.log_path`

### DIFF
--- a/mobly/config_parser.py
+++ b/mobly/config_parser.py
@@ -178,7 +178,8 @@ class TestRunConfig(object):
     """
 
     def __init__(self):
-        self.log_path = None
+        # Init value is an empty string to avoid string joining errors.
+        self.log_path = ''
         # Deprecated, use 'testbed_name'
         self.test_bed_name = None
         self.testbed_name = None


### PR DESCRIPTION
to avoid errors caused by `os.path.join`.
forking of #680 