### PR TITLE
Add a retry mechanism for the ADB command "root"

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -28,6 +28,11 @@ ADB = 'adb'
 # do with port forwarding must happen under this lock.
 ADB_PORT_LOCK = threading.Lock()
 
+# Number of attempts to execute "adb root", and seconds for interval time of
+# this commands.
+ADB_ROOT_ATTMEPTS = 3
+ADB_ROOT_ATTEMPTS_INTERVAL_SEC = 10
+
 # Qualified class name of the default instrumentation test runner.
 DEFAULT_INSTRUMENTATION_RUNNER = 'com.android.common.support.test.runner.AndroidJUnitRunner'
 
@@ -455,6 +460,38 @@ class AdbProxy(object):
         else:
             return self._execute_adb_and_process_stdout(
                 'shell', instrumentation_command, shell=False, handler=handler)
+
+    def root(self):
+        """Enables ADB root mode on the device.
+
+        This method will retry to execute the command `adb root` when an
+        AdbError occurs, since sometimes the error `adb: unable to connect
+        for root: closed` is raised when executing 'adb root' immediately after
+        the device is booted to OS.
+
+        Returns:
+            A string that is the stdout of root command.
+
+        Raises:
+            AdbError: If the command exit code is not 0.
+        """
+        for attempt in range(ADB_ROOT_ATTMEPTS):
+            try:
+                return self._exec_adb_cmd('root',
+                                          args=None,
+                                          shell=False,
+                                          timeout=None,
+                                          stderr=None)
+            except AdbError as e:
+                if attempt + 1 < ADB_ROOT_ATTMEPTS:
+                    logging.debug(
+                      'Retry the command "%s" since Error "%s" occurred.' %
+                      (utils.cli_cmd_to_string(e.cmd),
+                       e.stderr.decode('utf-8').strip()))
+                    # Buffer between "adb root" commands.
+                    time.sleep(ADB_ROOT_ATTEMPTS_INTERVAL_SEC)
+                else:
+                  raise e
 
     def __getattr__(self, name):
         def adb_call(args=None, shell=False, timeout=None, stderr=None):

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -30,8 +30,8 @@ ADB_PORT_LOCK = threading.Lock()
 
 # Number of attempts to execute "adb root", and seconds for interval time of
 # this commands.
-ADB_ROOT_ATTMEPTS = 3
-ADB_ROOT_ATTEMPTS_INTERVAL_SEC = 10
+ADB_ROOT_RETRY_ATTMEPTS = 3
+ADB_ROOT_RETRY_ATTEMPT_INTERVAL_SEC = 10
 
 # Qualified class name of the default instrumentation test runner.
 DEFAULT_INSTRUMENTATION_RUNNER = 'com.android.common.support.test.runner.AndroidJUnitRunner'
@@ -466,7 +466,7 @@ class AdbProxy(object):
 
         This method will retry to execute the command `adb root` when an
         AdbError occurs, since sometimes the error `adb: unable to connect
-        for root: closed` is raised when executing 'adb root' immediately after
+        for root: closed` is raised when executing `adb root` immediately after
         the device is booted to OS.
 
         Returns:
@@ -475,7 +475,7 @@ class AdbProxy(object):
         Raises:
             AdbError: If the command exit code is not 0.
         """
-        for attempt in range(ADB_ROOT_ATTMEPTS):
+        for attempt in range(ADB_ROOT_RETRY_ATTMEPTS):
             try:
                 return self._exec_adb_cmd('root',
                                           args=None,
@@ -483,13 +483,13 @@ class AdbProxy(object):
                                           timeout=None,
                                           stderr=None)
             except AdbError as e:
-                if attempt + 1 < ADB_ROOT_ATTMEPTS:
+                if attempt + 1 < ADB_ROOT_RETRY_ATTMEPTS:
                     logging.debug(
                       'Retry the command "%s" since Error "%s" occurred.' %
                       (utils.cli_cmd_to_string(e.cmd),
                        e.stderr.decode('utf-8').strip()))
                     # Buffer between "adb root" commands.
-                    time.sleep(ADB_ROOT_ATTEMPTS_INTERVAL_SEC)
+                    time.sleep(ADB_ROOT_RETRY_ATTEMPT_INTERVAL_SEC)
                 else:
                   raise e
 

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -43,7 +43,8 @@ MOCK_OPTIONS_INSTRUMENTATION_COMMAND = ('am instrument -r -w -e option1 value1'
 
 # Mock root command outputs.
 MOCK_ROOT_SUCCESS_OUTPUT = 'adbd is already running as root'
-MOCK_ROOT_ERROR_OUTPUT = 'adb: unable to connect for root: closed'.encode('utf-8')
+MOCK_ROOT_ERROR_OUTPUT = (
+    'adb: unable to connect for root: closed'.encode('utf-8'))
 
 # Mock Shell Command
 MOCK_SHELL_COMMAND = 'ls'
@@ -717,16 +718,16 @@ class AdbTest(unittest.TestCase):
             self.assertEqual(stderr,
                              mock_execute_and_process_stdout.return_value)
 
-    def test_root_success(self):
-        with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
-            mock_exec_cmd.return_value = MOCK_ROOT_SUCCESS_OUTPUT
-            output = adb.AdbProxy().root()
-            mock_exec_cmd.assert_called_once_with(
-                ['adb', 'root'],
-                shell=False,
-                timeout=None,
-                stderr=None)
-            self.assertEqual(output, MOCK_ROOT_SUCCESS_OUTPUT)
+    @mock.patch.object(adb.AdbProxy, '_exec_cmd')
+    def test_root_success(self, mock_exec_cmd):
+        mock_exec_cmd.return_value = MOCK_ROOT_SUCCESS_OUTPUT
+        output = adb.AdbProxy().root()
+        mock_exec_cmd.assert_called_once_with(
+            ['adb', 'root'],
+            shell=False,
+            timeout=None,
+            stderr=None)
+        self.assertEqual(output, MOCK_ROOT_SUCCESS_OUTPUT)
 
     @mock.patch('time.sleep', return_value=mock.MagicMock())
     @mock.patch.object(adb.AdbProxy, '_exec_cmd')


### PR DESCRIPTION
Sometimes Error "adb: unable to connect for root: closed" occurs when calling AndroidDevice.reboot(), this mechanism attempts to avoid this error causes a test to be stopped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/690)
<!-- Reviewable:end -->
