### PR TITLE
Add a retry mechanism for the ADB command "root"

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -31,6 +31,11 @@ ADB = 'adb'
 # do with port forwarding must happen under this lock.
 ADB_PORT_LOCK = threading.Lock()
 
+# Number of attempts to execute "adb root", and seconds for interval time of
+# this commands.
+ADB_ROOT_ATTMEPTS = 3
+ADB_ROOT_ATTEMPTS_INTERVAL_SEC = 10
+
 # Qualified class name of the default instrumentation test runner.
 DEFAULT_INSTRUMENTATION_RUNNER = 'com.android.common.support.test.runner.AndroidJUnitRunner'
 
@@ -458,6 +463,38 @@ class AdbProxy(object):
         else:
             return self._execute_adb_and_process_stdout(
                 'shell', instrumentation_command, shell=False, handler=handler)
+
+    def root(self):
+        """Enables ADB root mode on the device.
+
+        This method will retry to execute the command `adb root` when an
+        AdbError occurs, since sometimes the error `adb: unable to connect
+        for root: closed` is raised when executing `adb root` immediately
+        after the device is booted to OS.
+
+        Returns:
+            A string that is the stdout of root command.
+
+        Raises:
+            AdbError: If the command exit code is not 0.
+        """
+        for attempt in range(ADB_ROOT_ATTMEPTS):
+            try:
+                return self._exec_adb_cmd('root',
+                                          args=None,
+                                          shell=False,
+                                          timeout=None,
+                                          stderr=None)
+            except AdbError as e:
+                if attempt + 1 < ADB_ROOT_ATTMEPTS:
+                    logging.debug(
+                      'Retry the command "%s" since Error "%s" occurred.' %
+                      (utils.cli_cmd_to_string(e.cmd),
+                       e.stderr.decode('utf-8').strip()))
+                    # Buffer between "adb root" commands.
+                    time.sleep(ADB_ROOT_ATTEMPTS_INTERVAL_SEC)
+                else:
+                  raise e
 
     def __getattr__(self, name):
         def adb_call(args=None, shell=False, timeout=None, stderr=None):


### PR DESCRIPTION
Sometimes Error "adb: unable to connect for root: closed" occurs when calling AndroidDevice.reboot(), this mechanism attempts to avoid this error causes a test to be stopped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/691)
<!-- Reviewable:end -->
