### PR TITLE
Add tox config for running unit tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Gemfile.lock
 .pytest_cache/
 .sass-cache
 _site
+.tox/

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pip install tox
 ```
 
 Then in the Mobly directory, run:
-```
+```sh
 tox
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ How to use Mobly's Android instrumentation test runner to run Android instrument
 * [Mobly AndroidDevice Service](docs/android_device_service.md) -
 Create custom service to attach to Mobly's `AndroidDevice` controller.
 
+## Test
+To run the unit tests for Mobly to verify your local changes:
+
+Make sure you have `tox` installed:
+```sh
+pip install tox
+```
+
+Then in the Mobly directory, run:
+```
+tox
+```
+
 ## Mobly Snippet
 The Mobly Snippet projects let users better control Android devices.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py36
+
+[testenv]
+deps =
+    pytest
+    mock
+    pytz
+commands =
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,4 @@ deps =
     pytz
 commands =
     pytest
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py3
 
 [testenv]
 deps =


### PR DESCRIPTION
The `setup.py test` command is deprecated, and `tox` is the replacement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/702)
<!-- Reviewable:end -->
