### PR TITLE
Drop py2 and py<3.6 support in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,7 @@ While developed by Googlers, Mobly is not an official Google product.
 
 ## Compatibility
 
-Mobly is compatible with both *python 3.4+* and *python 2.7*.
-
-NOTE: As part of the bigger [communitiy initiative](https://python3statement.org/),
-we are planning to drop Python 2.7 support in 2020. Mobly 1.10 is likely the last
-major release to support Python 2.7.
+Mobly requires *python 3.6+* or newer.
 
 Mobly tests could run on the following platforms:
   - Ubuntu 14.04+
@@ -38,8 +34,8 @@ Mobly tests could run on the following platforms:
 | Windows  | [![Windows Build Status](https://storage.googleapis.com/mobly-kokoro-build-badges/mobly-windows.svg)](https://fusion.corp.google.com/projectanalysis/current/KOKORO/prod%3Amobly%2Fgcp_windows%2Fcontinuous) |
 
 ## System dependencies
-  - adb (1.0.36+ recommended)
-  - python2.7 or python3.4+
+  - adb (1.0.40+ recommended)
+  - python3.6+
   - python-setuptools
 
 *If you use Python3, use `pip3` and `python3` (or python3.x) accordingly.*


### PR DESCRIPTION
The Python 3.6 needs `pytest<6.2.0` due to f-string and some compatibility issues:
https://github.com/pytest-dev/pytest/commit/66bd44c13aa7fd1c94dd70aee40ce2d50ec20f2e
https://github.com/pytest-dev/pytest/releases/tag/6.2.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/703)
<!-- Reviewable:end -->
