### PR TITLE
Fix a non-pythonic usage of `not`.

### DIFF
--- a/mobly/controllers/android_device_lib/event_dispatcher.py
+++ b/mobly/controllers/android_device_lib/event_dispatcher.py
@@ -315,7 +315,7 @@ class EventDispatcher:
         passed.
     """
     self.lock.acquire()
-    if not event_name in self.event_dict or self.event_dict[
+    if event_name not in self.event_dict or self.event_dict[
         event_name] is None:
       self.event_dict[event_name] = queue.Queue()
     self.lock.release()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/708)
<!-- Reviewable:end -->
