### PR TITLE
Drop the py2 compatibility support modules.

### DIFF
--- a/mobly/controllers/android_device_lib/jsonrpc_shell_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_shell_base.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Shared library for frontends to jsonrpc servers."""
-from __future__ import print_function
 
 import code
 import os

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """JSON RPC interface to Mobly Snippet Lib."""
 
-from __future__ import print_function
-
 import re
 import time
 

--- a/mobly/logger.py
+++ b/mobly/logger.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import datetime
 import logging
 import os

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
-
 import argparse
 import contextlib
 import inspect

--- a/tools/snippet_shell.py
+++ b/tools/snippet_shell.py
@@ -24,7 +24,6 @@ $ snippet_shell com.my.package.snippets
 >>> s.mySnippet('example')
 u'You said: example'
 """
-from __future__ import print_function
 
 import argparse
 import logging


### PR DESCRIPTION
1. Remove __future__.print_function which is mandatory in py3
2. Remove future.standard_library.install_aliases() which provides aliases in py2.x

Reference:
https://docs.python.org/3/library/__future__.html
https://python-future.org/reference.html?highlight=install_aliases#module-future.standard_library

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/720)
<!-- Reviewable:end -->
