### PR TITLE
Remove importing class from modules.

### DIFF
--- a/mobly/controllers/android_device_lib/event_dispatcher.py
+++ b/mobly/controllers/android_device_lib/event_dispatcher.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from concurrent.futures import ThreadPoolExecutor
+from concurrent import futures
 import queue
 import re
 import threading
@@ -129,7 +129,7 @@ class EventDispatcher:
     """
     if not self.started:
       self.started = True
-      self.executor = ThreadPoolExecutor(max_workers=32)
+      self.executor = futures.ThreadPoolExecutor(max_workers=32)
       self.poller = self.executor.submit(self.poll_events)
     else:
       raise IllegalStateError("Dispatcher is already started.")


### PR DESCRIPTION
Use import statements for packages and modules only,
not for individual classes or functions.

Reference:
https://google.github.io/styleguide/pyguide.html#22-imports

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/721)
<!-- Reviewable:end -->
