### PR TITLE
Drop the py2 compatibility in super() statements.

### DIFF
--- a/mobly/controllers/android_device_lib/errors.py
+++ b/mobly/controllers/android_device_lib/errors.py
@@ -33,7 +33,7 @@ class DeviceError(Error):
     if isinstance(msg, str) and msg.startswith(HIERARCHY_TOKEN):
       template = '%s%s'
     new_msg = template % (repr(ad), msg)
-    super(DeviceError, self).__init__(new_msg)
+    super().__init__(new_msg)
 
 
 class ServiceError(DeviceError):
@@ -46,4 +46,4 @@ class ServiceError(DeviceError):
 
   def __init__(self, device, msg):
     new_msg = '%sService<%s> %s' % (HIERARCHY_TOKEN, self.SERVICE_TYPE, msg)
-    super(ServiceError, self).__init__(device, new_msg)
+    super().__init__(device, new_msg)

--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -57,7 +57,7 @@ class Logcat(base_service.BaseService):
   OUTPUT_FILE_TYPE = 'logcat'
 
   def __init__(self, android_device, configs=None):
-    super(Logcat, self).__init__(android_device, configs)
+    super().__init__(android_device, configs)
     self._ad = android_device
     self._adb_logcat_process = None
     self._adb_logcat_file_obj = None

--- a/mobly/controllers/android_device_lib/services/snippet_management_service.py
+++ b/mobly/controllers/android_device_lib/services/snippet_management_service.py
@@ -36,7 +36,7 @@ class SnippetManagementService(base_service.BaseService):
     self._device = device
     self._is_alive = False
     self._snippet_clients = {}
-    super(SnippetManagementService, self).__init__(device)
+    super().__init__(device)
 
   @property
   def is_alive(self):

--- a/mobly/controllers/android_device_lib/sl4a_client.py
+++ b/mobly/controllers/android_device_lib/sl4a_client.py
@@ -48,7 +48,7 @@ class Sl4aClient(jsonrpc_client_base.JsonRpcClientBase):
     Args:
       ad: AndroidDevice object.
     """
-    super(Sl4aClient, self).__init__(app_name=_APP_NAME, ad=ad)
+    super().__init__(app_name=_APP_NAME, ad=ad)
     self._ad = ad
     self.ed = None
     self._adb = ad.adb

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -84,7 +84,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
         defined.
       ad: (AndroidDevice) the device object associated with this client.
     """
-    super(SnippetClient, self).__init__(app_name=package, ad=ad)
+    super().__init__(app_name=package, ad=ad)
     self.package = package
     self._ad = ad
     self._adb = ad.adb

--- a/mobly/signals.py
+++ b/mobly/signals.py
@@ -32,7 +32,7 @@ class TestSignal(Exception):
   """
 
   def __init__(self, details, extras=None):
-    super(TestSignal, self).__init__(details)
+    super().__init__(details)
     self.details = details
     try:
       json.dumps(extras)

--- a/tests/lib/mock_instrumentation_test.py
+++ b/tests/lib/mock_instrumentation_test.py
@@ -32,7 +32,7 @@ class MockInstrumentationTest(
     mock_test_run_configs.log_path = tmp_dir
     mock_test_run_configs.user_params = user_params
     mock_test_run_configs.reporter = mock.MagicMock()
-    super(MockInstrumentationTest, self).__init__(mock_test_run_configs)
+    super().__init__(mock_test_run_configs)
 
   def run_mock_instrumentation_test(self, instrumentation_output, prefix):
 

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -145,7 +145,7 @@ class BaseTestTest(unittest.TestCase):
     class MockBaseTest(base_test.BaseTestClass):
 
       def __init__(self, controllers):
-        super(MockBaseTest, self).__init__(controllers)
+        super().__init__(controllers)
         self.tests = ("test_something",)
 
       def test_something(self):
@@ -165,7 +165,7 @@ class BaseTestTest(unittest.TestCase):
     class MockBaseTest(base_test.BaseTestClass):
 
       def __init__(self, controllers):
-        super(MockBaseTest, self).__init__(controllers)
+        super().__init__(controllers)
         self.tests = ("not_a_test_something",)
 
       def not_a_test_something(self):
@@ -186,7 +186,7 @@ class BaseTestTest(unittest.TestCase):
     class MockBaseTest(base_test.BaseTestClass):
 
       def __init__(self, controllers):
-        super(MockBaseTest, self).__init__(controllers)
+        super().__init__(controllers)
         self.tests = ("test_never",)
 
       def test_something(self):
@@ -206,7 +206,7 @@ class BaseTestTest(unittest.TestCase):
     class MockBaseTest(base_test.BaseTestClass):
 
       def __init__(self, controllers):
-        super(MockBaseTest, self).__init__(controllers)
+        super().__init__(controllers)
         self.tests = ("not_a_test_something",)
 
       def not_a_test_something(self):
@@ -257,7 +257,7 @@ class BaseTestTest(unittest.TestCase):
     class MockBaseTest(base_test.BaseTestClass):
 
       def __init__(self, controllers):
-        super(MockBaseTest, self).__init__(controllers)
+        super().__init__(controllers)
         self.test_noncallable = None
 
       @TestDecorator

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
@@ -26,8 +26,7 @@ from tests.lib import jsonrpc_client_test_base
 class FakeRpcClient(jsonrpc_client_base.JsonRpcClientBase):
 
   def __init__(self):
-    super(FakeRpcClient, self).__init__(app_name='FakeRpcClient',
-                                        ad=mock.Mock())
+    super().__init__(app_name='FakeRpcClient', ad=mock.Mock())
 
 
 class JsonRpcClientBaseTest(jsonrpc_client_test_base.JsonRpcClientTestBase):


### PR DESCRIPTION
In code that must support python2, 
super must be called as super(MyClass, self),
but in python3-only code this is unnecessary and not recommended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/722)
<!-- Reviewable:end -->
