### PR TITLE
Drop the py2 compatibility in class declaration statements.

### DIFF
--- a/docs/android_device_service.md
+++ b/docs/android_device_service.md
@@ -24,7 +24,7 @@ Here is a dummy service example:
 `my_service.py`
 
 ```python
-class Configs(object):
+class Configs:
   def __init__(self, secret=None):
     self.secret = secret
 

--- a/mobly/asserts.py
+++ b/mobly/asserts.py
@@ -253,7 +253,7 @@ def explicit_pass(msg, extras=None):
   raise signals.TestPass(msg, extras)
 
 
-class _AssertRaisesContext(object):
+class _AssertRaisesContext:
   """A context manager used to implement TestCase.assertRaises* methods."""
 
   def __init__(self, expected, expected_regexp=None, extras=None):

--- a/mobly/base_instrumentation_test.py
+++ b/mobly/base_instrumentation_test.py
@@ -22,7 +22,7 @@ from mobly import signals
 from mobly import utils
 
 
-class _InstrumentationStructurePrefixes(object):
+class _InstrumentationStructurePrefixes:
   """Class containing prefixes that structure insturmentation output.
 
   Android instrumentation generally follows the following format:
@@ -63,7 +63,7 @@ class _InstrumentationStructurePrefixes(object):
   FAILED = 'INSTRUMENTATION_FAILED:'
 
 
-class _InstrumentationKnownStatusKeys(object):
+class _InstrumentationKnownStatusKeys:
   """Commonly used keys used in instrumentation output for listing
   instrumentation test method result properties.
 
@@ -96,7 +96,7 @@ class _InstrumentationKnownStatusKeys(object):
   STREAM = 'stream'
 
 
-class _InstrumentationStatusCodes(object):
+class _InstrumentationStatusCodes:
   """A mapping of instrumentation status codes to test method results.
 
   When instrumentation runs, at various points output is created in a series
@@ -135,7 +135,7 @@ class _InstrumentationStatusCodes(object):
   ASSUMPTION_FAILURE = '-4'
 
 
-class _InstrumentationStatusCodeCategories(object):
+class _InstrumentationStatusCodeCategories:
   """A mapping of instrumentation test method results to categories.
 
   Aside from the TIMING category, these categories roughly map to Mobly
@@ -160,7 +160,7 @@ class _InstrumentationStatusCodeCategories(object):
   ]
 
 
-class _InstrumentationKnownResultKeys(object):
+class _InstrumentationKnownResultKeys:
   """Commonly used keys for outputting instrumentation errors.
 
   When instrumentation finishes running all of the instrumentation test
@@ -192,7 +192,7 @@ class _InstrumentationKnownResultKeys(object):
   SHORTMSG = 'shortMsg'
 
 
-class _InstrumentationResultSignals(object):
+class _InstrumentationResultSignals:
   """Instrumenttion result block strings for signalling run completion.
 
   The final section of the instrumentation output generally follows this
@@ -242,7 +242,7 @@ class _InstrumentationBlockStates(Enum):
   RESULT = 2
 
 
-class _InstrumentationBlock(object):
+class _InstrumentationBlock:
   """Container class for parsed instrumentation output for instrumentation
   test methods.
 
@@ -465,7 +465,7 @@ class _InstrumentationBlock(object):
       return next_block
 
 
-class _InstrumentationBlockFormatter(object):
+class _InstrumentationBlockFormatter:
   """Takes an instrumentation block and converts it into a Mobly test
   result.
   """
@@ -651,7 +651,7 @@ class _InstrumentationBlockFormatter(object):
       raise signals.TestError(details=error_message, extras=extras)
 
 
-class InstrumentationTestMixin(object):
+class InstrumentationTestMixin:
   """A mixin for Mobly test classes to inherit from for instrumentation tests.
 
   This class should be used in a subclass of both BaseTestClass and this class

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -49,7 +49,7 @@ class Error(Exception):
   """Raised for exceptions that occurred in BaseTestClass."""
 
 
-class BaseTestClass(object):
+class BaseTestClass:
   """Base class for all test classes to inherit from.
 
   This class gets all the controller objects from test_runner and executes

--- a/mobly/config_parser.py
+++ b/mobly/config_parser.py
@@ -156,7 +156,7 @@ def _load_config_file(path):
     return conf
 
 
-class TestRunConfig(object):
+class TestRunConfig:
   """The data class that holds all the information needed for a test run.
 
   Attributes:

--- a/mobly/controller_manager.py
+++ b/mobly/controller_manager.py
@@ -49,7 +49,7 @@ def verify_controller_module(module):
           (attr, module.__name__))
 
 
-class ControllerManager(object):
+class ControllerManager:
   """Manages the controller objects for Mobly tests.
 
   This manages the life cycles and info retrieval of all controller objects

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -413,7 +413,7 @@ def take_bug_reports(ads, test_name=None, begin_time=None, destination=None):
   utils.concurrent_exec(take_br, args)
 
 
-class AndroidDevice(object):
+class AndroidDevice:
   """Class representing an android device.
 
   Each object of this class represents one Android device in Mobly. This class

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -128,7 +128,7 @@ def list_occupied_adb_ports():
   return used_ports
 
 
-class AdbProxy(object):
+class AdbProxy:
   """Proxy class for ADB.
 
   For syntactic reasons, the '-' in adb commands need to be replaced with

--- a/mobly/controllers/android_device_lib/callback_handler.py
+++ b/mobly/controllers/android_device_lib/callback_handler.py
@@ -32,7 +32,7 @@ class TimeoutError(Error):
   pass
 
 
-class CallbackHandler(object):
+class CallbackHandler:
   """The class used to handle a specific group of callback events.
 
   All the events handled by a CallbackHandler are originally triggered by one

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -97,7 +97,7 @@ class ProtocolError(Error):
   MISMATCHED_API_ID = 'RPC request-response ID mismatch.'
 
 
-class JsonRpcCommand(object):
+class JsonRpcCommand:
   """Commands that can be invoked on all jsonrpc clients.
 
   INIT: Initializes a new session.

--- a/mobly/controllers/android_device_lib/jsonrpc_shell_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_shell_base.py
@@ -25,7 +25,7 @@ class Error(Exception):
   pass
 
 
-class JsonRpcShellBase(object):
+class JsonRpcShellBase:
 
   def _start_services(self, console_env):
     """Starts the services needed by this client and adds them to console_env.

--- a/mobly/controllers/android_device_lib/service_manager.py
+++ b/mobly/controllers/android_device_lib/service_manager.py
@@ -27,7 +27,7 @@ class Error(errors.DeviceError):
   """Root error type for this module."""
 
 
-class ServiceManager(object):
+class ServiceManager:
   """Manager for services of AndroidDevice.
 
   A service is a long running process that involves an Android device, like

--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -30,7 +30,7 @@ class Error(errors.ServiceError):
   SERVICE_TYPE = 'Logcat'
 
 
-class Config(object):
+class Config:
   """Config object for logcat service.
 
   Attributes:

--- a/mobly/controllers/android_device_lib/snippet_event.py
+++ b/mobly/controllers/android_device_lib/snippet_event.py
@@ -28,7 +28,7 @@ def from_dict(event_dict):
                       data=event_dict['data'])
 
 
-class SnippetEvent(object):
+class SnippetEvent:
   """The class that represents callback events for mobly snippet library.
 
   Attributes:

--- a/mobly/controllers/attenuator.py
+++ b/mobly/controllers/attenuator.py
@@ -97,7 +97,7 @@ def _validate_config(config):
       raise Error("Required key %s missing from config %s", (key, config))
 
 
-class AttenuatorPath(object):
+class AttenuatorPath:
   """A convenience class that allows users to control each attenuator path
     separately as different objects, as opposed to passing in an index number
     to the functions of an attenuator device object.

--- a/mobly/controllers/attenuator_lib/minicircuits.py
+++ b/mobly/controllers/attenuator_lib/minicircuits.py
@@ -22,7 +22,7 @@ from mobly.controllers import attenuator
 from mobly.controllers.attenuator_lib import telnet_scpi_client
 
 
-class AttenuatorDevice(object):
+class AttenuatorDevice:
   """This provides a specific telnet-controlled implementation of
     AttenuatorDevice for Mini-Circuits RC-DAT attenuators.
 

--- a/mobly/controllers/attenuator_lib/telnet_scpi_client.py
+++ b/mobly/controllers/attenuator_lib/telnet_scpi_client.py
@@ -26,7 +26,7 @@ def _ascii_string(uc_string):
   return str(uc_string).encode('ASCII')
 
 
-class TelnetScpiClient(object):
+class TelnetScpiClient:
   """This is an internal helper class for Telnet+SCPI command-based
     instruments. It should only be used by those implemention control libraries
     and not by any user code directly.

--- a/mobly/controllers/iperf_server.py
+++ b/mobly/controllers/iperf_server.py
@@ -41,7 +41,7 @@ def destroy(objs):
       pass
 
 
-class IPerfResult(object):
+class IPerfResult:
 
   def __init__(self, result_path):
     try:

--- a/mobly/controllers/monsoon.py
+++ b/mobly/controllers/monsoon.py
@@ -96,7 +96,7 @@ class MonsoonError(mobly.signals.ControllerError):
   """Raised for exceptions encountered in monsoon lib."""
 
 
-class MonsoonProxy(object):
+class MonsoonProxy:
   """Class that directly talks to monsoon over serial.
 
     Provides a simple class to use the power meter, e.g.
@@ -435,7 +435,7 @@ class MonsoonProxy(object):
     #     logging.info("dropped >%d bytes" % flushed)
 
 
-class MonsoonData(object):
+class MonsoonData:
   """A class for reporting power measurement data from monsoon.
 
     Data means the measured current value in Amps.
@@ -653,9 +653,8 @@ class MonsoonData(object):
     return self._header()
 
 
-class Monsoon(object):
-  """The wrapper class for test scripts to interact with monsoon.
-    """
+class Monsoon:
+  """The wrapper class for test scripts to interact with monsoon."""
 
   def __init__(self, *args, **kwargs):
     serial = kwargs["serial"]

--- a/mobly/controllers/sniffer.py
+++ b/mobly/controllers/sniffer.py
@@ -91,7 +91,7 @@ class InvalidOperationError(SnifferError):
   pass
 
 
-class Sniffer(object):
+class Sniffer:
   """This class defines an object representing a sniffer.
 
     The object defines the generic behavior of sniffers - irrespective of how
@@ -268,7 +268,7 @@ class Sniffer(object):
     raise NotImplementedError("Base class should not be called directly!")
 
 
-class ActiveCaptureContext(object):
+class ActiveCaptureContext:
   """This class defines an object representing an active sniffer capture.
 
     The object is returned by a Sniffer.start_capture() command and terminates

--- a/mobly/expects.py
+++ b/mobly/expects.py
@@ -29,7 +29,7 @@ from mobly import signals
 DEFAULT_TEST_RESULT_RECORD = records.TestResultRecord('mobly', 'global')
 
 
-class _ExpectErrorRecorder(object):
+class _ExpectErrorRecorder:
   """Singleton used to store errors caught via `expect_*` functions in test.
 
   This class is only instantiated once as a singleton. It holds a reference

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -99,7 +99,7 @@ class Error(Exception):
   """Raised for errors in records."""
 
 
-class TestSummaryWriter(object):
+class TestSummaryWriter:
   """Writer for the test result summary file of a test run.
 
   For each test run, a writer is created to stream test results to the
@@ -165,7 +165,7 @@ class TestSummaryWriter(object):
                        indent=4)
 
 
-class TestResultEnums(object):
+class TestResultEnums:
   """Enums used for TestResultRecord class.
 
   Includes the tokens to mark test result with, and the string names for each
@@ -189,7 +189,7 @@ class TestResultEnums(object):
   TEST_RESULT_ERROR = 'ERROR'
 
 
-class ControllerInfoRecord(object):
+class ControllerInfoRecord:
   """A record representing the controller info in test results."""
 
   KEY_TEST_CLASS = TestResultEnums.RECORD_CLASS
@@ -215,7 +215,7 @@ class ControllerInfoRecord(object):
     return str(self.to_dict())
 
 
-class ExceptionRecord(object):
+class ExceptionRecord:
   """A record representing exception objects in TestResultRecord.
 
   Attributes:
@@ -289,7 +289,7 @@ class ExceptionRecord(object):
     return result
 
 
-class TestResultRecord(object):
+class TestResultRecord:
   """A record that holds the information of a single test.
 
   The record object holds all information of a test, including all the
@@ -489,7 +489,7 @@ class TestResultRecord(object):
     return d
 
 
-class TestResult(object):
+class TestResult:
   """A class that contains metrics of a test run.
 
   This class is essentially a container of TestResultRecord objects.

--- a/mobly/runtime_test_info.py
+++ b/mobly/runtime_test_info.py
@@ -18,7 +18,7 @@ import os
 from mobly import utils
 
 
-class RuntimeTestInfo(object):
+class RuntimeTestInfo:
   """Container class for runtime information of a test or test stage.
 
   One object corresponds to one test. This is meant to be a read-only class.

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -174,7 +174,7 @@ def _print_test_names(test_class):
     print(name)
 
 
-class TestRunner(object):
+class TestRunner:
   """The class that instantiates test classes, executes tests, and
   report results.
 
@@ -187,7 +187,7 @@ class TestRunner(object):
       this test run.
   """
 
-  class _TestRunInfo(object):
+  class _TestRunInfo:
     """Identifies one test class to run, which tests to run, and config to
     run it with.
     """

--- a/tests/lib/jsonrpc_client_test_base.py
+++ b/tests/lib/jsonrpc_client_test_base.py
@@ -43,7 +43,7 @@ class JsonRpcClientTestBase(unittest.TestCase):
   MOCK_RESP_FLEXIABLE_RESULT_LENGTH = (
       '{"id": 0, "result": "%s", "error": null, "status": 0, "callback": null}')
 
-  class MockSocketFile(object):
+  class MockSocketFile:
 
     def __init__(self, resp):
       self.resp = resp

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -76,7 +76,7 @@ def list_adb_devices():
   return [ad.serial for ad in get_mock_ads(5)]
 
 
-class MockAdbProxy(object):
+class MockAdbProxy:
   """Mock class that swaps out calls to adb with mock calls."""
 
   def __init__(self,
@@ -155,7 +155,7 @@ class MockAdbProxy(object):
     return adb_call
 
 
-class MockFastbootProxy(object):
+class MockFastbootProxy:
   """Mock class that swaps out calls to adb with mock calls."""
 
   def __init__(self, serial):

--- a/tests/lib/mock_controller.py
+++ b/tests/lib/mock_controller.py
@@ -39,7 +39,7 @@ def get_info(objs):
   return infos
 
 
-class MagicDevice(object):
+class MagicDevice:
 
   def __init__(self, config):
     self.magic = config

--- a/tests/lib/mock_second_controller.py
+++ b/tests/lib/mock_second_controller.py
@@ -40,7 +40,7 @@ def get_info(objs):
   return infos
 
 
-class AnotherMagicDevice(object):
+class AnotherMagicDevice:
   """This controller supports adding controller's info during test.
 
   It is used for testing that this info is correctly recorded by Mobly.

--- a/tests/lib/multiple_subclasses_module.py
+++ b/tests/lib/multiple_subclasses_module.py
@@ -32,5 +32,5 @@ class Subclass2Runner(test_runner.TestRunner):
   pass
 
 
-class UnrelatedClass(object):
+class UnrelatedClass:
   pass

--- a/tests/mobly/base_instrumentation_test_test.py
+++ b/tests/mobly/base_instrumentation_test_test.py
@@ -46,7 +46,7 @@ INSTRUMENTATION_CODE: -1
 """
 
 
-class InstrumentationResult(object):
+class InstrumentationResult:
 
   def __init__(self):
     self.error = None

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -243,7 +243,7 @@ class BaseTestTest(unittest.TestCase):
     mock_decorated = mock.MagicMock()
     mock_undecorated = mock.MagicMock()
 
-    class TestDecorator(object):
+    class TestDecorator:
 
       def __init__(self, func):
         self.func = func

--- a/tests/mobly/controllers/android_device_lib/service_manager_test.py
+++ b/tests/mobly/controllers/android_device_lib/service_manager_test.py
@@ -104,7 +104,7 @@ class ServiceManagerTest(unittest.TestCase):
 
   def test_register_wrong_subclass_type(self):
 
-    class MyClass(object):
+    class MyClass:
       pass
 
     manager = service_manager.ServiceManager(mock.MagicMock())

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -502,7 +502,7 @@ class UtilsTest(unittest.TestCase):
 
   def test_get_settable_properties(self):
 
-    class SomeClass(object):
+    class SomeClass:
       regular_attr = 'regular_attr'
       _foo = 'foo'
       _bar = 'bar'


### PR DESCRIPTION
In Python 3, only new-style classes exist.
No need to inherit from class object.
Reference:
https://stackoverflow.com/questions/4015417/python-class-inherits-object

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/724)
<!-- Reviewable:end -->
