### PR TITLE
Prefer monotonic time from perf_counter for time measurement.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -1046,10 +1046,10 @@ class AndroidDevice:
       timeout: float, the number of seconds to wait before timing out.
         If not specified, no timeout takes effect.
     """
-    timeout_start = time.time()
+    deadline = time.monotonic() + timeout
 
     self.adb.wait_for_device(timeout=timeout)
-    while time.time() < timeout_start + timeout:
+    while time.monotonic() < deadline:
       try:
         if self.is_boot_completed():
           return

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -1046,10 +1046,10 @@ class AndroidDevice:
       timeout: float, the number of seconds to wait before timing out.
         If not specified, no timeout takes effect.
     """
-    deadline = time.monotonic() + timeout
+    deadline = time.perf_counter() + timeout
 
     self.adb.wait_for_device(timeout=timeout)
-    while time.monotonic() < deadline:
+    while time.perf_counter() < deadline:
       try:
         if self.is_boot_completed():
           return

--- a/mobly/controllers/android_device_lib/callback_handler.py
+++ b/mobly/controllers/android_device_lib/callback_handler.py
@@ -130,10 +130,10 @@ class CallbackHandler:
       TimeoutError: raised if no event that satisfies the predicate is
         received after timeout seconds.
     """
-    deadline = time.monotonic() + timeout
-    while time.monotonic() <= deadline:
+    deadline = time.perf_counter() + timeout
+    while time.perf_counter() <= deadline:
       # Calculate the max timeout for the next event rpc call.
-      rpc_timeout = deadline - time.monotonic()
+      rpc_timeout = deadline - time.perf_counter()
       if rpc_timeout < 0:
         break
       # A single RPC call cannot exceed MAX_TIMEOUT.

--- a/mobly/controllers/android_device_lib/callback_handler.py
+++ b/mobly/controllers/android_device_lib/callback_handler.py
@@ -130,10 +130,10 @@ class CallbackHandler:
       TimeoutError: raised if no event that satisfies the predicate is
         received after timeout seconds.
     """
-    deadline = time.time() + timeout
-    while time.time() <= deadline:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() <= deadline:
       # Calculate the max timeout for the next event rpc call.
-      rpc_timeout = deadline - time.time()
+      rpc_timeout = deadline - time.monotonic()
       if rpc_timeout < 0:
         break
       # A single RPC call cannot exceed MAX_TIMEOUT.

--- a/mobly/controllers/android_device_lib/event_dispatcher.py
+++ b/mobly/controllers/android_device_lib/event_dispatcher.py
@@ -225,7 +225,7 @@ class EventDispatcher:
       queue.Empty: Raised if no event that satisfies the predicate was
         found before time out.
     """
-    deadline = time.monotonic() + timeout
+    deadline = time.perf_counter() + timeout
 
     while True:
       event = None
@@ -237,7 +237,7 @@ class EventDispatcher:
       if event and predicate(event, *args, **kwargs):
         return event
 
-      if time.monotonic() > deadline:
+      if time.perf_counter() > deadline:
         raise queue.Empty('Timeout after {}s waiting for event: {}'.format(
             timeout, event_name))
 
@@ -267,11 +267,11 @@ class EventDispatcher:
     """
     if not self.started:
       raise IllegalStateError("Dispatcher needs to be started before popping.")
-    deadline = time.monotonic() + timeout
+    deadline = time.perf_counter() + timeout
     while True:
       #TODO: fix the sleep loop
       results = self._match_and_pop(regex_pattern)
-      if len(results) != 0 or time.monotonic() > deadline:
+      if len(results) != 0 or time.perf_counter() > deadline:
         break
       time.sleep(1)
     if len(results) == 0:

--- a/mobly/controllers/android_device_lib/event_dispatcher.py
+++ b/mobly/controllers/android_device_lib/event_dispatcher.py
@@ -225,7 +225,7 @@ class EventDispatcher:
       queue.Empty: Raised if no event that satisfies the predicate was
         found before time out.
     """
-    deadline = time.time() + timeout
+    deadline = time.monotonic() + timeout
 
     while True:
       event = None
@@ -237,7 +237,7 @@ class EventDispatcher:
       if event and predicate(event, *args, **kwargs):
         return event
 
-      if time.time() > deadline:
+      if time.monotonic() > deadline:
         raise queue.Empty('Timeout after {}s waiting for event: {}'.format(
             timeout, event_name))
 
@@ -267,11 +267,11 @@ class EventDispatcher:
     """
     if not self.started:
       raise IllegalStateError("Dispatcher needs to be started before popping.")
-    deadline = time.time() + timeout
+    deadline = time.monotonic() + timeout
     while True:
       #TODO: fix the sleep loop
       results = self._match_and_pop(regex_pattern)
-      if len(results) != 0 or time.time() > deadline:
+      if len(results) != 0 or time.monotonic() > deadline:
         break
       time.sleep(1)
     if len(results) == 0:

--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -178,9 +178,9 @@ class Logcat(base_service.BaseService):
     exist.
     """
     if not self._adb_logcat_file_obj:
-      deadline = time.monotonic() + CREATE_LOGCAT_FILE_TIMEOUT_SEC
+      deadline = time.perf_counter() + CREATE_LOGCAT_FILE_TIMEOUT_SEC
       while not os.path.exists(self.adb_logcat_file_path):
-        if time.monotonic() > deadline:
+        if time.perf_counter() > deadline:
           raise Error(self._ad,
                       'Timeout while waiting for logcat file to be created.')
         time.sleep(1)

--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -178,9 +178,9 @@ class Logcat(base_service.BaseService):
     exist.
     """
     if not self._adb_logcat_file_obj:
-      start_time = time.time()
+      deadline = time.monotonic() + CREATE_LOGCAT_FILE_TIMEOUT_SEC
       while not os.path.exists(self.adb_logcat_file_path):
-        if time.time() > start_time + CREATE_LOGCAT_FILE_TIMEOUT_SEC:
+        if time.monotonic() > deadline:
           raise Error(self._ad,
                       'Timeout while waiting for logcat file to be created.')
         time.sleep(1)

--- a/mobly/controllers/android_device_lib/sl4a_client.py
+++ b/mobly/controllers/android_device_lib/sl4a_client.py
@@ -132,9 +132,9 @@ class Sl4aClient(jsonrpc_client_base.JsonRpcClientBase):
 
   def _retry_connect(self):
     self._adb.forward(['tcp:%d' % self.host_port, 'tcp:%d' % self.device_port])
-    expiration_time = time.monotonic() + _APP_START_WAIT_TIME
+    expiration_time = time.perf_counter() + _APP_START_WAIT_TIME
     started = False
-    while time.monotonic() < expiration_time:
+    while time.perf_counter() < expiration_time:
       self.log.debug('Attempting to start %s.', self.app_name)
       try:
         self.connect()

--- a/mobly/controllers/android_device_lib/sl4a_client.py
+++ b/mobly/controllers/android_device_lib/sl4a_client.py
@@ -132,10 +132,9 @@ class Sl4aClient(jsonrpc_client_base.JsonRpcClientBase):
 
   def _retry_connect(self):
     self._adb.forward(['tcp:%d' % self.host_port, 'tcp:%d' % self.device_port])
-    start_time = time.time()
-    expiration_time = start_time + _APP_START_WAIT_TIME
+    expiration_time = time.monotonic() + _APP_START_WAIT_TIME
     started = False
-    while time.time() < expiration_time:
+    while time.monotonic() < expiration_time:
       self.log.debug('Attempting to start %s.', self.app_name)
       try:
         self.connect()

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -173,7 +173,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
     cmd = _LAUNCH_CMD.format(shell_cmd=persists_shell_cmd,
                              user=self._get_user_command_string(),
                              snippet_package=self.package)
-    start_time = time.monotonic()
+    start_time = time.perf_counter()
     self._proc = self._do_start_app(cmd)
 
     # Check protocol version and get the device port
@@ -196,7 +196,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
     # Yaaay! We're done!
     self.log.debug('Snippet %s started after %.1fs on host port %s',
                    self.package,
-                   time.monotonic() - start_time, self.host_port)
+                   time.perf_counter() - start_time, self.host_port)
 
   def restore_app_connection(self, port=None):
     """Restores the app after device got reconnected.

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -173,7 +173,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
     cmd = _LAUNCH_CMD.format(shell_cmd=persists_shell_cmd,
                              user=self._get_user_command_string(),
                              snippet_package=self.package)
-    start_time = time.time()
+    start_time = time.monotonic()
     self._proc = self._do_start_app(cmd)
 
     # Check protocol version and get the device port
@@ -196,7 +196,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
     # Yaaay! We're done!
     self.log.debug('Snippet %s started after %.1fs on host port %s',
                    self.package,
-                   time.time() - start_time, self.host_port)
+                   time.monotonic() - start_time, self.host_port)
 
   def restore_app_connection(self, port=None):
     """Restores the app after device got reconnected.

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -1252,7 +1252,7 @@ class AndroidDeviceTest(unittest.TestCase):
                               serial=1), False, False, False, False
       ])
   @mock.patch('time.sleep', return_value=None)
-  @mock.patch('time.time', side_effect=[0, 5, 10, 15, 20, 25, 30])
+  @mock.patch('time.monotonic', side_effect=[0, 5, 10, 15, 20, 25, 30])
   def test_AndroidDevice_wait_for_completion_never_boot(self, MockTime,
                                                         MockSleep,
                                                         MockIsBootCompleted,

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -1252,7 +1252,7 @@ class AndroidDeviceTest(unittest.TestCase):
                               serial=1), False, False, False, False
       ])
   @mock.patch('time.sleep', return_value=None)
-  @mock.patch('time.monotonic', side_effect=[0, 5, 10, 15, 20, 25, 30])
+  @mock.patch('time.perf_counter', side_effect=[0, 5, 10, 15, 20, 25, 30])
   def test_AndroidDevice_wait_for_completion_never_boot(self, MockTime,
                                                         MockSleep,
                                                         MockIsBootCompleted,


### PR DESCRIPTION
Reference:
https://docs.python.org/3/library/time.html#time.perf_counter
https://www.webucator.com/blog/2015/08/python-clocks-explained/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/725)
<!-- Reviewable:end -->
