### PR TITLE
Drop the py2 compatibility in unittest usages.

### DIFF
--- a/tests/mobly/asserts_test.py
+++ b/tests/mobly/asserts_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from future.tests.base import unittest
+import unittest
 
 from mobly import asserts
 from mobly import signals

--- a/tests/mobly/base_instrumentation_test_test.py
+++ b/tests/mobly/base_instrumentation_test_test.py
@@ -16,8 +16,7 @@ import os
 import mock
 import shutil
 import tempfile
-
-from future.tests.base import unittest
+import unittest
 
 from mobly.base_instrumentation_test import _InstrumentationBlock
 from mobly.base_instrumentation_test import _InstrumentationKnownStatusKeys

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -19,9 +19,8 @@ import os
 import mock
 import shutil
 import tempfile
+import unittest
 import yaml
-
-from future.tests.base import unittest
 
 from mobly import asserts
 from mobly import base_test

--- a/tests/mobly/controller_manager_test.py
+++ b/tests/mobly/controller_manager_test.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for controller manager."""
-import mock
 
-from future.tests.base import unittest
+import mock
+import unittest
 
 from mobly import controller_manager
 from mobly import signals

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import io
 import mock
 import subprocess
+import unittest
 
-from collections import OrderedDict
-from future.tests.base import unittest
 from mobly.controllers.android_device_lib import adb
 
 # Mock parameters for instrumentation.
 MOCK_INSTRUMENTATION_PACKAGE = 'com.my.instrumentation.tests'
 MOCK_INSTRUMENTATION_RUNNER = 'com.my.instrumentation.runner'
-MOCK_INSTRUMENTATION_OPTIONS = OrderedDict([
+MOCK_INSTRUMENTATION_OPTIONS = collections.OrderedDict([
     ('option1', 'value1'),
     ('option2', 'value2'),
 ])

--- a/tests/mobly/controllers/android_device_lib/callback_handler_test.py
+++ b/tests/mobly/controllers/android_device_lib/callback_handler_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import mock
-from future.tests.base import unittest
+import unittest
 
 from mobly.controllers.android_device_lib import callback_handler
 from mobly.controllers.android_device_lib import jsonrpc_client_base

--- a/tests/mobly/controllers/android_device_lib/errors_test.py
+++ b/tests/mobly/controllers/android_device_lib/errors_test.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for Mobly android_device_lib.errors."""
-import mock
 
-from future.tests.base import unittest
+import mock
+import unittest
 
 from mobly.controllers.android_device_lib import errors
 

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
@@ -17,7 +17,7 @@ from builtins import str
 import json
 import mock
 import socket
-from future.tests.base import unittest
+import unittest
 
 from mobly.controllers.android_device_lib import jsonrpc_client_base
 from tests.lib import jsonrpc_client_test_base

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_shell_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_shell_base_test.py
@@ -13,17 +13,15 @@
 # limitations under the License.
 
 import os
-
 import mock
-from future.tests.base import unittest
+import unittest
 
 from mobly.controllers import android_device
 from mobly.controllers.android_device_lib import jsonrpc_shell_base
 
 
 class JsonRpcClientBaseTest(unittest.TestCase):
-  """Unit tests for mobly.controllers.android_device_lib.jsonrpc_shell_base.
-  """
+  """Unit tests for mobly.controllers.android_device_lib.jsonrpc_shell_base."""
 
   @mock.patch.object(android_device, 'list_adb_devices')
   @mock.patch.object(android_device, 'get_instances')

--- a/tests/mobly/controllers/android_device_lib/service_manager_test.py
+++ b/tests/mobly/controllers/android_device_lib/service_manager_test.py
@@ -15,8 +15,7 @@
 
 import importlib
 import mock
-
-from future.tests.base import unittest
+import unittest
 
 from mobly import expects
 from mobly.controllers.android_device_lib import service_manager

--- a/tests/mobly/controllers/android_device_lib/services/base_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/base_service_test.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import mock
-from future.tests.base import unittest
+import unittest
+
 from mobly.controllers.android_device_lib.services import base_service
 
 

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -18,8 +18,7 @@ import mock
 import os
 import shutil
 import tempfile
-
-from future.tests.base import unittest
+import unittest
 
 from mobly import utils
 from mobly import runtime_test_info

--- a/tests/mobly/controllers/android_device_lib/services/sl4a_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/sl4a_service_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import mock
-from future.tests.base import unittest
+import unittest
 
 from mobly.controllers.android_device_lib.services import sl4a_service
 from mobly.controllers.android_device_lib import service_manager

--- a/tests/mobly/controllers/android_device_lib/services/snippet_management_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/snippet_management_service_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import mock
-from future.tests.base import unittest
+import unittest
 
 from mobly.controllers.android_device_lib.services import snippet_management_service
 

--- a/tests/mobly/controllers/android_device_lib/sl4a_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/sl4a_client_test.py
@@ -16,7 +16,7 @@ from builtins import str
 from builtins import bytes
 
 import mock
-from future.tests.base import unittest
+import unittest
 
 from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import jsonrpc_client_base

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -16,7 +16,7 @@ from builtins import str
 from builtins import bytes
 
 import mock
-from future.tests.base import unittest
+import unittest
 
 from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import jsonrpc_client_base

--- a/tests/mobly/controllers/android_device_lib/snippet_event_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_event_test.py
@@ -14,8 +14,7 @@
 
 import logging
 import time
-
-from future.tests.base import unittest
+import unittest
 
 from mobly.controllers.android_device_lib import snippet_event
 

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -21,9 +21,8 @@ import os
 import shutil
 import sys
 import tempfile
+import unittest
 import yaml
-
-from future.tests.base import unittest
 
 from mobly import runtime_test_info
 from mobly.controllers import android_device

--- a/tests/mobly/controllers/monsoon_test.py
+++ b/tests/mobly/controllers/monsoon_test.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import platform
-
-from future.tests.base import unittest
+import unittest
 
 
 class MonsoonTest(unittest.TestCase):

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -21,9 +21,8 @@ import os
 import shutil
 import tempfile
 import threading
+import unittest
 import yaml
-
-from future.tests.base import unittest
 
 from mobly import records
 from mobly import signals

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -19,8 +19,8 @@ import os
 import re
 import shutil
 import tempfile
+import unittest
 import yaml
-from future.tests.base import unittest
 
 from mobly import config_parser
 from mobly import records

--- a/tests/mobly/test_suite_test.py
+++ b/tests/mobly/test_suite_test.py
@@ -16,8 +16,7 @@ import os
 import mock
 import shutil
 import tempfile
-
-from future.tests.base import unittest
+import unittest
 
 from mobly import base_test
 from mobly import config_parser

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -24,7 +24,7 @@ import subprocess
 import tempfile
 import threading
 import time
-from future.tests.base import unittest
+import unittest
 
 import portpicker
 import psutil


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/726)
<!-- Reviewable:end -->
