### PR TITLE
Drop the py2 compatibility in raise_with_traceback.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -19,8 +19,7 @@ import functools
 import inspect
 import logging
 import os
-
-from future.utils import raise_with_traceback
+import sys
 
 from mobly import controller_manager
 from mobly import expects
@@ -585,7 +584,8 @@ class BaseTestClass(object):
         try:
           self._setup_test(test_name)
         except signals.TestFailure as e:
-          raise_with_traceback(signals.TestError(e.details, e.extras))
+          _, _, traceback = sys.exc_info()
+          raise signals.TestError(e.details, e.extras).with_traceback(traceback)
         test_method()
       except (signals.TestPass, signals.TestAbortSignal):
         raise


### PR DESCRIPTION
Directly call BaseException#with_traceback to remove "future" module dependence.
Reference:
https://github.com/PythonCharmers/python-future/blob/master/src/future/utils/__init__.py#L446

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/727)
<!-- Reviewable:end -->
