### PR TITLE
Use "GitHub actions" to run CI tests for google/mobly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
     steps:
-    - name: checkout repo
+    - name: Checkout repo
       uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI tests for google/mobly
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: [ubuntu-latest, macos-latest, windows-latest]
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: checkout repo
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: ${{ github.repository }}
+        token: ${{ github.token }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+
+    # https://github.com/diegovalenzuelaiturra/yapf-action
+    - name: YAPF Formatter
+      uses: diegovalenzuelaiturra/yapf-action@master
+      with:
+        args: . --verbose --recursive --in-place --parallel
+
+    - name: Test with tox
+      run: |
+        tox
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox
 
-    # https://github.com/diegovalenzuelaiturra/yapf-action
-    - name: YAPF Formatter
-      uses: diegovalenzuelaiturra/yapf-action@master
-      with:
-        args: . --verbose --recursive --in-place --parallel
-
     - name: Test with tox
       run: |
         tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,12 @@ name: CI tests for google/mobly
 on: [push]
 
 jobs:
-  build:
-    runs-on: [ubuntu-latest, macos-latest, windows-latest]
+  build-and-test:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
-
     steps:
     - name: checkout repo
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,13 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v2
+    - name: checkout repo
+      uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: checkout repo
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: ${{ github.repository }}
-        token: ${{ github.token }}
 
     - name: Install dependencies
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+language: python
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+install: pip install tox-travis
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: python
-python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
-install: pip install tox-travis
-script: tox


### PR DESCRIPTION
Because Travis CI seems down and we can't get CI signal for google/mobly.     
We want to replace the "Travis CI" with "GitHub actions".
It not only can cover Linux but also Windows and MacOS with simple config files.
This PR add "GitHub actions" and delete "Travis CI" in the next PR.

The sample run results can be found at:    
https://github.com/eric100lin/mobly/runs/2436275239

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/736)
<!-- Reviewable:end -->
