### PR TITLE
Trigger the CI runs on pull request too.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI tests for google/mobly
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
For external contributors or PR created from forked repository, we need to trigger the CI for them.     
Reference:
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/738)
<!-- Reviewable:end -->
