### PR TITLE
Show test run metadata in test summary.

### DIFF
--- a/mobly/logger.py
+++ b/mobly/logger.py
@@ -259,7 +259,7 @@ def setup_test_logger(log_path, prefix=None, alias='latest'):
   """
   utils.create_dir(log_path)
   _setup_test_logger(log_path, prefix)
-  logging.info('Test output folder: "%s"', log_path)
+  logging.debug('Test output folder: "%s"', log_path)
   if alias:
     create_latest_log_alias(log_path, alias=alias)
 

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -183,8 +183,8 @@ class TestRunner:
   results for all tests that have been added to this runner.
 
   Attributes:
-    self.results: The test result object used to record the results of
-      this test run.
+    results: records.TestResult, object used to record the results of a test
+      run.
   """
 
   class _TestRunInfo:
@@ -300,7 +300,7 @@ class TestRunner:
     Yields:
       The host file path where the logs for the test run are stored.
     """
-    # Refersh the log path at the beginning of the logger context.
+    # Refresh the log path at the beginning of the logger context.
     root_output_path = self._test_run_metadata.generate_test_run_log_path()
     logger.setup_test_logger(root_output_path, self._testbed_name, alias=alias)
     try:
@@ -415,5 +415,4 @@ class TestRunner:
           f'Artifacts are saved in "{self._test_run_metadata.root_output_path}"',
           f'Test results: {self.results.summary_str()}'
       ]
-      msg = '\n'.join(summary_lines)
-      logging.info(msg.strip())
+      logging.info('\n'.join(summary_lines))


### PR DESCRIPTION
* Encapsulate test run metadata with a proper container.
* Record test run elapsed time and print it in console.
* Print out the log path in console to make parsing easier.
* Clarify the ambiguity in test runner logger setup and run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/751)
<!-- Reviewable:end -->
