### PR TITLE
Update tutorial.md: add: pip install mobly to setup instructions

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -6,6 +6,7 @@ various devices and you can also use your own custom hardware/equipment.
 
 ## Setup Requirements
 
+*   pip install mobly
 *   A computer with at least 2 USB ports.
 *   Mobly package and its system dependencies installed on the computer.
 *   One or two Android devices with the [Mobly Bundled Snippets]


### PR DESCRIPTION
pip install mobly missing from setup instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/752)
<!-- Reviewable:end -->
