### PR TITLE
Use `assertRaises` instead of catch and assert

### DIFF
--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -1141,21 +1141,23 @@ class AndroidDeviceTest(unittest.TestCase):
     mock_serial = '1'
     ad = android_device.AndroidDevice(serial=mock_serial)
     self.assertEqual(ad.debug_tag, '1')
-    try:
+    with self.assertRaisesRegex(
+        android_device.DeviceError,
+        r'<AndroidDevice\|1> Something'):
       raise android_device.DeviceError(ad, 'Something')
-    except android_device.DeviceError as e:
-      self.assertEqual('<AndroidDevice|1> Something', str(e))
+
     # Verify that debug tag's setter updates the debug prefix correctly.
     ad.debug_tag = 'Mememe'
-    try:
+    with self.assertRaisesRegex(
+        android_device.DeviceError,
+        r'<AndroidDevice\|Mememe> Something'):
       raise android_device.DeviceError(ad, 'Something')
-    except android_device.DeviceError as e:
-      self.assertEqual('<AndroidDevice|Mememe> Something', str(e))
+
     # Verify that repr is changed correctly.
-    try:
+    with self.assertRaisesRegex(
+        Exception,
+        r"(<AndroidDevice\|Mememe>, 'Something')"):
       raise Exception(ad, 'Something')
-    except Exception as e:
-      self.assertEqual("(<AndroidDevice|Mememe>, 'Something')", str(e))
 
   @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
               return_value=mock_android_device.MockAdbProxy('1'))

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -1156,7 +1156,7 @@ class AndroidDeviceTest(unittest.TestCase):
     # Verify that repr is changed correctly.
     with self.assertRaisesRegex(
         Exception,
-        r"(<AndroidDevice\|Mememe>, 'Something')"):
+        r'(<AndroidDevice\|Mememe>, \'Something\')'):
       raise Exception(ad, 'Something')
 
   @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',


### PR DESCRIPTION
Cleanup "Use of an assertion within an except block is error-prone" 

fixes #753

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/754)
<!-- Reviewable:end -->
