### PR TITLE
Cache the current user id in SnippetClient.

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -270,33 +270,30 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
 
   def _check_app_installed(self):
     # Check that the Mobly Snippet app is installed for the current user.
-    user_id = self.user_id
-    out = self._adb.shell('pm list package --user %s' % user_id)
+    out = self._adb.shell(f'pm list package --user {self.user_id}')
     if not utils.grep('^package:%s$' % self.package, out):
       raise AppStartPreCheckError(
-          self._ad,
-          '%s is not installed for user %s.' % (self.package, user_id))
+          self._ad, f'{self.package} is not installed for user {self.user_id}.')
     # Check that the app is instrumented.
     out = self._adb.shell('pm list instrumentation')
     matched_out = utils.grep(
-        '^instrumentation:%s/%s' %
-        (self.package, _INSTRUMENTATION_RUNNER_PACKAGE), out)
+        f'^instrumentation:{self.package}/{_INSTRUMENTATION_RUNNER_PACKAGE}',
+        out)
     if not matched_out:
       raise AppStartPreCheckError(
-          self._ad,
-          '%s is installed, but it is not instrumented.' % self.package)
+          self._ad, f'{self.package} is installed, but it is not instrumented.')
     match = re.search(r'^instrumentation:(.*)\/(.*) \(target=(.*)\)$',
                       matched_out[0])
     target_name = match.group(3)
     # Check that the instrumentation target is installed if it's not the
     # same as the snippet package.
     if target_name != self.package:
-      out = self._adb.shell('pm list package --user %s' % user_id)
+      out = self._adb.shell(f'pm list package --user {self.user_id}')
       if not utils.grep('^package:%s$' % target_name, out):
         raise AppStartPreCheckError(
             self._ad,
-            'Instrumentation target %s is not installed for user %s.' %
-            (target_name, user_id))
+            f'Instrumentation target {target_name} is not installed for user '
+            f'{self.user_id}.')
 
   def _do_start_app(self, launch_cmd):
     adb_cmd = [adb.ADB]

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -87,11 +87,27 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
     self._ad = ad
     self._adb = ad.adb
     self._proc = None
+    self._user_id = None
 
   @property
   def is_alive(self):
     """Does the client have an active connection to the snippet server."""
     return self._conn is not None
+
+  @property
+  def user_id(self):
+    """The user id to use for this snippet client.
+
+    This value is cached and, once set, does not change through the lifecycles
+    of this snippet client object. This caching also reduces the number of adb
+    calls needed.
+
+    Because all the operations of the snippet client should be done for a
+    partucular user.
+    """
+    if self._user_id is None:
+      self._user_id = self._adb.current_user_id
+    return self._user_id
 
   def _get_user_command_string(self):
     """Gets the appropriate command argument for specifying user IDs.
@@ -108,7 +124,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
     sdk_int = int(self._ad.build_info['build_version_sdk'])
     if sdk_int < 24:
       return ''
-    return '--user %s' % self._adb.current_user_id
+    return '--user %s' % self.user_id
 
   def start_app_and_connect(self):
     """Starts snippet apk on the device and connects to it.
@@ -254,7 +270,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
 
   def _check_app_installed(self):
     # Check that the Mobly Snippet app is installed for the current user.
-    user_id = self._adb.current_user_id
+    user_id = self._user_id
     out = self._adb.shell('pm list package --user %s' % user_id)
     if not utils.grep('^package:%s$' % self.package, out):
       raise AppStartPreCheckError(
@@ -313,7 +329,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
       # considering any blank output line to be EOF.
       line = line.strip()
       if (line.startswith('INSTRUMENTATION_RESULT:') or
-         line.startswith('SNIPPET ')):
+          line.startswith('SNIPPET ')):
         self.log.debug('Accepted line from instrumentation output: "%s"', line)
         return line
       self.log.debug('Discarded line from instrumentation output: "%s"', line)

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -124,7 +124,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
     sdk_int = int(self._ad.build_info['build_version_sdk'])
     if sdk_int < 24:
       return ''
-    return '--user %s' % self.user_id
+    return f'--user {self.user_id}'
 
   def start_app_and_connect(self):
     """Starts snippet apk on the device and connects to it.
@@ -270,7 +270,7 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
 
   def _check_app_installed(self):
     # Check that the Mobly Snippet app is installed for the current user.
-    user_id = self._user_id
+    user_id = self.user_id
     out = self._adb.shell('pm list package --user %s' % user_id)
     if not utils.grep('^package:%s$' % self.package, out):
       raise AppStartPreCheckError(

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -338,7 +338,9 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
 
     # Test 'setsid' exists
     client = self._make_client()
-    client._adb.shell = mock.Mock(return_value=b'setsid')
+    client._adb = mock.MagicMock()
+    client._adb.shell.return_value = b'setsid'
+    client._adb.current_user_id = MOCK_USER_ID
     client.start_app_and_connect()
     cmd_setsid = '%s am instrument --user %s -w -e action start %s/%s' % (
         snippet_client._SETSID_COMMAND, MOCK_USER_ID, MOCK_PACKAGE_NAME,


### PR DESCRIPTION
1. For a particular client obj, this value should not change between operations.
2. Reduce the number of `adb getprop` calls to reduce the chance of flakiness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/756)
<!-- Reviewable:end -->
