### PR TITLE
Inspect class instead of class instance to get test methods list.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -905,7 +905,7 @@ class BaseTestClass:
       A list of strings, each is a test method name.
     """
     test_names = []
-    for name, _ in inspect.getmembers(self, callable):
+    for name, _ in inspect.getmembers(type(self), callable):
       if name.startswith('test_'):
         test_names.append(name)
     return test_names + list(self._generated_test_table.keys())

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -274,6 +274,21 @@ class BaseTestTest(unittest.TestCase):
     mock_decorated.assert_called_once_with('test_decorated')
     mock_undecorated.assert_called_once_with('test_undecorated')
 
+  def test_get_existing_tests_do_not_call_properties(self):
+
+    class MockBaseTest(base_test.BaseTestClass):
+
+      def test_something(self):
+        pass
+
+      @property
+      def not_a_test(self):
+        # This property should not be called during get_existing_tests()
+        never_call()
+
+    bt_cls = MockBaseTest(self.mock_test_cls_configs)
+    bt_cls.run()
+
   def test_missing_requested_test_func(self):
 
     class MockBaseTest(base_test.BaseTestClass):


### PR DESCRIPTION
This prevents inspect.getmembers from calling the properties of given test class. 

e.g.
```
>>>class Foo():
...   @property
...   def bar(self):
...       print('Called')

>>> inspect.getmembers(Foo(), callable)
Called
[...]
>>> getattr(Foo(), 'bar')
Called
'baz'

>>> inspect.getmembers(Foo, callable)
[...]
>>> getattr(Foo, 'bar')
<property object at 0x7f7c7463cb30>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/762)
<!-- Reviewable:end -->
