### PR TITLE
Add basic `retry()` and `repeat()` support to generated tests.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -862,6 +862,15 @@ class BaseTestClass:
         raise Error('%s Test name "%s" already exists, cannot be duplicated!' %
                     (root_msg, test_name))
       test_func = functools.partial(test_logic, *args)
+      # If the `test_logic` method is decorated by `retry` or `repeat`
+      # decorators, copy the attributes added by the decorators to the
+      # generated test methods as well, so the generated test methods
+      # also have the retry/repeat behavior.
+      for attr_name in (
+        ATTR_MAX_RETRY_CNT, ATTR_MAX_CONSEC_ERROR, ATTR_REPEAT_CNT):
+        attr = getattr(test_logic, attr_name, None)
+        if attr is not None:
+          setattr(test_func, attr_name, attr)
       if uid_func is not None:
         uid = uid_func(*args)
         if uid is None:

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -2292,6 +2292,27 @@ class BaseTestTest(unittest.TestCase):
     for i, record in enumerate(bt_cls.results.passed):
       self.assertEqual(record.test_name, f'test_something_{i}')
 
+  def test_repeat_generated(self):
+    repeat_count = 3
+
+    class MockBaseTest(base_test.BaseTestClass):
+
+      @base_test.repeat(count=repeat_count)
+      def _run_test_logic(self, arg):
+        pass
+
+      def setup_generated_tests(self):
+        self.generate_tests(
+          self._run_test_logic,
+          name_func=lambda arg: f'test_generated_{arg}',
+          arg_sets=[(1,)])
+
+    bt_cls = MockBaseTest(self.mock_test_cls_configs)
+    bt_cls.run()
+    self.assertEqual(repeat_count, len(bt_cls.results.passed))
+    for i, record in enumerate(bt_cls.results.passed):
+      self.assertEqual(record.test_name, f'test_generated_1_{i}')
+
   def test_repeat_with_failures(self):
     repeat_count = 3
     mock_action = mock.MagicMock()
@@ -2454,6 +2475,38 @@ class BaseTestTest(unittest.TestCase):
     error_record_1, error_record_2 = bt_cls.results.error
     self.assertEqual(error_record_1.test_name, 'test_something')
     self.assertEqual(error_record_2.test_name, 'test_something_retry_1')
+    self.assertIs(error_record_1, error_record_2.retry_parent)
+    self.assertIs(error_record_2, pass_record.retry_parent)
+
+  def test_retry_generated_test_last_pass(self):
+    max_count = 3
+    mock_action = mock.MagicMock(
+      side_effect = [Exception('Fail 1'), Exception('Fail 2'), None])
+
+    class MockBaseTest(base_test.BaseTestClass):
+
+      @base_test.retry(max_count=max_count)
+      def _run_test_logic(self, arg):
+        mock_action()
+
+      def setup_generated_tests(self):
+        self.generate_tests(
+          self._run_test_logic,
+          name_func=lambda arg: f'test_generated_{arg}',
+          arg_sets=[(1,)])
+
+    bt_cls = MockBaseTest(self.mock_test_cls_configs)
+    bt_cls.run()
+    self.assertTrue(bt_cls.results.is_all_pass,
+                    'This test run should be considered pass.')
+    self.assertEqual(3, len(bt_cls.results.executed))
+    self.assertEqual(1, len(bt_cls.results.passed))
+    pass_record = bt_cls.results.passed[0]
+    self.assertEqual(pass_record.test_name, f'test_generated_1_retry_2')
+    self.assertEqual(2, len(bt_cls.results.error))
+    error_record_1, error_record_2 = bt_cls.results.error
+    self.assertEqual(error_record_1.test_name, 'test_generated_1')
+    self.assertEqual(error_record_2.test_name, 'test_generated_1_retry_1')
     self.assertIs(error_record_1, error_record_2.retry_parent)
     self.assertIs(error_record_2, pass_record.retry_parent)
 


### PR DESCRIPTION
When generating tests, if the `test_logic` function is decorated with
either `retry()` or `repeat()` decorators, apply the settings to the
generated test methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/766)
<!-- Reviewable:end -->
