### PR TITLE
Add assertion functions for parity with unittest

### DIFF
--- a/mobly/asserts.py
+++ b/mobly/asserts.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mobly/asserts.py
+++ b/mobly/asserts.py
@@ -36,6 +36,7 @@ def _call_unittest_assertion(assertion_method,
     msg: A string that adds additional info about the failure.
     extras: An optional field for extra information to be included in
       test result.
+    **kwargs: Keyword arguments for the assertion call.
   """
   my_msg = None
   try:
@@ -43,7 +44,7 @@ def _call_unittest_assertion(assertion_method,
   except AssertionError as e:
     my_msg = str(e)
     if msg:
-      my_msg = "%s %s" % (my_msg, msg)
+      my_msg = f'{my_msg} {msg}'
 
   # This raise statement is outside of the above except statement to
   # prevent Python3's exception message from having two tracebacks.
@@ -52,7 +53,7 @@ def _call_unittest_assertion(assertion_method,
 
 
 def assert_equal(first, second, msg=None, extras=None):
-  """Assert the equality of objects, otherwise fail the test.
+  """Asserts the equality of objects, otherwise fail the test.
 
   Error message is "first != second" by default. Additional explanation can
   be supplied in the message.
@@ -72,7 +73,7 @@ def assert_equal(first, second, msg=None, extras=None):
 
 
 def assert_not_equal(first, second, msg=None, extras=None):
-  """Assert that first is not equal (!=) to second."""
+  """Asserts that first is not equal (!=) to second."""
   _call_unittest_assertion(_pyunit_proxy.assertNotEqual,
                            first,
                            second,
@@ -86,7 +87,7 @@ def assert_almost_equal(first,
                         msg=None,
                         delta=None,
                         extras=None):
-  """Assert that first is almost equal to second.
+  """Asserts that first is almost equal to second.
 
   Fails if the two objects are unequal as determined by their difference
   rounded to the given number of decimal places (default 7) and
@@ -121,7 +122,7 @@ def assert_not_almost_equal(first,
                             msg=None,
                             delta=None,
                             extras=None):
-  """Assert that first is not almost equal to second.
+  """Asserts that first is not almost equal to second.
 
   Args:
     first: The first value to compare.
@@ -144,7 +145,7 @@ def assert_not_almost_equal(first,
 
 
 def assert_in(member, container, msg=None, extras=None):
-  """Assert that member is in container."""
+  """Asserts that member is in container."""
   _call_unittest_assertion(_pyunit_proxy.assertIn,
                            member,
                            container,
@@ -153,7 +154,7 @@ def assert_in(member, container, msg=None, extras=None):
 
 
 def assert_not_in(member, container, msg=None, extras=None):
-  """Assert that member is not in container."""
+  """Asserts that member is not in container."""
   _call_unittest_assertion(_pyunit_proxy.assertNotIn,
                            member,
                            container,
@@ -162,7 +163,7 @@ def assert_not_in(member, container, msg=None, extras=None):
 
 
 def assert_is(expr1, expr2, msg=None, extras=None):
-  """Assert that expr1 is expr2."""
+  """Asserts that expr1 is expr2."""
   _call_unittest_assertion(_pyunit_proxy.assertIs,
                            expr1,
                            expr2,
@@ -171,7 +172,7 @@ def assert_is(expr1, expr2, msg=None, extras=None):
 
 
 def assert_is_not(expr1, expr2, msg=None, extras=None):
-  """Assert that expr1 is not expr2."""
+  """Asserts that expr1 is not expr2."""
   _call_unittest_assertion(_pyunit_proxy.assertIsNot,
                            expr1,
                            expr2,
@@ -180,7 +181,7 @@ def assert_is_not(expr1, expr2, msg=None, extras=None):
 
 
 def assert_count_equal(first, second, msg=None, extras=None):
-  """Assert that two iterables have the same element count.
+  """Asserts that two iterables have the same element count.
 
   Element order does not matter.
   Similar to assert_equal(Counter(list(first)), Counter(list(second))).
@@ -204,7 +205,7 @@ def assert_count_equal(first, second, msg=None, extras=None):
 
 
 def assert_less(a, b, msg=None, extras=None):
-  """Assert that a < b."""
+  """Asserts that a < b."""
   _call_unittest_assertion(_pyunit_proxy.assertLess,
                            a,
                            b,
@@ -213,7 +214,7 @@ def assert_less(a, b, msg=None, extras=None):
 
 
 def assert_less_equal(a, b, msg=None, extras=None):
-  """Assert that a <= b."""
+  """Asserts that a <= b."""
   _call_unittest_assertion(_pyunit_proxy.assertLessEqual,
                            a,
                            b,
@@ -222,7 +223,7 @@ def assert_less_equal(a, b, msg=None, extras=None):
 
 
 def assert_greater(a, b, msg=None, extras=None):
-  """Assert that a > b."""
+  """Asserts that a > b."""
   _call_unittest_assertion(_pyunit_proxy.assertGreater,
                            a,
                            b,
@@ -231,7 +232,7 @@ def assert_greater(a, b, msg=None, extras=None):
 
 
 def assert_greater_equal(a, b, msg=None, extras=None):
-  """Assert that a >= b."""
+  """Asserts that a >= b."""
   _call_unittest_assertion(_pyunit_proxy.assertGreaterEqual,
                            a,
                            b,
@@ -240,7 +241,7 @@ def assert_greater_equal(a, b, msg=None, extras=None):
 
 
 def assert_is_none(obj, msg=None, extras=None):
-  """Assert that obj is None."""
+  """Asserts that obj is None."""
   _call_unittest_assertion(_pyunit_proxy.assertIsNone,
                            obj,
                            msg=msg,
@@ -248,7 +249,7 @@ def assert_is_none(obj, msg=None, extras=None):
 
 
 def assert_is_not_none(obj, msg=None, extras=None):
-  """Assert that obj is not None."""
+  """Asserts that obj is not None."""
   _call_unittest_assertion(_pyunit_proxy.assertIsNotNone,
                            obj,
                            msg=msg,
@@ -256,7 +257,7 @@ def assert_is_not_none(obj, msg=None, extras=None):
 
 
 def assert_is_instance(obj, cls, msg=None, extras=None):
-  """Assert that obj is an instance of cls."""
+  """Asserts that obj is an instance of cls."""
   _call_unittest_assertion(_pyunit_proxy.assertIsInstance,
                            obj,
                            cls,
@@ -265,7 +266,7 @@ def assert_is_instance(obj, cls, msg=None, extras=None):
 
 
 def assert_not_is_instance(obj, cls, msg=None, extras=None):
-  """Assert that obj is not an instance of cls."""
+  """Asserts that obj is not an instance of cls."""
   _call_unittest_assertion(_pyunit_proxy.assertNotIsInstance,
                            obj,
                            cls,
@@ -274,7 +275,7 @@ def assert_not_is_instance(obj, cls, msg=None, extras=None):
 
 
 def assert_regex(text, expected_regex, msg=None, extras=None):
-  """Fail the test unless the text matches the regular expression."""
+  """Fails the test unless the text matches the regular expression."""
   _call_unittest_assertion(_pyunit_proxy.assertRegex,
                            text,
                            expected_regex,
@@ -283,7 +284,7 @@ def assert_regex(text, expected_regex, msg=None, extras=None):
 
 
 def assert_not_regex(text, unexpected_regex, msg=None, extras=None):
-  """Fail the test if the text matches the regular expression."""
+  """Fails the test if the text matches the regular expression."""
   _call_unittest_assertion(_pyunit_proxy.assertNotRegex,
                            text,
                            unexpected_regex,

--- a/tests/mobly/asserts_test.py
+++ b/tests/mobly/asserts_test.py
@@ -17,14 +17,13 @@ import unittest
 from mobly import asserts
 from mobly import signals
 
-MSG_EXPECTED_EXCEPTION = "This is an expected exception."
+MSG_EXPECTED_EXCEPTION = 'This is an expected exception.'
 _OBJECT_1 = object()
 _OBJECT_2 = object()
 
 
 class AssertsTest(unittest.TestCase):
-  """Verifies that asserts.xxx functions raise the correct test signals.
-  """
+  """Verifies that asserts.xxx functions raise the correct test signals."""
 
   def test_assert_false(self):
     asserts.assert_false(False, MSG_EXPECTED_EXCEPTION)
@@ -35,18 +34,18 @@ class AssertsTest(unittest.TestCase):
     asserts.assert_not_equal(1, 2)
 
   def test_assert_not_equal_pass_with_msg_and_extras(self):
-    asserts.assert_not_equal(1, 2, msg="Message", extras="Extras")
+    asserts.assert_not_equal(1, 2, msg='Message', extras='Extras')
 
   def test_assert_not_equal_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_not_equal(1, 1)
-    self.assertEqual(cm.exception.details, "1 == 1")
+    self.assertEqual(cm.exception.details, '1 == 1')
 
   def test_assert_not_equal_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_not_equal(1, 1, msg="Message", extras="Extras")
-    self.assertEqual(cm.exception.details, "1 == 1 Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+      asserts.assert_not_equal(1, 1, msg='Message', extras='Extras')
+    self.assertEqual(cm.exception.details, '1 == 1 Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_almost_equal_pass(self):
     asserts.assert_almost_equal(1.000001, 1.000002, places=3)
@@ -55,17 +54,17 @@ class AssertsTest(unittest.TestCase):
   def test_assert_almost_equal_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_almost_equal(1, 1.0005, places=7)
-    self.assertRegex(cm.exception.details, r"1 != 1\.0005 within 7 places")
+    self.assertRegex(cm.exception.details, r'1 != 1\.0005 within 7 places')
 
   def test_assert_almost_equal_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_almost_equal(1,
                                   2,
                                   delta=0.1,
-                                  msg="Message",
-                                  extras="Extras")
-    self.assertRegex(cm.exception.details, r"1 != 2 within 0\.1 delta.*Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+                                  msg='Message',
+                                  extras='Extras')
+    self.assertRegex(cm.exception.details, r'1 != 2 within 0\.1 delta.*Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_not_almost_equal_pass(self):
     asserts.assert_not_almost_equal(1.001, 1.002, places=3)
@@ -74,52 +73,52 @@ class AssertsTest(unittest.TestCase):
   def test_assert_not_almost_equal_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_not_almost_equal(1, 1.0005, places=3)
-    self.assertRegex(cm.exception.details, r"1 == 1\.0005 within 3 places")
+    self.assertRegex(cm.exception.details, r'1 == 1\.0005 within 3 places')
 
   def test_assert_not_almost_equal_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_not_almost_equal(1,
                                       2,
                                       delta=1,
-                                      msg="Message",
-                                      extras="Extras")
-    self.assertRegex(cm.exception.details, r"1 == 2 within 1 delta.*Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+                                      msg='Message',
+                                      extras='Extras')
+    self.assertRegex(cm.exception.details, r'1 == 2 within 1 delta.*Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_in_pass(self):
     asserts.assert_in(1, [1, 2, 3])
     asserts.assert_in(1, (1, 2, 3))
     asserts.assert_in(1, {1: 2, 3: 4})
-    asserts.assert_in("a", "abcd")
+    asserts.assert_in('a', 'abcd')
 
   def test_assert_in_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_in(4, [1, 2, 3])
-    self.assertEqual(cm.exception.details, "4 not found in [1, 2, 3]")
+    self.assertEqual(cm.exception.details, '4 not found in [1, 2, 3]')
 
   def test_assert_in_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_in(4, [1, 2, 3], msg="Message", extras="Extras")
-    self.assertEqual(cm.exception.details, "4 not found in [1, 2, 3] Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+      asserts.assert_in(4, [1, 2, 3], msg='Message', extras='Extras')
+    self.assertEqual(cm.exception.details, '4 not found in [1, 2, 3] Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_not_in_pass(self):
     asserts.assert_not_in(4, [1, 2, 3])
     asserts.assert_not_in(4, (1, 2, 3))
     asserts.assert_not_in(4, {1: 2, 3: 4})
-    asserts.assert_not_in("e", "abcd")
+    asserts.assert_not_in('e', 'abcd')
 
   def test_assert_not_in_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_not_in(1, [1, 2, 3])
-    self.assertEqual(cm.exception.details, "1 unexpectedly found in [1, 2, 3]")
+    self.assertEqual(cm.exception.details, '1 unexpectedly found in [1, 2, 3]')
 
   def test_assert_not_in_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_not_in(1, [1, 2, 3], msg="Message", extras="Extras")
+      asserts.assert_not_in(1, [1, 2, 3], msg='Message', extras='Extras')
     self.assertEqual(cm.exception.details,
-                     "1 unexpectedly found in [1, 2, 3] Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+                     '1 unexpectedly found in [1, 2, 3] Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_is_pass(self):
     asserts.assert_is(_OBJECT_1, _OBJECT_1)
@@ -127,14 +126,14 @@ class AssertsTest(unittest.TestCase):
   def test_assert_is_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_is(_OBJECT_1, _OBJECT_2)
-    self.assertEqual(cm.exception.details, f"{_OBJECT_1} is not {_OBJECT_2}")
+    self.assertEqual(cm.exception.details, f'{_OBJECT_1} is not {_OBJECT_2}')
 
   def test_assert_is_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_is(_OBJECT_1, _OBJECT_2, msg="Message", extras="Extras")
+      asserts.assert_is(_OBJECT_1, _OBJECT_2, msg='Message', extras='Extras')
     self.assertEqual(cm.exception.details,
-                     f"{_OBJECT_1} is not {_OBJECT_2} Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+                     f'{_OBJECT_1} is not {_OBJECT_2} Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_is_not_pass(self):
     asserts.assert_is_not(_OBJECT_1, _OBJECT_2)
@@ -143,17 +142,17 @@ class AssertsTest(unittest.TestCase):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_is_not(_OBJECT_1, _OBJECT_1)
     self.assertEqual(cm.exception.details,
-                     f"unexpectedly identical: {_OBJECT_1}")
+                     f'unexpectedly identical: {_OBJECT_1}')
 
   def test_assert_is_not_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_is_not(_OBJECT_1,
                             _OBJECT_1,
-                            msg="Message",
-                            extras="Extras")
+                            msg='Message',
+                            extras='Extras')
     self.assertEqual(cm.exception.details,
-                     f"unexpectedly identical: {_OBJECT_1} Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+                     f'unexpectedly identical: {_OBJECT_1} Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_count_equal_pass(self):
     asserts.assert_count_equal((1, 3, 3), [3, 1, 3])
@@ -163,16 +162,16 @@ class AssertsTest(unittest.TestCase):
       asserts.assert_count_equal([3, 3], [3])
     self.assertEqual(
         cm.exception.details,
-        "Element counts were not equal:\nFirst has 2, Second has 1:  3")
+        'Element counts were not equal:\nFirst has 2, Second has 1:  3')
 
   def test_assert_count_equal_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_count_equal((3, 3), (4, 4), msg="Message", extras="Extras")
+      asserts.assert_count_equal((3, 3), (4, 4), msg='Message', extras='Extras')
     self.assertEqual(cm.exception.details,
-                     ("Element counts were not equal:\n"
-                      "First has 2, Second has 0:  3\n"
-                      "First has 0, Second has 2:  4 Message"))
-    self.assertEqual(cm.exception.extras, "Extras")
+                     ('Element counts were not equal:\n'
+                      'First has 2, Second has 0:  3\n'
+                      'First has 0, Second has 2:  4 Message'))
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_less_pass(self):
     asserts.assert_less(1.0, 2)
@@ -180,13 +179,13 @@ class AssertsTest(unittest.TestCase):
   def test_assert_less_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_less(1, 1)
-    self.assertEqual(cm.exception.details, "1 not less than 1")
+    self.assertEqual(cm.exception.details, '1 not less than 1')
 
   def test_assert_less_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_less(2, 1, msg="Message", extras="Extras")
-    self.assertEqual(cm.exception.details, "2 not less than 1 Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+      asserts.assert_less(2, 1, msg='Message', extras='Extras')
+    self.assertEqual(cm.exception.details, '2 not less than 1 Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_less_equal_pass(self):
     asserts.assert_less_equal(1.0, 2)
@@ -195,14 +194,14 @@ class AssertsTest(unittest.TestCase):
   def test_assert_less_equal_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_less_equal(2, 1)
-    self.assertEqual(cm.exception.details, "2 not less than or equal to 1")
+    self.assertEqual(cm.exception.details, '2 not less than or equal to 1')
 
   def test_assert_less_equal_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_less_equal(2, 1, msg="Message", extras="Extras")
+      asserts.assert_less_equal(2, 1, msg='Message', extras='Extras')
     self.assertEqual(cm.exception.details,
-                     "2 not less than or equal to 1 Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+                     '2 not less than or equal to 1 Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_greater_pass(self):
     asserts.assert_greater(2, 1.0)
@@ -210,13 +209,13 @@ class AssertsTest(unittest.TestCase):
   def test_assert_greater_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_greater(1, 1)
-    self.assertEqual(cm.exception.details, "1 not greater than 1")
+    self.assertEqual(cm.exception.details, '1 not greater than 1')
 
   def test_assert_greater_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_greater(1, 2, msg="Message", extras="Extras")
-    self.assertEqual(cm.exception.details, "1 not greater than 2 Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+      asserts.assert_greater(1, 2, msg='Message', extras='Extras')
+    self.assertEqual(cm.exception.details, '1 not greater than 2 Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_greater_equal_pass(self):
     asserts.assert_greater_equal(2, 1.0)
@@ -225,14 +224,14 @@ class AssertsTest(unittest.TestCase):
   def test_assert_greater_equal_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_greater_equal(1, 2)
-    self.assertEqual(cm.exception.details, "1 not greater than or equal to 2")
+    self.assertEqual(cm.exception.details, '1 not greater than or equal to 2')
 
   def test_assert_greater_equal_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_greater_equal(1, 2, msg="Message", extras="Extras")
+      asserts.assert_greater_equal(1, 2, msg='Message', extras='Extras')
     self.assertEqual(cm.exception.details,
-                     "1 not greater than or equal to 2 Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+                     '1 not greater than or equal to 2 Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_is_none_pass(self):
     asserts.assert_is_none(None)
@@ -240,13 +239,13 @@ class AssertsTest(unittest.TestCase):
   def test_assert_is_none_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_is_none(1)
-    self.assertEqual(cm.exception.details, "1 is not None")
+    self.assertEqual(cm.exception.details, '1 is not None')
 
   def test_assert_is_none_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_is_none(1, msg="Message", extras="Extras")
-    self.assertEqual(cm.exception.details, "1 is not None Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+      asserts.assert_is_none(1, msg='Message', extras='Extras')
+    self.assertEqual(cm.exception.details, '1 is not None Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_is_not_none_pass(self):
     asserts.assert_is_not_none(1)
@@ -254,92 +253,92 @@ class AssertsTest(unittest.TestCase):
   def test_assert_is_not_none_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_is_not_none(None)
-    self.assertEqual(cm.exception.details, "unexpectedly None")
+    self.assertEqual(cm.exception.details, 'unexpectedly None')
 
   def test_assert_is_none_not_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_is_not_none(None, msg="Message", extras="Extras")
-    self.assertEqual(cm.exception.details, "unexpectedly None Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+      asserts.assert_is_not_none(None, msg='Message', extras='Extras')
+    self.assertEqual(cm.exception.details, 'unexpectedly None Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_is_instance_pass(self):
-    asserts.assert_is_instance("foo", str)
+    asserts.assert_is_instance('foo', str)
     asserts.assert_is_instance(1, int)
     asserts.assert_is_instance(1.0, float)
 
   def test_assert_is_instance_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_is_instance(1, str)
-    self.assertEqual(cm.exception.details, f"1 is not an instance of {str}")
+    self.assertEqual(cm.exception.details, f'1 is not an instance of {str}')
 
   def test_assert_is_instance_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_is_instance(1.0, int, msg="Message", extras="Extras")
+      asserts.assert_is_instance(1.0, int, msg='Message', extras='Extras')
     self.assertEqual(cm.exception.details,
-                     f"1.0 is not an instance of {int} Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+                     f'1.0 is not an instance of {int} Message')
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_not_is_instance_pass(self):
-    asserts.assert_not_is_instance("foo", int)
+    asserts.assert_not_is_instance('foo', int)
     asserts.assert_not_is_instance(1, float)
     asserts.assert_not_is_instance(1.0, int)
 
   def test_assert_not_is_instance_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
       asserts.assert_not_is_instance(1, int)
-    self.assertEqual(cm.exception.details, f"1 is an instance of {int}")
+    self.assertEqual(cm.exception.details, f'1 is an instance of {int}')
 
   def test_assert_not_is_instance_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_not_is_instance("foo", str, msg="Message", extras="Extras")
+      asserts.assert_not_is_instance('foo', str, msg='Message', extras='Extras')
     self.assertEqual(cm.exception.details,
                      f"'foo' is an instance of {str} Message")
-    self.assertEqual(cm.exception.extras, "Extras")
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_regex_pass(self):
-    asserts.assert_regex("Big rocks", r"(r|m)ocks")
+    asserts.assert_regex('Big rocks', r'(r|m)ocks')
 
   def test_assert_regex_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_regex("Big socks", r"(r|m)ocks")
+      asserts.assert_regex('Big socks', r'(r|m)ocks')
     self.assertEqual(
         cm.exception.details,
         "Regex didn't match: '(r|m)ocks' not found in 'Big socks'")
 
   def test_assert_regex_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_regex("Big socks",
-                           r"(r|m)ocks",
-                           msg="Message",
-                           extras="Extras")
+      asserts.assert_regex('Big socks',
+                           r'(r|m)ocks',
+                           msg='Message',
+                           extras='Extras')
     self.assertEqual(
         cm.exception.details,
         ("Regex didn't match: '(r|m)ocks' not found in 'Big socks' "
-         "Message"))
-    self.assertEqual(cm.exception.extras, "Extras")
+         'Message'))
+    self.assertEqual(cm.exception.extras, 'Extras')
 
   def test_assert_not_regex_pass(self):
-    asserts.assert_not_regex("Big socks", r"(r|m)ocks")
+    asserts.assert_not_regex('Big socks', r'(r|m)ocks')
 
   def test_assert_not_regex_fail(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_not_regex("Big rocks", r"(r|m)ocks")
+      asserts.assert_not_regex('Big rocks', r'(r|m)ocks')
     self.assertEqual(
         cm.exception.details,
         "Regex matched: 'rocks' matches '(r|m)ocks' in 'Big rocks'")
 
   def test_assert_not_regex_fail_with_msg_and_extras(self):
     with self.assertRaises(signals.TestFailure) as cm:
-      asserts.assert_not_regex("Big mocks",
-                               r"(r|m)ocks",
-                               msg="Message",
-                               extras="Extras")
+      asserts.assert_not_regex('Big mocks',
+                               r'(r|m)ocks',
+                               msg='Message',
+                               extras='Extras')
     self.assertEqual(
         cm.exception.details,
         ("Regex matched: 'mocks' matches '(r|m)ocks' in 'Big mocks' "
-         "Message"))
-    self.assertEqual(cm.exception.extras, "Extras")
+         'Message'))
+    self.assertEqual(cm.exception.extras, 'Extras')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
   unittest.main()

--- a/tests/mobly/asserts_test.py
+++ b/tests/mobly/asserts_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2021 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ from mobly import asserts
 from mobly import signals
 
 MSG_EXPECTED_EXCEPTION = "This is an expected exception."
+_OBJECT_1 = object()
+_OBJECT_2 = object()
 
 
 class AssertsTest(unittest.TestCase):
@@ -28,6 +30,315 @@ class AssertsTest(unittest.TestCase):
     asserts.assert_false(False, MSG_EXPECTED_EXCEPTION)
     with self.assertRaisesRegex(signals.TestFailure, MSG_EXPECTED_EXCEPTION):
       asserts.assert_false(True, MSG_EXPECTED_EXCEPTION)
+
+  def test_assert_not_equal_pass(self):
+    asserts.assert_not_equal(1, 2)
+
+  def test_assert_not_equal_pass_with_msg_and_extras(self):
+    asserts.assert_not_equal(1, 2, msg="Message", extras="Extras")
+
+  def test_assert_not_equal_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_not_equal(1, 1)
+    self.assertEqual(cm.exception.details, "1 == 1")
+
+  def test_assert_not_equal_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_not_equal(1, 1, msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details, "1 == 1 Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_almost_equal_pass(self):
+    asserts.assert_almost_equal(1.000001, 1.000002, places=3)
+    asserts.assert_almost_equal(1.0, 1.05, delta=0.1)
+
+  def test_assert_almost_equal_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_almost_equal(1, 1.0005, places=7)
+    self.assertRegex(cm.exception.details, r"1 != 1\.0005 within 7 places")
+
+  def test_assert_almost_equal_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_almost_equal(1,
+                                  2,
+                                  delta=0.1,
+                                  msg="Message",
+                                  extras="Extras")
+    self.assertRegex(cm.exception.details, r"1 != 2 within 0\.1 delta.*Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_not_almost_equal_pass(self):
+    asserts.assert_not_almost_equal(1.001, 1.002, places=3)
+    asserts.assert_not_almost_equal(1.0, 1.05, delta=0.01)
+
+  def test_assert_not_almost_equal_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_not_almost_equal(1, 1.0005, places=3)
+    self.assertRegex(cm.exception.details, r"1 == 1\.0005 within 3 places")
+
+  def test_assert_not_almost_equal_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_not_almost_equal(1,
+                                      2,
+                                      delta=1,
+                                      msg="Message",
+                                      extras="Extras")
+    self.assertRegex(cm.exception.details, r"1 == 2 within 1 delta.*Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_in_pass(self):
+    asserts.assert_in(1, [1, 2, 3])
+    asserts.assert_in(1, (1, 2, 3))
+    asserts.assert_in(1, {1: 2, 3: 4})
+    asserts.assert_in("a", "abcd")
+
+  def test_assert_in_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_in(4, [1, 2, 3])
+    self.assertEqual(cm.exception.details, "4 not found in [1, 2, 3]")
+
+  def test_assert_in_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_in(4, [1, 2, 3], msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details, "4 not found in [1, 2, 3] Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_not_in_pass(self):
+    asserts.assert_not_in(4, [1, 2, 3])
+    asserts.assert_not_in(4, (1, 2, 3))
+    asserts.assert_not_in(4, {1: 2, 3: 4})
+    asserts.assert_not_in("e", "abcd")
+
+  def test_assert_not_in_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_not_in(1, [1, 2, 3])
+    self.assertEqual(cm.exception.details, "1 unexpectedly found in [1, 2, 3]")
+
+  def test_assert_not_in_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_not_in(1, [1, 2, 3], msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details,
+                     "1 unexpectedly found in [1, 2, 3] Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_is_pass(self):
+    asserts.assert_is(_OBJECT_1, _OBJECT_1)
+
+  def test_assert_is_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_is(_OBJECT_1, _OBJECT_2)
+    self.assertEqual(cm.exception.details, f"{_OBJECT_1} is not {_OBJECT_2}")
+
+  def test_assert_is_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_is(_OBJECT_1, _OBJECT_2, msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details,
+                     f"{_OBJECT_1} is not {_OBJECT_2} Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_is_not_pass(self):
+    asserts.assert_is_not(_OBJECT_1, _OBJECT_2)
+
+  def test_assert_is_not_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_is_not(_OBJECT_1, _OBJECT_1)
+    self.assertEqual(cm.exception.details,
+                     f"unexpectedly identical: {_OBJECT_1}")
+
+  def test_assert_is_not_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_is_not(_OBJECT_1,
+                            _OBJECT_1,
+                            msg="Message",
+                            extras="Extras")
+    self.assertEqual(cm.exception.details,
+                     f"unexpectedly identical: {_OBJECT_1} Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_count_equal_pass(self):
+    asserts.assert_count_equal((1, 3, 3), [3, 1, 3])
+
+  def test_assert_count_equal_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_count_equal([3, 3], [3])
+    self.assertEqual(
+        cm.exception.details,
+        "Element counts were not equal:\nFirst has 2, Second has 1:  3")
+
+  def test_assert_count_equal_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_count_equal((3, 3), (4, 4), msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details,
+                     ("Element counts were not equal:\n"
+                      "First has 2, Second has 0:  3\n"
+                      "First has 0, Second has 2:  4 Message"))
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_less_pass(self):
+    asserts.assert_less(1.0, 2)
+
+  def test_assert_less_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_less(1, 1)
+    self.assertEqual(cm.exception.details, "1 not less than 1")
+
+  def test_assert_less_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_less(2, 1, msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details, "2 not less than 1 Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_less_equal_pass(self):
+    asserts.assert_less_equal(1.0, 2)
+    asserts.assert_less_equal(1, 1)
+
+  def test_assert_less_equal_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_less_equal(2, 1)
+    self.assertEqual(cm.exception.details, "2 not less than or equal to 1")
+
+  def test_assert_less_equal_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_less_equal(2, 1, msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details,
+                     "2 not less than or equal to 1 Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_greater_pass(self):
+    asserts.assert_greater(2, 1.0)
+
+  def test_assert_greater_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_greater(1, 1)
+    self.assertEqual(cm.exception.details, "1 not greater than 1")
+
+  def test_assert_greater_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_greater(1, 2, msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details, "1 not greater than 2 Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_greater_equal_pass(self):
+    asserts.assert_greater_equal(2, 1.0)
+    asserts.assert_greater_equal(1, 1)
+
+  def test_assert_greater_equal_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_greater_equal(1, 2)
+    self.assertEqual(cm.exception.details, "1 not greater than or equal to 2")
+
+  def test_assert_greater_equal_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_greater_equal(1, 2, msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details,
+                     "1 not greater than or equal to 2 Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_is_none_pass(self):
+    asserts.assert_is_none(None)
+
+  def test_assert_is_none_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_is_none(1)
+    self.assertEqual(cm.exception.details, "1 is not None")
+
+  def test_assert_is_none_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_is_none(1, msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details, "1 is not None Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_is_not_none_pass(self):
+    asserts.assert_is_not_none(1)
+
+  def test_assert_is_not_none_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_is_not_none(None)
+    self.assertEqual(cm.exception.details, "unexpectedly None")
+
+  def test_assert_is_none_not_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_is_not_none(None, msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details, "unexpectedly None Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_is_instance_pass(self):
+    asserts.assert_is_instance("foo", str)
+    asserts.assert_is_instance(1, int)
+    asserts.assert_is_instance(1.0, float)
+
+  def test_assert_is_instance_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_is_instance(1, str)
+    self.assertEqual(cm.exception.details, f"1 is not an instance of {str}")
+
+  def test_assert_is_instance_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_is_instance(1.0, int, msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details,
+                     f"1.0 is not an instance of {int} Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_not_is_instance_pass(self):
+    asserts.assert_not_is_instance("foo", int)
+    asserts.assert_not_is_instance(1, float)
+    asserts.assert_not_is_instance(1.0, int)
+
+  def test_assert_not_is_instance_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_not_is_instance(1, int)
+    self.assertEqual(cm.exception.details, f"1 is an instance of {int}")
+
+  def test_assert_not_is_instance_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_not_is_instance("foo", str, msg="Message", extras="Extras")
+    self.assertEqual(cm.exception.details,
+                     f"'foo' is an instance of {str} Message")
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_regex_pass(self):
+    asserts.assert_regex("Big rocks", r"(r|m)ocks")
+
+  def test_assert_regex_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_regex("Big socks", r"(r|m)ocks")
+    self.assertEqual(
+        cm.exception.details,
+        "Regex didn't match: '(r|m)ocks' not found in 'Big socks'")
+
+  def test_assert_regex_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_regex("Big socks",
+                           r"(r|m)ocks",
+                           msg="Message",
+                           extras="Extras")
+    self.assertEqual(
+        cm.exception.details,
+        ("Regex didn't match: '(r|m)ocks' not found in 'Big socks' "
+         "Message"))
+    self.assertEqual(cm.exception.extras, "Extras")
+
+  def test_assert_not_regex_pass(self):
+    asserts.assert_not_regex("Big socks", r"(r|m)ocks")
+
+  def test_assert_not_regex_fail(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_not_regex("Big rocks", r"(r|m)ocks")
+    self.assertEqual(
+        cm.exception.details,
+        "Regex matched: 'rocks' matches '(r|m)ocks' in 'Big rocks'")
+
+  def test_assert_not_regex_fail_with_msg_and_extras(self):
+    with self.assertRaises(signals.TestFailure) as cm:
+      asserts.assert_not_regex("Big mocks",
+                               r"(r|m)ocks",
+                               msg="Message",
+                               extras="Extras")
+    self.assertEqual(
+        cm.exception.details,
+        ("Regex matched: 'mocks' matches '(r|m)ocks' in 'Big mocks' "
+         "Message"))
+    self.assertEqual(cm.exception.extras, "Extras")
 
 
 if __name__ == "__main__":

--- a/tests/mobly/asserts_test.py
+++ b/tests/mobly/asserts_test.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google Inc.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Added assertion functions for parity with unittest (implemented as wrappers around unittest assertions).

Excluded:
- assertWarns, assertLogs, and assertWarnsRegex as
   they are implemented with their own context managers
   in unittest;
- assertDictContainsSubset (deprecated in unittest).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/769)
<!-- Reviewable:end -->
