### PR TITLE
Fix bad import order according to Google Python style guide.

### DIFF
--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -14,18 +14,15 @@
 
 from concurrent import futures
 import io
-import mock
 import os
 import platform
 import shutil
 import socket
-import sys
 import subprocess
+import sys
 import tempfile
 import threading
 import unittest
-
-import psutil
 
 from mobly import base_test
 from mobly import signals
@@ -35,6 +32,8 @@ from tests.lib import integration_test
 from tests.lib import mock_controller
 from tests.lib import mock_instrumentation_test
 from tests.lib import multiple_subclasses_module
+import mock
+import psutil
 
 MOCK_AVAILABLE_PORT = 5
 ADB_MODULE_PACKAGE_NAME = 'mobly.controllers.android_device_lib.adb'


### PR DESCRIPTION
Imports formatting:
https://google.github.io/styleguide/pyguide.html#313-imports-formatting

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/781)
<!-- Reviewable:end -->
