### PR TITLE
Replace mock with unittest.mock and cleanup import section.

### DIFF
--- a/tests/lib/integration2_test.py
+++ b/tests/lib/integration2_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from mobly import test_runner
-
 from tests.lib import integration_test
 
 

--- a/tests/lib/integration_test.py
+++ b/tests/lib/integration_test.py
@@ -17,7 +17,6 @@ import logging
 from mobly import asserts
 from mobly import base_test
 from mobly import test_runner
-
 from tests.lib import mock_controller
 
 

--- a/tests/lib/jsonrpc_client_test_base.py
+++ b/tests/lib/jsonrpc_client_test_base.py
@@ -11,12 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import random
 import string
-from builtins import str
-
-import mock
 import unittest
+from unittest import mock
 
 
 class JsonRpcClientTestBase(unittest.TestCase):

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -15,11 +15,9 @@
 # This module has common mock objects and functions used in unit tests for
 # mobly.controllers.android_device module.
 
-from builtins import bytes
-
 import logging
-import mock
 import os
+from unittest import mock
 
 DEFAULT_MOCK_PROPERTIES = {
     'ro.build.id': 'AB42',

--- a/tests/lib/mock_instrumentation_test.py
+++ b/tests/lib/mock_instrumentation_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 
 from mobly import base_instrumentation_test
 from mobly import config_parser

--- a/tests/lib/teardown_class_failure_test.py
+++ b/tests/lib/teardown_class_failure_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """A test used to verify the output file includes teardown_class failures."""
+
 from mobly import base_test
 from mobly import test_runner
 

--- a/tests/lib/utils.py
+++ b/tests/lib/utils.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# This module holds util functions that are used in more than one test module.
+"""Holds util functions that are used in more than one test module."""
 
 from mobly import records
 

--- a/tests/mobly/base_instrumentation_test_test.py
+++ b/tests/mobly/base_instrumentation_test_test.py
@@ -12,20 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import mock
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
+from mobly import signals
 from mobly.base_instrumentation_test import _InstrumentationBlock
 from mobly.base_instrumentation_test import _InstrumentationKnownStatusKeys
 from mobly.base_instrumentation_test import _InstrumentationStructurePrefixes
-from mobly.base_instrumentation_test import BaseInstrumentationTestClass
-from mobly import config_parser
-from mobly import signals
-from mobly.controllers import android_device
-from mobly.controllers.android_device_lib import adb
 from tests.lib import mock_instrumentation_test
 
 # A random prefix to test that prefixes are added properly.

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -16,12 +16,11 @@ import copy
 import functools
 import io
 import os
-import mock
 import re
 import shutil
 import tempfile
 import unittest
-import yaml
+from unittest import mock
 
 from mobly import asserts
 from mobly import base_test
@@ -29,10 +28,10 @@ from mobly import config_parser
 from mobly import expects
 from mobly import records
 from mobly import signals
-
 from tests.lib import utils
 from tests.lib import mock_controller
 from tests.lib import mock_second_controller
+import yaml
 
 MSG_EXPECTED_EXCEPTION = "This is an expected exception."
 MSG_EXPECTED_TEST_FAILURE = "This is an expected test failure."

--- a/tests/mobly/controller_manager_test.py
+++ b/tests/mobly/controller_manager_test.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 """Unit tests for controller manager."""
 
-import mock
 import unittest
+from unittest import mock
 
 from mobly import controller_manager
 from mobly import signals
-
 from tests.lib import mock_controller
 
 

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -14,9 +14,9 @@
 
 import collections
 import io
-import mock
 import subprocess
 import unittest
+from unittest import mock
 
 from mobly.controllers.android_device_lib import adb
 

--- a/tests/mobly/controllers/android_device_lib/callback_handler_test.py
+++ b/tests/mobly/controllers/android_device_lib/callback_handler_test.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
 import unittest
+from unittest import mock
 
 from mobly.controllers.android_device_lib import callback_handler
 from mobly.controllers.android_device_lib import jsonrpc_client_base

--- a/tests/mobly/controllers/android_device_lib/errors_test.py
+++ b/tests/mobly/controllers/android_device_lib/errors_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Unit tests for Mobly android_device_lib.errors."""
 
-import mock
 import unittest
+from unittest import mock
 
 from mobly.controllers.android_device_lib import errors
 

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_client_base_test.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str
-
 import json
-import mock
 import socket
 import unittest
+from unittest import mock
 
 from mobly.controllers.android_device_lib import jsonrpc_client_base
 from tests.lib import jsonrpc_client_test_base

--- a/tests/mobly/controllers/android_device_lib/jsonrpc_shell_base_test.py
+++ b/tests/mobly/controllers/android_device_lib/jsonrpc_shell_base_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-import mock
 import unittest
+from unittest import mock
 
 from mobly.controllers import android_device
 from mobly.controllers.android_device_lib import jsonrpc_shell_base

--- a/tests/mobly/controllers/android_device_lib/service_manager_test.py
+++ b/tests/mobly/controllers/android_device_lib/service_manager_test.py
@@ -14,8 +14,8 @@
 """Unit tests for Mobly's ServiceManager."""
 
 import importlib
-import mock
 import unittest
+from unittest import mock
 
 from mobly import expects
 from mobly.controllers.android_device_lib import service_manager

--- a/tests/mobly/controllers/android_device_lib/services/base_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/base_service_test.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
 import unittest
+from unittest import mock
 
 from mobly.controllers.android_device_lib.services import base_service
 

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -12,21 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import logging
-import mock
 import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 from mobly import records
-from mobly import utils
 from mobly import runtime_test_info
 from mobly.controllers import android_device
 from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib.services import logcat
-
 from tests.lib import mock_android_device
 
 # The expected result of the cat adb operation.

--- a/tests/mobly/controllers/android_device_lib/services/sl4a_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/sl4a_service_test.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import mock
-import unittest
 
-from mobly.controllers.android_device_lib.services import sl4a_service
+import unittest
+from unittest import mock
+
 from mobly.controllers.android_device_lib import service_manager
+from mobly.controllers.android_device_lib.services import sl4a_service
 
 
 @mock.patch('mobly.controllers.android_device_lib.sl4a_client.Sl4aClient')

--- a/tests/mobly/controllers/android_device_lib/services/snippet_management_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/snippet_management_service_test.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import mock
+
 import unittest
+from unittest import mock
 
 from mobly.controllers.android_device_lib.services import snippet_management_service
 

--- a/tests/mobly/controllers/android_device_lib/sl4a_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/sl4a_client_test.py
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str
-from builtins import bytes
-
-import mock
 import unittest
+from unittest import mock
 
-from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import jsonrpc_client_base
 from mobly.controllers.android_device_lib import sl4a_client
 from tests.lib import jsonrpc_client_test_base

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str
-from builtins import bytes
-
-import mock
 import unittest
+from unittest import mock
 
 from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import jsonrpc_client_base

--- a/tests/mobly/controllers/android_device_lib/snippet_event_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_event_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-import time
 import unittest
 
 from mobly.controllers.android_device_lib import snippet_event
@@ -37,5 +35,5 @@ class SnippetEventTest(unittest.TestCase):
         "creation_time: 12345678, data: {'foo': 'bar'})")
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
   unittest.main()

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -12,27 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str as new_str
-
 import io
 import logging
-import mock
 import os
 import shutil
-import sys
 import tempfile
 import unittest
-import yaml
+from unittest import mock
 
 from mobly import runtime_test_info
 from mobly.controllers import android_device
 from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import errors
-from mobly.controllers.android_device_lib import snippet_client
 from mobly.controllers.android_device_lib.services import base_service
 from mobly.controllers.android_device_lib.services import logcat
-
 from tests.lib import mock_android_device
+import yaml
 
 MOCK_SNIPPET_PACKAGE_NAME = 'com.my.snippet'
 

--- a/tests/mobly/logger_test.py
+++ b/tests/mobly/logger_test.py
@@ -12,19 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
 import os
-import pytz
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 from mobly import logger
+import pytz
 
 
 class LoggerTest(unittest.TestCase):
-  """Verifies code in mobly.logger module.
-  """
+  """Verifies code in mobly.logger module."""
 
   def setUp(self):
     self.log_dir = tempfile.mkdtemp()

--- a/tests/mobly/output_test.py
+++ b/tests/mobly/output_test.py
@@ -14,22 +14,21 @@
 
 import io
 import logging
-import mock
 import os
 import platform
 import shutil
 import tempfile
 import time
 import unittest
-import yaml
+from unittest import mock
 
 from mobly import config_parser
 from mobly import records
 from mobly import test_runner
-
 from tests.lib import mock_controller
 from tests.lib import integration_test
 from tests.lib import teardown_class_failure_test
+import yaml
 
 if platform.system() == 'Windows':
   import win32file

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -12,22 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import str
-
 import copy
 import io
-import mock
 import os
 import shutil
 import tempfile
-import threading
 import unittest
-import yaml
+from unittest import mock
 
 from mobly import records
 from mobly import signals
-
 from tests.lib import utils
+import yaml
 
 
 class RecordTestError(Exception):

--- a/tests/mobly/suite_runner_test.py
+++ b/tests/mobly/suite_runner_test.py
@@ -13,16 +13,15 @@
 # limitations under the License.
 
 import io
-import mock
 import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 from mobly import suite_runner
-
-from tests.lib import integration_test
 from tests.lib import integration2_test
+from tests.lib import integration_test
 
 
 class SuiteRunnerTest(unittest.TestCase):

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -14,25 +14,24 @@
 
 import io
 import logging
-import mock
 import os
 import re
 import shutil
 import tempfile
 import unittest
-import yaml
+from unittest import mock
 
 from mobly import config_parser
 from mobly import records
 from mobly import signals
 from mobly import test_runner
-
 from tests.lib import mock_android_device
 from tests.lib import mock_controller
 from tests.lib import integration_test
 from tests.lib import integration2_test
 from tests.lib import integration3_test
 from tests.lib import multiple_subclasses_module
+import yaml
 
 
 class TestRunnerTest(unittest.TestCase):

--- a/tests/mobly/test_suite_test.py
+++ b/tests/mobly/test_suite_test.py
@@ -13,18 +13,16 @@
 # limitations under the License.
 
 import os
-import mock
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 from mobly import base_test
 from mobly import config_parser
 from mobly import records
 from mobly import test_runner
-
 from tests.lib import mock_controller
-from tests.lib import utils
 
 
 class TestSuiteTest(unittest.TestCase):

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 import threading
 import unittest
+from unittest import mock
 
 from mobly import base_test
 from mobly import signals
@@ -33,7 +34,6 @@ from tests.lib import integration_test
 from tests.lib import mock_controller
 from tests.lib import mock_instrumentation_test
 from tests.lib import multiple_subclasses_module
-import mock
 
 MOCK_AVAILABLE_PORT = 5
 ADB_MODULE_PACKAGE_NAME = 'mobly.controllers.android_device_lib.adb'

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py3
 [testenv]
 deps =
     pytest
-    mock
     pytz
 commands =
     pytest


### PR DESCRIPTION
1. unittest.mock is added in Python 3.3, Mobly works on 3.6+ so we can replace mock with unittest.mock
2. Fix bad import order according to Google Python style guide: https://google.github.io/styleguide/pyguide.html#313-imports-formatting
3. Cleanup unused import
4. Remove `from builtins import str`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/785)
<!-- Reviewable:end -->
