### PR TITLE
Include fastboot devices when validating controller creation.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -149,7 +149,8 @@ def _validate_device_existence(serials):
     serials: list of strings, the serials of all the devices that are expected
       to exist.
   """
-  valid_ad_identifiers = list_adb_devices() + list_adb_devices_by_usb_id()
+  valid_ad_identifiers = (list_adb_devices() + list_adb_devices_by_usb_id() +
+                          list_fastboot_devices())
   for serial in serials:
     if serial not in valid_ad_identifiers:
       raise Error(f'Android device serial "{serial}" is specified in '


### PR DESCRIPTION
This allows running Mobly tests against devices that are in fastboot mode 
without manually rebooting them first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/791)
<!-- Reviewable:end -->
