### PR TITLE
Fix tests for fastboot device detection on Windows CI.

### DIFF
--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -132,20 +132,26 @@ class AndroidDeviceTest(unittest.TestCase):
     with self.assertRaisesRegex(android_device.Error, expected_msg):
       android_device.create([1])
 
+  @mock.patch('mobly.controllers.android_device.list_fastboot_devices')
   @mock.patch('mobly.controllers.android_device.list_adb_devices')
   @mock.patch('mobly.controllers.android_device.list_adb_devices_by_usb_id')
   @mock.patch('mobly.controllers.android_device.AndroidDevice')
-  def test_get_instances(self, mock_ad_class, mock_list_adb_usb, mock_list_adb):
+  def test_get_instances(self, mock_ad_class, mock_list_adb_usb, mock_list_adb,
+                         mock_list_fastboot):
+    mock_list_fastboot.return_value = ['0']
     mock_list_adb.return_value = ['1']
     mock_list_adb_usb.return_value = []
-    android_device.get_instances(['1'])
-    mock_ad_class.assert_called_with('1')
+    android_device.get_instances(['0', '1'])
+    mock_ad_class.assert_any_call('0')
+    mock_ad_class.assert_any_call('1')
 
+  @mock.patch('mobly.controllers.android_device.list_fastboot_devices')
   @mock.patch('mobly.controllers.android_device.list_adb_devices')
   @mock.patch('mobly.controllers.android_device.list_adb_devices_by_usb_id')
   @mock.patch('mobly.controllers.android_device.AndroidDevice')
   def test_get_instances_do_not_exist(self, mock_ad_class, mock_list_adb_usb,
-                                      mock_list_adb):
+                                      mock_list_adb, mock_list_fastboot):
+    mock_list_fastboot.return_value = []
     mock_list_adb.return_value = []
     mock_list_adb_usb.return_value = []
     with self.assertRaisesRegex(
@@ -154,12 +160,14 @@ class AndroidDeviceTest(unittest.TestCase):
     ):
       android_device.get_instances(['1'])
 
+  @mock.patch('mobly.controllers.android_device.list_fastboot_devices')
   @mock.patch('mobly.controllers.android_device.list_adb_devices')
   @mock.patch('mobly.controllers.android_device.list_adb_devices_by_usb_id')
   @mock.patch('mobly.controllers.android_device.AndroidDevice')
   def test_get_instances_with_configs(self, mock_ad_class, mock_list_adb_usb,
-                                      mock_list_adb):
-    mock_list_adb.return_value = ['1', '2']
+                                      mock_list_adb, mock_list_fastboot):
+    mock_list_fastboot.return_value = ['1']
+    mock_list_adb.return_value = ['2']
     mock_list_adb_usb.return_value = []
     configs = [{'serial': '1'}, {'serial': '2'}]
     android_device.get_instances_with_configs(configs)
@@ -173,12 +181,15 @@ class AndroidDeviceTest(unittest.TestCase):
         f'Required value "serial" is missing in AndroidDevice config {config}'):
       android_device.get_instances_with_configs([config])
 
+  @mock.patch('mobly.controllers.android_device.list_fastboot_devices')
   @mock.patch('mobly.controllers.android_device.list_adb_devices')
   @mock.patch('mobly.controllers.android_device.list_adb_devices_by_usb_id')
   @mock.patch('mobly.controllers.android_device.AndroidDevice')
   def test_get_instances_with_configsdo_not_exist(self, mock_ad_class,
                                                   mock_list_adb_usb,
-                                                  mock_list_adb):
+                                                  mock_list_adb,
+                                                  mock_list_fastboot):
+    mock_list_fastboot.return_value = []
     mock_list_adb.return_value = []
     mock_list_adb_usb.return_value = []
     config = {'serial': '1'}


### PR DESCRIPTION
117f8ec neglected to additionally mock out list_fastboot_devices() in
relevant tests, so running tests would use the system adb if present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/792)
<!-- Reviewable:end -->
