### PR TITLE
Add a flag for switching to use snippet client v2

### DIFF
--- a/mobly/config_parser.py
+++ b/mobly/config_parser.py
@@ -27,7 +27,7 @@ from mobly import utils
 ENV_MOBLY_LOGPATH = 'MOBLY_LOGPATH'
 _DEFAULT_LOG_PATH = '/tmp/logs/mobly/'
 
-# The key in controller config about whether to use snippet client V2
+# The key in controller config for whether to use snippet client v2
 USE_SNIPPET_CLIENT_V2 = 'use_snippet_client_v2'
 
 

--- a/mobly/config_parser.py
+++ b/mobly/config_parser.py
@@ -27,7 +27,6 @@ from mobly import utils
 ENV_MOBLY_LOGPATH = 'MOBLY_LOGPATH'
 _DEFAULT_LOG_PATH = '/tmp/logs/mobly/'
 
-
 # The key in controller config about whether to use snippet client V2
 USE_SNIPPET_CLIENT_V2 = 'use_snippet_client_v2'
 

--- a/mobly/config_parser.py
+++ b/mobly/config_parser.py
@@ -28,6 +28,10 @@ ENV_MOBLY_LOGPATH = 'MOBLY_LOGPATH'
 _DEFAULT_LOG_PATH = '/tmp/logs/mobly/'
 
 
+# The key in controller config about whether to use snippet client V2
+USE_SNIPPET_CLIENT_V2 = 'use_snippet_client_v2'
+
+
 class MoblyConfigError(Exception):
   """Raised when there is a problem in test configuration file."""
 

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -883,7 +883,7 @@ class AndroidDevice:
       if k == config_parser.USE_SNIPPET_CLIENT_V2:
         # This is a special config related to snippet client, do not set it
         # to AndroidDevice itself.
-        self._set_snippet_client_v2(v)
+        self._set_snippet_client_v2_flag(v)
         continue
 
       if hasattr(self, k) and k not in _ANDROID_DEVICE_SETTABLE_PROPS:
@@ -892,8 +892,9 @@ class AndroidDevice:
                    'again.') % (k, getattr(self, k)))
       setattr(self, k, v)
 
-  def _set_snippet_client_v2(self, value):
-    self.services.snippets.set_client_v2(value)
+  def _set_snippet_client_v2_flag(self, flag: bool):
+    """Passes the snippet client v2 flag to snippet management service."""
+    self.services.snippets.set_client_v2_flag(flag)
 
   def root_adb(self):
     """Change adb to root mode for this device if allowed.

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -20,6 +20,7 @@ import re
 import shutil
 import time
 
+from mobly import config_parser
 from mobly import logger as mobly_logger
 from mobly import runtime_test_info
 from mobly import utils
@@ -434,7 +435,7 @@ def take_bug_reports(ads, test_name=None, begin_time=None, destination=None):
 
 class BuildInfoConstants(enum.Enum):
   """Enums for build info constants used for AndroidDevice build info.
-  
+
   Attributes:
     build_info_key: The key used for the build_info dictionary in AndroidDevice.
     system_prop_key: The key used for getting the build info from system
@@ -876,11 +877,20 @@ class AndroidDevice:
       Error: The config is trying to overwrite an existing attribute.
     """
     for k, v in config.items():
+      if k == config_parser.USE_SNIPPET_CLIENT_V2:
+        # This is a special config related to snippet client, do not set it
+        # to AndroidDevice itself.
+        self._set_snippet_client_v2(v)
+        continue
+
       if hasattr(self, k) and k not in _ANDROID_DEVICE_SETTABLE_PROPS:
         raise DeviceError(
             self, ('Attribute %s already exists with value %s, cannot set '
                    'again.') % (k, getattr(self, k)))
       setattr(self, k, v)
+
+  def _set_snippet_client_v2(self, value):
+    self.services.snippets.set_client_v2(value)
 
   def root_adb(self):
     """Change adb to root mode for this device if allowed.

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -792,7 +792,7 @@ class AndroidDevice:
       device is in bootloader mode.
     """
     if self.is_bootloader:
-      self.log.error('Device is in fastboot mode, could not get build ' 'info.')
+      self.log.error('Device is in fastboot mode, could not get build info.')
       return
     if self._build_info is None or self._is_rebooting:
       info = {}
@@ -892,7 +892,7 @@ class AndroidDevice:
                    'again.') % (k, getattr(self, k)))
       setattr(self, k, v)
 
-  def _set_snippet_client_v2_flag(self, flag: bool):
+  def _set_snippet_client_v2_flag(self, flag: bool) -> None:
     """Passes the snippet client v2 flag to snippet management service."""
     self.services.snippets.set_client_v2_flag(flag)
 

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -792,7 +792,7 @@ class AndroidDevice:
       device is in bootloader mode.
     """
     if self.is_bootloader:
-      self.log.error('Device is in fastboot mode, could not get build info.')
+      self.log.error('Device is in fastboot mode, could not get build ' 'info.')
       return
     if self._build_info is None or self._is_rebooting:
       info = {}

--- a/mobly/controllers/android_device_lib/services/snippet_management_service.py
+++ b/mobly/controllers/android_device_lib/services/snippet_management_service.py
@@ -43,7 +43,7 @@ class SnippetManagementService(base_service.BaseService):
       raise Error(self,
                   'Must call `set_client_v2` before adding any snippet. ')
     self._use_client_v2 = flag
-    self._device.log.debug('Set use_client_v2 to %s', self._use_client_v2)
+    self._device.log.debug('Set use_client_v2 to %s', str(self._use_client_v2))
 
   @property
   def is_alive(self):

--- a/mobly/controllers/android_device_lib/services/snippet_management_service.py
+++ b/mobly/controllers/android_device_lib/services/snippet_management_service.py
@@ -39,11 +39,11 @@ class SnippetManagementService(base_service.BaseService):
     self._use_client_v2 = False
     super().__init__(device)
 
-  def set_client_v2_flag(self, flag: bool):
+  def set_client_v2_flag(self, flag: bool) -> None:
     """Sets the flag for whether to use snippet client v2.
 
-    Do not use snippet clients of v1 and v2 at the same time. Thus call this
-    function before adding any snippet client.
+    It is not allowed to use snippet clients of v1 and v2 at the same time.
+    Thus must call this function before adding any snippet client.
 
     By default it will use snippet client v1.
 
@@ -55,9 +55,9 @@ class SnippetManagementService(base_service.BaseService):
       Error: if there is any snippet client in use.
     """
     if self._snippet_clients:
-      raise Error(self,
-                  'There is already a snippet client in use. Please call '
-                  '`set_client_v2_flag` before adding any snippet client. ')
+      raise Error(
+          self, 'There is already a snippet client in use. Please call '
+          '`set_client_v2_flag` before adding any snippet client. ')
     self._use_client_v2 = flag
     self._device.log.debug('Set use_client_v2 flag to %s',
                            str(self._use_client_v2))

--- a/mobly/controllers/android_device_lib/services/snippet_management_service.py
+++ b/mobly/controllers/android_device_lib/services/snippet_management_service.py
@@ -57,7 +57,7 @@ class SnippetManagementService(base_service.BaseService):
     if self._snippet_clients:
       raise Error(
           self, 'There is already a snippet client in use. Please call '
-          '`set_client_v2_flag` before adding any snippet client. ')
+          '`set_client_v2_flag` before adding any snippet client.')
     self._use_client_v2 = flag
     self._device.log.debug('Set use_client_v2 flag to %s',
                            str(self._use_client_v2))

--- a/mobly/controllers/android_device_lib/services/snippet_management_service.py
+++ b/mobly/controllers/android_device_lib/services/snippet_management_service.py
@@ -48,8 +48,7 @@ class SnippetManagementService(base_service.BaseService):
     By default it will use snippet client v1.
 
     Args:
-      flag: whether to use snippet client v2, True for using v2. Default to
-        False.
+      flag: whether to use snippet client v2, True for using v2.
 
     Raises:
       Error: if there is already a snippet client in use.

--- a/mobly/controllers/android_device_lib/services/snippet_management_service.py
+++ b/mobly/controllers/android_device_lib/services/snippet_management_service.py
@@ -36,14 +36,31 @@ class SnippetManagementService(base_service.BaseService):
     self._device = device
     self._is_alive = False
     self._snippet_clients = {}
+    self._use_client_v2 = False
     super().__init__(device)
 
-  def set_client_v2(self, flag):
+  def set_client_v2_flag(self, flag: bool):
+    """Sets the flag for whether to use snippet client v2.
+
+    Do not use snippet clients of v1 and v2 at the same time. Thus call this
+    function before adding any snippet client.
+
+    By default it will use snippet client v1.
+
+    Args:
+      flag: whether to use snippet client v2, True for using v2. Default to
+        False.
+
+    Raises:
+      Error: if there is any snippet client in use.
+    """
     if self._snippet_clients:
       raise Error(self,
-                  'Must call `set_client_v2` before adding any snippet. ')
+                  'There is already a snippet client in use. Please call '
+                  '`set_client_v2_flag` before adding any snippet client. ')
     self._use_client_v2 = flag
-    self._device.log.debug('Set use_client_v2 to %s', str(self._use_client_v2))
+    self._device.log.debug('Set use_client_v2 flag to %s',
+                           str(self._use_client_v2))
 
   @property
   def is_alive(self):

--- a/mobly/controllers/android_device_lib/services/snippet_management_service.py
+++ b/mobly/controllers/android_device_lib/services/snippet_management_service.py
@@ -52,14 +52,14 @@ class SnippetManagementService(base_service.BaseService):
         False.
 
     Raises:
-      Error: if there is any snippet client in use.
+      Error: if there is already a snippet client in use.
     """
     if self._snippet_clients:
       raise Error(
           self, 'There is already a snippet client in use. Please call '
           '`set_client_v2_flag` before adding any snippet client.')
     self._use_client_v2 = flag
-    self._device.log.debug('Set use_client_v2 flag to %s',
+    self._device.log.debug('Set using client v2 flag to %s',
                            str(self._use_client_v2))
 
   @property

--- a/mobly/controllers/android_device_lib/services/snippet_management_service.py
+++ b/mobly/controllers/android_device_lib/services/snippet_management_service.py
@@ -38,6 +38,13 @@ class SnippetManagementService(base_service.BaseService):
     self._snippet_clients = {}
     super().__init__(device)
 
+  def set_client_v2(self, flag):
+    if self._snippet_clients:
+      raise Error(self,
+                  'Must call `set_client_v2` before adding any snippet. ')
+    self._use_client_v2 = flag
+    self._device.log.debug('Set use_client_v2 to %s', self._use_client_v2)
+
   @property
   def is_alive(self):
     """True if any client is running, False otherwise."""

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -94,17 +94,15 @@ def update_controller_config_attribute(test_config: config_parser.TestRunConfig,
                                        key: str, value: Any) -> None:
   """Updates each controller config with the given key and value.
 
-  This function updates each controller config in the given TestRunConfig. This
-  function expects that each controller config is a dictionary, otherwise
-  it throws an error.
+  This function updates each controller config in the given TestRunConfig. It
+  expects that each controller config is a dictionary, otherwise it throws
+  an error.
 
   Args:
-    test_config: config_parser.TestRunConfig, the object which contains all the
-      controller configs to be updated.
-    key: str, the key of the attribute to be updated into the controller
-      config dictionary.
-    value: Any, the value of the attribute to be updated into the controller
-      config dictionary.
+    test_config: the object which contains all the controller configs to be
+      updated.
+    key: the key of the attribute to be updated into each controller config.
+    value: the value of the attribute to be updated into each controller config.
 
   Raises:
     Error: when there is a non-dictionary controller config.
@@ -113,8 +111,8 @@ def update_controller_config_attribute(test_config: config_parser.TestRunConfig,
     for device_config in device_config_list:
       if not isinstance(device_config, dict):
         raise Error(
-            'Tried to update contronller config while it is not a dict.'
-            'Got controller config: %s', str(device_config))
+            'Trying to update a non-dictionary controller config (%s), which '
+            'is not allowed.', str(device_config))
       device_config[key] = value
 
 
@@ -150,7 +148,7 @@ def parse_mobly_cli_args(argv):
   parser.add_argument(
       '--use_mobly_snippet_client_v2',
       action='store_true',
-      help='Whether to use snippet client v1 or v2. If True, use v2. Default '
+      help='Whether to use snippet client v2. True for using v2. Default '
       'to False.')
   parser.add_argument('--tests',
                       '--test_case',

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -94,15 +94,15 @@ def update_controller_config_attribute(test_config: config_parser.TestRunConfig,
                                        key: str, value: Any) -> None:
   """Updates each controller config with the given key and value.
 
-  This function updates each controller config in the given TestRunConfig. It
-  expects that each controller config is a dictionary, otherwise it throws
-  an error.
+  This function puts the given attribute, i.e. key and value, into each
+  controller config in the given TestRunConfig. It expects the type of each
+  controller config to be a dictionary, otherwise it throws an error.
 
   Args:
     test_config: the object which contains all the controller configs to be
       updated.
-    key: the key of the attribute to be updated into each controller config.
-    value: the value of the attribute to be updated into each controller config.
+    key: the key of the attribute to be put into each controller config.
+    value: the value of the attribute to be put into each controller config.
 
   Raises:
     Error: when there is a non-dictionary controller config.

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -72,8 +72,8 @@ def main(argv=None):
     # Set flag of using snippet client v2 according to the command line argument
     if args.use_mobly_snippet_client_v2:
       update_controller_config_attribute(config,
-                                     config_parser.USE_SNIPPET_CLIENT_V2,
-                                     True)
+                                         config_parser.USE_SNIPPET_CLIENT_V2,
+                                         True)
     runner = TestRunner(log_dir=config.log_path,
                         testbed_name=config.testbed_name)
     with runner.mobly_logger():
@@ -90,7 +90,8 @@ def main(argv=None):
     sys.exit(1)
 
 
-def update_controller_config_attribute(test_config: config_parser.TestRunConfig, key: str, value: Any):
+def update_controller_config_attribute(test_config: config_parser.TestRunConfig,
+                                       key: str, value: Any) -> None:
   """Updates each controller config with the given key and value.
 
   This function updates each controller config in the given TestRunConfig. This
@@ -111,8 +112,9 @@ def update_controller_config_attribute(test_config: config_parser.TestRunConfig,
   for device_config_list in test_config.controller_configs.values():
     for device_config in device_config_list:
       if not isinstance(device_config, dict):
-        raise Error('Tried to update contronller config while it is not a dict.'
-                    'Got controller config: %s', str(device_config))
+        raise Error(
+            'Tried to update contronller config while it is not a dict.'
+            'Got controller config: %s', str(device_config))
       device_config[key] = value
 
 

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -61,6 +61,10 @@ def main(argv=None):
     sys.exit(0)
   # Load test config file.
   test_configs = config_parser.load_test_config_file(args.config, args.test_bed)
+  # Modify controller config according to the command line argument
+  update_controller_config_attribute(test_configs,
+                                     config_parser.USE_SNIPPET_CLIENT_V2,
+                                     args.use_mobly_snippet_client_v2)
   # Parse test specifiers if exist.
   tests = None
   if args.tests:
@@ -82,6 +86,15 @@ def main(argv=None):
         ok = False
   if not ok:
     sys.exit(1)
+
+
+def update_controller_config_attribute(test_configs, key, value):
+  if value is None:
+    return
+  for test_config in test_configs:
+    for device_config_list in test_config.controller_configs.values():
+      for device_config in device_config_list:
+        device_config[key] = value
 
 
 def parse_mobly_cli_args(argv):
@@ -113,6 +126,11 @@ def parse_mobly_cli_args(argv):
       action='store_true',
       help='Print the names of the tests defined in a script without '
       'executing them.')
+  parser.add_argument(
+      '--use_mobly_snippet_client_v2',
+      action='store_true',
+      help='Whether to use snippet client v1 or v2. If True, use v2. Default '
+      'to False.')
   parser.add_argument('--tests',
                       '--test_case',
                       nargs='+',

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -18,6 +18,7 @@ import logging
 import os
 import sys
 import time
+from typing import Any
 
 from mobly import base_test
 from mobly import config_parser
@@ -89,7 +90,7 @@ def main(argv=None):
     sys.exit(1)
 
 
-def update_controller_config_attribute(test_config, key, value):
+def update_controller_config_attribute(test_config: config_parser.TestRunConfig, key: str, value: Any):
   """Updates each controller config with the given key and value.
 
   This function updates each controller config in the given TestRunConfig. This

--- a/tests/mobly/controllers/android_device_lib/services/snippet_management_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/snippet_management_service_test.py
@@ -177,7 +177,7 @@ class SnippetManagementServiceTest(unittest.TestCase):
     self.assertEqual(manager._use_client_v2, False)
 
   @mock.patch(SNIPPET_CLIENT_CLASS_PATH)
-  def test_set_client_v2_flag_after_adding_client(self, mock_class):
+  def test_set_client_v2_flag_after_adding_client(self, _):
     """Tests setting client v2 flag after adding a client is not allowed."""
     manager = snippet_management_service.SnippetManagementService(
         mock.MagicMock())

--- a/tests/mobly/controllers/android_device_lib/services/snippet_management_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/snippet_management_service_test.py
@@ -168,11 +168,11 @@ class SnippetManagementServiceTest(unittest.TestCase):
     # assert the default value is False
     self.assertEqual(manager._use_client_v2, False)
 
-    # test set flag to True
+    # test setting flag to True
     manager.set_client_v2_flag(True)
     self.assertEqual(manager._use_client_v2, True)
 
-    # test set flag to False
+    # test setting flag to False
     manager.set_client_v2_flag(False)
     self.assertEqual(manager._use_client_v2, False)
 
@@ -181,8 +181,8 @@ class SnippetManagementServiceTest(unittest.TestCase):
     """Tests setting client v2 flag after adding a client is not allowed."""
     manager = snippet_management_service.SnippetManagementService(
         mock.MagicMock())
-
     manager.add_snippet_client('foo', MOCK_PACKAGE)
+
     with self.assertRaises(snippet_management_service.Error):
       manager.set_client_v2_flag(True)
 

--- a/tests/mobly/controllers/android_device_lib/services/snippet_management_service_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/snippet_management_service_test.py
@@ -161,6 +161,34 @@ class SnippetManagementServiceTest(unittest.TestCase):
     manager.foo.ha('param')
     mock_client.ha.assert_called_once_with('param')
 
+  def test_set_client_v2_flag(self):
+    """Tests setting client v2 flag works normally."""
+    manager = snippet_management_service.SnippetManagementService(
+        mock.MagicMock())
+    # assert the default value is False
+    self.assertEqual(manager._use_client_v2, False)
+
+    # test set flag to True
+    manager.set_client_v2_flag(True)
+    self.assertEqual(manager._use_client_v2, True)
+
+    # test set flag to False
+    manager.set_client_v2_flag(False)
+    self.assertEqual(manager._use_client_v2, False)
+
+  @mock.patch(SNIPPET_CLIENT_CLASS_PATH)
+  def test_set_client_v2_flag_after_adding_client(self, mock_class):
+    """Tests setting client v2 flag after adding a client is not allowed."""
+    manager = snippet_management_service.SnippetManagementService(
+        mock.MagicMock())
+
+    manager.add_snippet_client('foo', MOCK_PACKAGE)
+    with self.assertRaises(snippet_management_service.Error):
+      manager.set_client_v2_flag(True)
+
+    with self.assertRaises(snippet_management_service.Error):
+      manager.set_client_v2_flag(False)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -27,7 +27,8 @@ from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import errors
 from mobly.controllers.android_device_lib.services import base_service
 from mobly.controllers.android_device_lib.services import logcat
-from mobly.controllers.android_device_lib.services import snippet_management_service
+from mobly.controllers.android_device_lib.services import (
+    snippet_management_service)
 from tests.lib import mock_android_device
 import yaml
 

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -872,8 +872,8 @@ class AndroidDeviceTest(unittest.TestCase):
   @mock.patch('mobly.utils.create_dir')
   @mock.patch('mobly.logger.get_log_file_timestamp')
   def test_AndroidDevice_take_screenshot_with_prefix(
-    self, get_log_file_timestamp_mock, create_dir_mock,
-    FastbootProxy, MockAdbProxy):
+      self, get_log_file_timestamp_mock, create_dir_mock, FastbootProxy,
+      MockAdbProxy):
     get_log_file_timestamp_mock.return_value = '07-22-2019_17-53-34-450'
     mock_serial = '1'
     ad = android_device.AndroidDevice(serial=mock_serial)
@@ -1154,22 +1154,19 @@ class AndroidDeviceTest(unittest.TestCase):
     mock_serial = '1'
     ad = android_device.AndroidDevice(serial=mock_serial)
     self.assertEqual(ad.debug_tag, '1')
-    with self.assertRaisesRegex(
-        android_device.DeviceError,
-        r'<AndroidDevice\|1> Something'):
+    with self.assertRaisesRegex(android_device.DeviceError,
+                                r'<AndroidDevice\|1> Something'):
       raise android_device.DeviceError(ad, 'Something')
 
     # Verify that debug tag's setter updates the debug prefix correctly.
     ad.debug_tag = 'Mememe'
-    with self.assertRaisesRegex(
-        android_device.DeviceError,
-        r'<AndroidDevice\|Mememe> Something'):
+    with self.assertRaisesRegex(android_device.DeviceError,
+                                r'<AndroidDevice\|Mememe> Something'):
       raise android_device.DeviceError(ad, 'Something')
 
     # Verify that repr is changed correctly.
-    with self.assertRaisesRegex(
-        Exception,
-        r'(<AndroidDevice\|Mememe>, \'Something\')'):
+    with self.assertRaisesRegex(Exception,
+                                r'(<AndroidDevice\|Mememe>, \'Something\')'):
       raise Exception(ad, 'Something')
 
   @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
@@ -1374,8 +1371,9 @@ class AndroidDeviceTest(unittest.TestCase):
     self.assertTrue(raised, 'did not raise an exception when parsing gbk bytes')
 
   @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
-                return_value=mock_android_device.MockAdbProxy('1'))
-  @mock.patch.object(snippet_management_service.SnippetManagementService, 'set_client_v2_flag')
+              return_value=mock_android_device.MockAdbProxy('1'))
+  @mock.patch.object(snippet_management_service.SnippetManagementService,
+                     'set_client_v2_flag')
   def test_AndroidDevice_set_snippet_client_v2(self, mock_set_func, mock_adb):
     """Tests AndroidDevice passes snippet client flag to management service."""
     del mock_adb  # mock it to avoid errors when instantiating AndroidDevice
@@ -1387,13 +1385,15 @@ class AndroidDeviceTest(unittest.TestCase):
     config = {config_parser.USE_SNIPPET_CLIENT_V2: False}
     ad.load_config(config)
 
-    expected_call_args = [mock.call(True, ), mock.call(False, )]
+    expected_call_args = [mock.call(True,), mock.call(False,)]
     self.assertListEqual(mock_set_func.call_args_list, expected_call_args)
 
   @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
-                return_value=mock_android_device.MockAdbProxy('1'))
-  @mock.patch.object(snippet_management_service.SnippetManagementService, 'set_client_v2_flag')
-  def test_AndroidDevice_do_not_set_snippet_client_v2(self, mock_set_func, mock_adb):
+              return_value=mock_android_device.MockAdbProxy('1'))
+  @mock.patch.object(snippet_management_service.SnippetManagementService,
+                     'set_client_v2_flag')
+  def test_AndroidDevice_do_not_set_snippet_client_v2(self, mock_set_func,
+                                                      mock_adb):
     """Tests AndroidDevice doesn't pass snippet client flag without config."""
     del mock_adb  # mock it to avoid errors when instantiating AndroidDevice
     ad = android_device.AndroidDevice(serial='1')

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -873,8 +873,8 @@ class AndroidDeviceTest(unittest.TestCase):
   @mock.patch('mobly.utils.create_dir')
   @mock.patch('mobly.logger.get_log_file_timestamp')
   def test_AndroidDevice_take_screenshot_with_prefix(
-      self, get_log_file_timestamp_mock, create_dir_mock, FastbootProxy,
-      MockAdbProxy):
+    self, get_log_file_timestamp_mock, create_dir_mock,
+    FastbootProxy, MockAdbProxy):
     get_log_file_timestamp_mock.return_value = '07-22-2019_17-53-34-450'
     mock_serial = '1'
     ad = android_device.AndroidDevice(serial=mock_serial)
@@ -1155,19 +1155,22 @@ class AndroidDeviceTest(unittest.TestCase):
     mock_serial = '1'
     ad = android_device.AndroidDevice(serial=mock_serial)
     self.assertEqual(ad.debug_tag, '1')
-    with self.assertRaisesRegex(android_device.DeviceError,
-                                r'<AndroidDevice\|1> Something'):
+    with self.assertRaisesRegex(
+        android_device.DeviceError,
+        r'<AndroidDevice\|1> Something'):
       raise android_device.DeviceError(ad, 'Something')
 
     # Verify that debug tag's setter updates the debug prefix correctly.
     ad.debug_tag = 'Mememe'
-    with self.assertRaisesRegex(android_device.DeviceError,
-                                r'<AndroidDevice\|Mememe> Something'):
+    with self.assertRaisesRegex(
+        android_device.DeviceError,
+        r'<AndroidDevice\|Mememe> Something'):
       raise android_device.DeviceError(ad, 'Something')
 
     # Verify that repr is changed correctly.
-    with self.assertRaisesRegex(Exception,
-                                r'(<AndroidDevice\|Mememe>, \'Something\')'):
+    with self.assertRaisesRegex(
+        Exception,
+        r'(<AndroidDevice\|Mememe>, \'Something\')'):
       raise Exception(ad, 'Something')
 
   @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -20,6 +20,8 @@ import tempfile
 import unittest
 from unittest import mock
 
+import yaml
+
 from mobly import config_parser
 from mobly import runtime_test_info
 from mobly.controllers import android_device
@@ -30,7 +32,6 @@ from mobly.controllers.android_device_lib.services import logcat
 from mobly.controllers.android_device_lib.services import (
     snippet_management_service)
 from tests.lib import mock_android_device
-import yaml
 
 MOCK_SNIPPET_PACKAGE_NAME = 'com.my.snippet'
 

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -1374,9 +1374,8 @@ class AndroidDeviceTest(unittest.TestCase):
               return_value=mock_android_device.MockAdbProxy('1'))
   @mock.patch.object(snippet_management_service.SnippetManagementService,
                      'set_client_v2_flag')
-  def test_AndroidDevice_set_snippet_client_v2(self, mock_set_func, mock_adb):
+  def test_AndroidDevice_set_snippet_client_v2(self, mock_set_func, _):
     """Tests AndroidDevice passes snippet client flag to management service."""
-    del mock_adb  # mock it to avoid errors when instantiating AndroidDevice
     ad = android_device.AndroidDevice(serial='1')
     config = {config_parser.USE_SNIPPET_CLIENT_V2: True}
     ad.load_config(config)
@@ -1392,10 +1391,8 @@ class AndroidDeviceTest(unittest.TestCase):
               return_value=mock_android_device.MockAdbProxy('1'))
   @mock.patch.object(snippet_management_service.SnippetManagementService,
                      'set_client_v2_flag')
-  def test_AndroidDevice_do_not_set_snippet_client_v2(self, mock_set_func,
-                                                      mock_adb):
+  def test_AndroidDevice_do_not_set_snippet_client_v2(self, mock_set_func, _):
     """Tests AndroidDevice doesn't pass snippet client flag without config."""
-    del mock_adb  # mock it to avoid errors when instantiating AndroidDevice
     ad = android_device.AndroidDevice(serial='1')
     config = {'test_key_not_related_to_snippet_client': True}
     ad.load_config(config)

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -370,73 +370,118 @@ class TestRunnerTest(unittest.TestCase):
     )
 
   def test_update_config_one_controller(self):
-    """Test updating config function works well with one config."""
+    """Tests updating config function works well with one config."""
     self.base_mock_test_config = mock.Mock()
     input_dict = {'AndroidDevice': [{'serial': '8AAAAAAAA'}]}
-    expected_output_dict = {'AndroidDevice': [{'serial': '8AAAAAAAA', 'test_key': True}]}
+    expected_output_dict = {
+        'AndroidDevice': [{
+            'serial': '8AAAAAAAA',
+            'test_key': True
+        }]
+    }
     self.base_mock_test_config.controller_configs = input_dict
-    test_runner.update_controller_config_attribute(self.base_mock_test_config, 'test_key', True)
-    self.assertDictEqual(self.base_mock_test_config.controller_configs, expected_output_dict)
+    test_runner.update_controller_config_attribute(self.base_mock_test_config,
+                                                   'test_key', True)
+    self.assertDictEqual(self.base_mock_test_config.controller_configs,
+                         expected_output_dict)
 
-  def test_update_config_multiple_controller(self):
-    """Test updating config function works well with multiple configs."""
+  def test_update_config_multiple_controllers(self):
+    """Tests updating config function works well with multiple configs."""
     input_dict = {
-        'AndroidDevice': [{'serial': '8AAAAAAAA'}, {'serial': '9AAAAAAAA'}],
-        'IosDevice': [{'serial': '7AAAAAAAA'}]
+        'AndroidDevice': [{
+            'serial': '8AAAAAAAA'
+        }, {
+            'serial': '9AAAAAAAA'
+        }],
+        'IosDevice': [{
+            'serial': '7AAAAAAAA'
+        }]
     }
     expected_output_dict = {
-        'AndroidDevice': [{'serial': '8AAAAAAAA', 'test_key': True},
-                          {'serial': '9AAAAAAAA', 'test_key': True}],
-        'IosDevice': [{'serial': '7AAAAAAAA', 'test_key': True}]
+        'AndroidDevice': [{
+            'serial': '8AAAAAAAA',
+            'test_key': True
+        }, {
+            'serial': '9AAAAAAAA',
+            'test_key': True
+        }],
+        'IosDevice': [{
+            'serial': '7AAAAAAAA',
+            'test_key': True
+        }]
     }
     self.base_mock_test_config.controller_configs = input_dict
-    test_runner.update_controller_config_attribute(self.base_mock_test_config, 'test_key', True)
-    self.assertDictEqual(self.base_mock_test_config.controller_configs, expected_output_dict)
+    test_runner.update_controller_config_attribute(self.base_mock_test_config,
+                                                   'test_key', True)
+    self.assertDictEqual(self.base_mock_test_config.controller_configs,
+                         expected_output_dict)
 
   def test_update_config_non_dict(self):
-    """Test updating config function throws error with non-dict config."""
-    # The controller config is the pick all symbol '*'
+    """Tests updating config function throws error with non-dict config."""
+    # The controller config is a pick all symbol '*'
     self.base_mock_test_config.controller_configs = {'AndroidDevice': '*'}
-    with self.assertRaisesRegex(test_runner.Error, 'Tried to update contronller config while it is not a dict.'):
-      test_runner.update_controller_config_attribute(self.base_mock_test_config, 'test_key', True)
+    with self.assertRaisesRegex(
+        test_runner.Error,
+        'Tried to update contronller config while it is not a dict.'):
+      test_runner.update_controller_config_attribute(self.base_mock_test_config,
+                                                     'test_key', True)
 
-    # The controller config is the list of serial number
-    self.base_mock_test_config.controller_configs = {'AndroidDevice': ['7AAAAAAAA', '8AAAAAAAA']}
-    with self.assertRaisesRegex(test_runner.Error, 'Tried to update contronller config while it is not a dict.'):
-      test_runner.update_controller_config_attribute(self.base_mock_test_config, 'test_key', True)
+    # The controller config is the a of serial number
+    self.base_mock_test_config.controller_configs = {
+        'AndroidDevice': ['7AAAAAAAA', '8AAAAAAAA']
+    }
+    with self.assertRaisesRegex(
+        test_runner.Error,
+        'Tried to update contronller config while it is not a dict.'):
+      test_runner.update_controller_config_attribute(self.base_mock_test_config,
+                                                     'test_key', True)
 
-
-  @mock.patch('mobly.test_runner.update_controller_config_attribute')
   @mock.patch('mobly.test_runner._find_test_class',
               return_value=type('SampleTest', (), {}))
   @mock.patch('mobly.test_runner.config_parser.load_test_config_file',
               return_value=[config_parser.TestRunConfig()])
   @mock.patch('mobly.test_runner.TestRunner', return_value=mock.MagicMock())
-  def test_main_skip_update_config_when_no_arg_specified(self, mock_test_runner, mock_config, mock_find_test, mock_update_func):
-    """Test main function skips updating controller config.
+  @mock.patch('mobly.test_runner.update_controller_config_attribute')
+  def test_main_skip_update_config_when_no_arg_specified(
+      self, mock_update_func, mock_test_runner, mock_configs, mock_find_test):
+    """Tests main function skips updating controller config.
 
     Main function should only update controller config if the command line
     argument `use_mobly_snippet_client_v2` is specified.
     """
+    # mock them to make the test went through normally, while the test code
+    # doesn't use them directly
+    del mock_test_runner
+    del mock_configs
+    del mock_find_test
     test_runner.main(['-c', 'some/path/foo.yaml'])
     mock_update_func.assert_not_called()
 
-  @mock.patch('mobly.test_runner.update_controller_config_attribute')
   @mock.patch('mobly.test_runner._find_test_class',
               return_value=type('SampleTest', (), {}))
   @mock.patch('mobly.test_runner.config_parser.load_test_config_file',
               return_value=[config_parser.TestRunConfig()])
   @mock.patch('mobly.test_runner.TestRunner', return_value=mock.MagicMock())
-  def test_main_updates_config_when_arg_specified(self, mock_test_runner, mock_configs, mock_find_test, mock_update_func):
-    """Test main function updates controller config.
+  @mock.patch('mobly.test_runner.update_controller_config_attribute')
+  def test_main_updates_config_when_arg_specified(self, mock_update_func,
+                                                  mock_test_runner,
+                                                  mock_configs, mock_find_test):
+    """Tests main function updates controller config.
 
     Main function should update controller config if the command line
     argument `use_mobly_snippet_client_v2` is specified.
     """
-    test_runner.main(['-c', 'some/path/foo.yaml', '--use_mobly_snippet_client_v2'])
+    # mock them to make the test went through normally, while the test code
+    # doesn't use them directly
+    del mock_test_runner
+    del mock_find_test
+    test_runner.main(
+        ['-c', 'some/path/foo.yaml', '--use_mobly_snippet_client_v2'])
     for mock_config in mock_configs:
-      mock_update_func.assert_called_with(
-          mock_config, config_parser.USE_SNIPPET_CLIENT_V2, True)
+      mock_update_func.assert_called_with(mock_config,
+                                          config_parser.USE_SNIPPET_CLIENT_V2,
+                                          True)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -420,9 +420,7 @@ class TestRunnerTest(unittest.TestCase):
     """Tests updating config function throws error with non-dict config."""
     # The controller config is a pick all symbol '*'
     self.base_mock_test_config.controller_configs = {'AndroidDevice': '*'}
-    with self.assertRaisesRegex(
-        test_runner.Error,
-        'Tried to update contronller config while it is not a dict.'):
+    with self.assertRaises(test_runner.Error):
       test_runner.update_controller_config_attribute(self.base_mock_test_config,
                                                      'test_key', True)
 
@@ -430,9 +428,7 @@ class TestRunnerTest(unittest.TestCase):
     self.base_mock_test_config.controller_configs = {
         'AndroidDevice': ['7AAAAAAAA', '8AAAAAAAA']
     }
-    with self.assertRaisesRegex(
-        test_runner.Error,
-        'Tried to update contronller config while it is not a dict.'):
+    with self.assertRaises(test_runner.Error):
       test_runner.update_controller_config_attribute(self.base_mock_test_config,
                                                      'test_key', True)
 

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -21,6 +21,8 @@ import tempfile
 import unittest
 from unittest import mock
 
+import yaml
+
 from mobly import config_parser
 from mobly import records
 from mobly import signals
@@ -31,7 +33,6 @@ from tests.lib import integration_test
 from tests.lib import integration2_test
 from tests.lib import integration3_test
 from tests.lib import multiple_subclasses_module
-import yaml
 
 
 class TestRunnerTest(unittest.TestCase):
@@ -418,13 +419,13 @@ class TestRunnerTest(unittest.TestCase):
 
   def test_update_config_non_dict(self):
     """Tests updating config function throws error with non-dict config."""
-    # The controller config is a pick all symbol '*'
+    # The config is a pick all symbol '*'
     self.base_mock_test_config.controller_configs = {'AndroidDevice': '*'}
     with self.assertRaises(test_runner.Error):
       test_runner.update_controller_config_attribute(self.base_mock_test_config,
                                                      'test_key', True)
 
-    # The controller config is the a of serial number
+    # The config is a list of serial numbers
     self.base_mock_test_config.controller_configs = {
         'AndroidDevice': ['7AAAAAAAA', '8AAAAAAAA']
     }
@@ -441,10 +442,10 @@ class TestRunnerTest(unittest.TestCase):
   def test_main_skip_update_config_when_no_arg_specified(
       self, mock_update_func, mock_test_runner, mock_load_conf_func,
       mock_find_test):
-    """Tests main function skips updating controller config.
+    """Tests main function skips updating controller configs.
 
-    Main function should only update controller config if the command line
-    argument `use_mobly_snippet_client_v2` is specified.
+    Main function should not update controller configs if the command line
+    argument `use_mobly_snippet_client_v2` is not specified.
     """
     # mock them to make the test went through normally, while the test code
     # doesn't use them directly
@@ -457,22 +458,25 @@ class TestRunnerTest(unittest.TestCase):
   @mock.patch('mobly.test_runner._find_test_class',
               return_value=type('SampleTest', (), {}))
   @mock.patch('mobly.test_runner.TestRunner', return_value=mock.MagicMock())
-  @mock.patch('mobly.test_runner.config_parser.load_test_config_file',
-              return_value=[config_parser.TestRunConfig()])
+  @mock.patch('mobly.test_runner.config_parser.load_test_config_file')
   @mock.patch('mobly.test_runner.update_controller_config_attribute')
   def test_main_updates_config_when_arg_specified(self, mock_update_func,
                                                   mock_load_conf_func,
                                                   mock_test_runner,
                                                   mock_find_test):
-    """Tests main function updates controller config.
+    """Tests main function updates controller configs.
 
-    Main function should update controller config if the command line
+    Main function should update controller configs if the command line
     argument `use_mobly_snippet_client_v2` is specified.
     """
     # mock them to make the test went through normally, while the test code
     # doesn't use them directly
     del mock_test_runner
     del mock_find_test
+    mock_load_conf_func.return_value = [
+        config_parser.TestRunConfig(),
+        config_parser.TestRunConfig(),
+    ]
     test_runner.main(
         ['-c', 'some/path/foo.yaml', '--use_mobly_snippet_client_v2'])
 


### PR DESCRIPTION
This PR is a part of #793. 

This PR adds a flag for switching to use snippet client v2, including:
* Adds a command line argument `use_mobly_snippet_client_v2`.
* If the argument is specified, the flag will be passed to `SnippetManagementService`, which is responsible for creating, stopping and resuming snippet client.

For this switch, this PR only sets `SnippetManagementService._use_client_v2` to True instead of really using snippet client v2, because client v2 is not ready now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/800)
<!-- Reviewable:end -->
