### PR TITLE
Run yapf to fix format

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -437,7 +437,7 @@ def take_bug_reports(ads, test_name=None, begin_time=None, destination=None):
 
 class BuildInfoConstants(enum.Enum):
   """Enums for build info constants used for AndroidDevice build info.
-  
+
   Attributes:
     build_info_key: The key used for the build_info dictionary in AndroidDevice.
     system_prop_key: The key used for getting the build info from system
@@ -791,7 +791,7 @@ class AndroidDevice:
       device is in bootloader mode.
     """
     if self.is_bootloader:
-      self.log.error('Device is in fastboot mode, could not get build ' 'info.')
+      self.log.error('Device is in fastboot mode, could not get build info.')
       return
     if self._build_info is None or self._is_rebooting:
       info = {}

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -870,8 +870,8 @@ class AndroidDeviceTest(unittest.TestCase):
   @mock.patch('mobly.utils.create_dir')
   @mock.patch('mobly.logger.get_log_file_timestamp')
   def test_AndroidDevice_take_screenshot_with_prefix(
-    self, get_log_file_timestamp_mock, create_dir_mock,
-    FastbootProxy, MockAdbProxy):
+      self, get_log_file_timestamp_mock, create_dir_mock, FastbootProxy,
+      MockAdbProxy):
     get_log_file_timestamp_mock.return_value = '07-22-2019_17-53-34-450'
     mock_serial = '1'
     ad = android_device.AndroidDevice(serial=mock_serial)
@@ -1152,22 +1152,19 @@ class AndroidDeviceTest(unittest.TestCase):
     mock_serial = '1'
     ad = android_device.AndroidDevice(serial=mock_serial)
     self.assertEqual(ad.debug_tag, '1')
-    with self.assertRaisesRegex(
-        android_device.DeviceError,
-        r'<AndroidDevice\|1> Something'):
+    with self.assertRaisesRegex(android_device.DeviceError,
+                                r'<AndroidDevice\|1> Something'):
       raise android_device.DeviceError(ad, 'Something')
 
     # Verify that debug tag's setter updates the debug prefix correctly.
     ad.debug_tag = 'Mememe'
-    with self.assertRaisesRegex(
-        android_device.DeviceError,
-        r'<AndroidDevice\|Mememe> Something'):
+    with self.assertRaisesRegex(android_device.DeviceError,
+                                r'<AndroidDevice\|Mememe> Something'):
       raise android_device.DeviceError(ad, 'Something')
 
     # Verify that repr is changed correctly.
-    with self.assertRaisesRegex(
-        Exception,
-        r'(<AndroidDevice\|Mememe>, \'Something\')'):
+    with self.assertRaisesRegex(Exception,
+                                r'(<AndroidDevice\|Mememe>, \'Something\')'):
       raise Exception(ad, 'Something')
 
   @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',


### PR DESCRIPTION
According to Mobly's [Contributing Doc](https://github.com/google/mobly/blob/master/CONTRIBUTING.md), run yapf to fix format:

```
yapf -i mobly/controllers/android_device.py tests/mobly/controllers/android_device_test.py
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/801)
<!-- Reviewable:end -->
