### PR TITLE
Refactor the function ClientBase#start_server 

### DIFF
--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -131,15 +131,16 @@ class ClientBase(abc.ABC):
       self._make_connection()
 
     except Exception:
-      self.log.error('Error occurs when initializing the snippet server of %s.',
-                     self.package)
+      self.log.error(
+          'Error occurred trying to initialize the snippet server of %s.',
+          self.package)
       try:
         self.stop_server()
       except Exception:  # pylint: disable=broad-except
         # Only prints this exception and re-raises the original exception
         self.log.exception(
-            'Failed to stop the snippet server of %s because of a new '
-            'exception.', self.package)
+            'Failed to stop the snippet server of %s after initialization '
+            'failure.', self.package)
 
       raise
 

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -127,9 +127,8 @@ class ClientBase(abc.ABC):
       self.log.debug('Starting the snippet server for %s.', self.package)
       self.start_server()
 
-      self.log.debug(
-          'Initializing a connection with the snippet server for %s.',
-          self.package)
+      self.log.debug('Initiating a connection with the snippet server for %s.',
+                     self.package)
       self._init_connection()
 
     except Exception:
@@ -152,7 +151,7 @@ class ClientBase(abc.ABC):
 
   @abc.abstractmethod
   def before_starting_server(self):
-    """Performs preparation steps before starting the remote server.
+    """Performs the preparation steps before starting the remote server.
 
     For example, subclass can check or modify the device settings at this
     stage.
@@ -180,10 +179,10 @@ class ClientBase(abc.ABC):
 
   @abc.abstractmethod
   def init_connection(self):
-    """Initializes a connection with the server on the remote device.
+    """Initiates a connection with the server on the remote device.
 
-    This function initializes a connection to it and sends a handshake
-    to ensure the server is available for upcoming RPCs.
+    This function initiates a connection to the server and sends a handshake
+    request to ensure the server is available for upcoming RPCs.
 
     There are two types of connections used by snippet clients:
     * the client builds a connection each time it wants to send a RPC,
@@ -193,7 +192,7 @@ class ClientBase(abc.ABC):
 
     This function uses self.host_port for communicating with the server. If
     self.host_port is 0 or None, this function finds an available host port to
-    initialize connection and set self.host_port to the found port.
+    initiate the connection and set self.host_port to the found port.
 
     Raises:
       errors.ProtocolError: something went wrong when exchanging data with the

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -38,7 +38,7 @@ The JSON RPC protocol expected by this module is:
               or returned void.>,
     'callback': <Required. String that represents a callback ID used to
                 identify events associated with a particular CallbackHandler
-                object, `null` if this is not a async RPC.>,
+                object, `null` if this is not an asynchronous RPC.>,
   }
 """
 
@@ -185,8 +185,8 @@ class ClientBase(abc.ABC):
     request to ensure the server is available for upcoming RPCs.
 
     There are two types of connections used by snippet clients:
-    * the client builds a connection each time it wants to send a RPC,
-    * the client builds a connection in this stage and uses it for all the RPCs.
+    * The client makes a new connection each time it needs to send an RPC.
+    * The client makes a connection in this stage and uses it for all the RPCs.
       In this way, the client should implement `close_connection` to close
       the connection.
 
@@ -251,7 +251,7 @@ class ClientBase(abc.ABC):
     """
 
   def _rpc(self, rpc_func_name, *args, **kwargs):
-    """Sends a RPC to the server.
+    """Sends an RPC to the server.
 
     Args:
       rpc_func_name: str, the name of the snippet function to execute on the
@@ -299,7 +299,7 @@ class ClientBase(abc.ABC):
     """Checks whether the server is still running.
 
     If the server is not running, it throws an error. As this function is called
-    each time the client tries to send a RPC, this should be a quick check
+    each time the client tries to send an RPC, this should be a quick check
     without affecting performance. Otherwise it is fine to not check anything.
 
     Raises:

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -178,7 +178,7 @@ class ClientBase(abc.ABC):
 
   @abc.abstractmethod
   def make_connection(self):
-    """Makes a connection to the server on the remote device.
+    """Makes a connection to the snippet server on the remote device.
 
     This function makes a connection to the server and sends a handshake
     request to ensure the server is available for upcoming RPCs.

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -101,9 +101,9 @@ class ClientBase(abc.ABC):
     """Initializes the snippet client to interact with the remote device.
 
     This function contains following stages:
-      - preparing for starting the snippet server.
-      - starting the snippet server on the remote device.
-      - initializing a connection with the snippet server.
+      1. preparing to start the snippet server.
+      2. starting the snippet server on the remote device.
+      3. initializing a connection with the snippet server.
 
     After this, the self.host_port and self.device_port attributes must be
     set.
@@ -119,9 +119,9 @@ class ClientBase(abc.ABC):
     self.log.debug('Initializing the snippet package %s.', self.package)
     start_time = time.perf_counter()
 
-    self.log.debug('Preparing starting the snippet server for %s.',
+    self.log.debug('Preparing to start the snippet server for %s.',
                    self.package)
-    self.prepare_starting_server()
+    self.before_starting_server()
 
     try:
       self.log.debug('Starting the snippet server for %s.', self.package)
@@ -151,8 +151,8 @@ class ClientBase(abc.ABC):
                    time.perf_counter() - start_time, self.host_port)
 
   @abc.abstractmethod
-  def prepare_starting_server(self):
-    """Prepares for starting the server.
+  def before_starting_server(self):
+    """Performs preparation steps before starting the remote server.
 
     For example, subclass can check or modify the device settings at this
     stage.

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -103,7 +103,7 @@ class ClientBase(abc.ABC):
     This function contains following stages:
       1. preparing to start the snippet server.
       2. starting the snippet server on the remote device.
-      3. making a connection with the snippet server.
+      3. making a connection to the snippet server.
 
     After this, the self.host_port and self.device_port attributes must be
     set.
@@ -119,33 +119,33 @@ class ClientBase(abc.ABC):
     self.log.debug('Initializing the snippet package %s.', self.package)
     start_time = time.perf_counter()
 
-    self.log.debug('Preparing to start the snippet server for %s.',
+    self.log.debug('Preparing to start the snippet server of %s.',
                    self.package)
     self.before_starting_server()
 
     try:
-      self.log.debug('Starting the snippet server for %s.', self.package)
+      self.log.debug('Starting the snippet server of %s.', self.package)
       self.start_server()
 
-      self.log.debug('Making a connection with the snippet server for %s.',
+      self.log.debug('Making a connection to the snippet server of %s.',
                      self.package)
       self._make_connection()
 
     except Exception:
       self.log.error(
-          'Error occurs when initializing the snippet server for %s.',
+          'Error occurs when initializing the snippet server of %s.',
           self.package)
       try:
         self.stop_server()
       except Exception:  # pylint: disable=broad-except
         # Only prints this exception and re-raises the original exception
         self.log.exception(
-            'Failed to stop server for %s because of new exception.',
+            'Failed to stop the snippet server of %s because of new exception.',
             self.package)
 
       raise
 
-    self.log.debug('Snippet %s initialized after %.1fs on host port %d.',
+    self.log.debug('Snippet package %s initialized after %.1fs on host port %d.',
                    self.package,
                    time.perf_counter() - start_time, self.host_port)
 
@@ -179,7 +179,7 @@ class ClientBase(abc.ABC):
 
   @abc.abstractmethod
   def make_connection(self):
-    """Makes a connection with the server on the remote device.
+    """Makes a connection to the server on the remote device.
 
     This function makes a connection to the server and sends a handshake
     request to ensure the server is available for upcoming RPCs.
@@ -247,7 +247,7 @@ class ClientBase(abc.ABC):
 
     Raises:
       errors.ServerRestoreConnectionError: when failed to restore the connection
-        with the snippet server.
+        to the snippet server.
     """
 
   def _rpc(self, rpc_func_name, *args, **kwargs):

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -98,12 +98,12 @@ class ClientBase(abc.ABC):
     self.close_connection()
 
   def initialize(self):
-    """Starts the server on the remote device and connects to it.
+    """Initializes the snippet client to interact with the remote device.
 
-    This process contains following stages:
-      - preparing for starting the server.
-      - starting the server on the remote device.
-      - initializing a connection with the server.
+    This function contains following stages:
+      - preparing for starting the snippet server.
+      - starting the snippet server on the remote device.
+      - initializing a connection with the snippet server.
 
     After this, the self.host_port and self.device_port attributes must be
     set.

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -187,7 +187,7 @@ class ClientBase(abc.ABC):
     There are two types of connections used by snippet clients:
     * The client makes a new connection each time it needs to send an RPC.
     * The client makes a connection in this stage and uses it for all the RPCs.
-      In this way, the client should implement `close_connection` to close
+      In this case, the client should implement `close_connection` to close
       the connection.
 
     This function uses self.host_port for communicating with the server. If

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -119,8 +119,7 @@ class ClientBase(abc.ABC):
     self.log.debug('Initializing the snippet package %s.', self.package)
     start_time = time.perf_counter()
 
-    self.log.debug('Preparing to start the snippet server of %s.',
-                   self.package)
+    self.log.debug('Preparing to start the snippet server of %s.', self.package)
     self.before_starting_server()
 
     try:
@@ -132,22 +131,22 @@ class ClientBase(abc.ABC):
       self._make_connection()
 
     except Exception:
-      self.log.error(
-          'Error occurs when initializing the snippet server of %s.',
-          self.package)
+      self.log.error('Error occurs when initializing the snippet server of %s.',
+                     self.package)
       try:
         self.stop_server()
       except Exception:  # pylint: disable=broad-except
         # Only prints this exception and re-raises the original exception
         self.log.exception(
-            'Failed to stop the snippet server of %s because of new exception.',
-            self.package)
+            'Failed to stop the snippet server of %s because of a new '
+            'exception.', self.package)
 
       raise
 
-    self.log.debug('Snippet package %s initialized after %.1fs on host port %d.',
-                   self.package,
-                   time.perf_counter() - start_time, self.host_port)
+    self.log.debug(
+        'Snippet package %s initialized after %.1fs on host port %d.',
+        self.package,
+        time.perf_counter() - start_time, self.host_port)
 
   @abc.abstractmethod
   def before_starting_server(self):

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -132,15 +132,15 @@ class ClientBase(abc.ABC):
 
     except Exception:
       self.log.error(
-          'Error occurred trying to initialize the snippet server of %s.',
-          self.package)
+          'Error occurred trying to start and connect to the snippet server '
+          'of %s.', self.package)
       try:
         self.stop_server()
       except Exception:  # pylint: disable=broad-except
         # Only prints this exception and re-raises the original exception
         self.log.exception(
-            'Failed to stop the snippet server of %s after initialization '
-            'failure.', self.package)
+            'Failed to stop the snippet server of %s after failure to start '
+            'and connect.', self.package)
 
       raise
 

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -103,7 +103,7 @@ class ClientBase(abc.ABC):
     This function contains following stages:
       1. preparing to start the snippet server.
       2. starting the snippet server on the remote device.
-      3. initializing a connection with the snippet server.
+      3. making a connection with the snippet server.
 
     After this, the self.host_port and self.device_port attributes must be
     set.
@@ -127,9 +127,9 @@ class ClientBase(abc.ABC):
       self.log.debug('Starting the snippet server for %s.', self.package)
       self.start_server()
 
-      self.log.debug('Initiating a connection with the snippet server for %s.',
+      self.log.debug('Making a connection with the snippet server for %s.',
                      self.package)
-      self._init_connection()
+      self._make_connection()
 
     except Exception:
       self.log.error(
@@ -169,19 +169,19 @@ class ClientBase(abc.ABC):
     function to start the server.
     """
 
-  def _init_connection(self):
-    """Proxy function of init_connection.
+  def _make_connection(self):
+    """Proxy function of make_connection.
 
-    This function resets the RPC id counter before calling `init_connection`.
+    This function resets the RPC id counter before calling `make_connection`.
     """
     self._counter = self._id_counter()
-    self.init_connection()
+    self.make_connection()
 
   @abc.abstractmethod
-  def init_connection(self):
-    """Initiates a connection with the server on the remote device.
+  def make_connection(self):
+    """Makes a connection with the server on the remote device.
 
-    This function initiates a connection to the server and sends a handshake
+    This function makes a connection to the server and sends a handshake
     request to ensure the server is available for upcoming RPCs.
 
     There are two types of connections used by snippet clients:
@@ -192,7 +192,7 @@ class ClientBase(abc.ABC):
 
     This function uses self.host_port for communicating with the server. If
     self.host_port is 0 or None, this function finds an available host port to
-    initiate the connection and set self.host_port to the found port.
+    make the connection and set self.host_port to the found port.
 
     Raises:
       errors.ProtocolError: something went wrong when exchanging data with the

--- a/tests/mobly/snippet/client_base_test.py
+++ b/tests/mobly/snippet/client_base_test.py
@@ -63,7 +63,7 @@ class FakeClient(client_base.ClientBase):
     super().__init__(package='FakeClient', device=mock_device)
 
   # Override abstract methods to enable initialization
-  def prepare_starting_server(self):
+  def before_starting_server(self):
     pass
 
   def start_server(self):
@@ -99,32 +99,32 @@ class ClientBaseTest(unittest.TestCase):
     self.client = FakeClient()
     self.client.host_port = 12345
 
-  @mock.patch.object(FakeClient, 'prepare_starting_server')
+  @mock.patch.object(FakeClient, 'before_starting_server')
   @mock.patch.object(FakeClient, 'start_server')
   @mock.patch.object(FakeClient, '_init_connection')
   def test_init_server_stage_order(self, mock_init_conn_func, mock_start_func,
-                                   mock_prepare_func):
+                                   mock_before_func):
     """Test that initialization runs its stages in expected order."""
     order_manager = mock.Mock()
-    order_manager.attach_mock(mock_prepare_func, 'mock_prepare_func')
+    order_manager.attach_mock(mock_before_func, 'mock_before_func')
     order_manager.attach_mock(mock_start_func, 'mock_start_func')
     order_manager.attach_mock(mock_init_conn_func, 'mock_init_conn_func')
 
     self.client.initialize()
 
     expected_call_order = [
-        mock.call.mock_prepare_func(),
+        mock.call.mock_before_func(),
         mock.call.mock_start_func(),
         mock.call.mock_init_conn_func(),
     ]
     self.assertListEqual(order_manager.mock_calls, expected_call_order)
 
   @mock.patch.object(FakeClient, 'stop_server')
-  @mock.patch.object(FakeClient, 'prepare_starting_server')
-  def test_init_server_prepare_starting_server_fail(self, mock_prepare_func,
-                                                    mock_stop_server):
-    """Test prepare_starting_server stage of initialization fails."""
-    mock_prepare_func.side_effect = Exception('ha')
+  @mock.patch.object(FakeClient, 'before_starting_server')
+  def test_init_server_before_starting_server_fail(self, mock_before_func,
+                                                   mock_stop_server):
+    """Test before_starting_server stage of initialization fails."""
+    mock_before_func.side_effect = Exception('ha')
 
     with self.assertRaisesRegex(Exception, 'ha'):
       self.client.initialize()

--- a/tests/mobly/snippet/client_base_test.py
+++ b/tests/mobly/snippet/client_base_test.py
@@ -26,7 +26,7 @@ from mobly.snippet import errors
 def _generate_fix_length_rpc_response(
     response_length,
     template='{"id": 0, "result": "%s", "error": null, "callback": null}'):
-  """Generates a RPC response string with specified length.
+  """Generates an RPC response string with specified length.
 
   This function generates a random string and formats the template with the
   generated random string to get the response string. This function formats
@@ -160,9 +160,9 @@ class ClientBaseTest(unittest.TestCase):
   def test_rpc_stage_dependencies(self, mock_handle_resp, mock_decode_resp_str,
                                   mock_send_request, mock_gen_request,
                                   mock_precheck):
-    """Test the internal dependencies when sending a RPC.
+    """Test the internal dependencies when sending an RPC.
 
-    When sending a RPC, it calls multiple functions in specific order, and
+    When sending an RPC, it calls multiple functions in specific order, and
     each function uses the output of the previously called function. This test
     case checks above dependencies.
 
@@ -209,7 +209,7 @@ class ClientBaseTest(unittest.TestCase):
   def test_rpc_precheck_fail(self, mock_handle_resp, mock_decode_resp_str,
                              mock_send_request, mock_gen_request,
                              mock_precheck):
-    """Test when RPC precheck fails it will skip sending RPC."""
+    """Test when RPC precheck fails it will skip sending the RPC."""
     self.client.initialize()
     mock_precheck.side_effect = Exception('server_died')
 
@@ -222,7 +222,7 @@ class ClientBaseTest(unittest.TestCase):
     mock_decode_resp_str.assert_not_called()
 
   def test_gen_request(self):
-    """Test generating a RPC request.
+    """Test generating an RPC request.
 
     Test that _gen_rpc_request returns a string represents a JSON dict
     with all required fields.
@@ -253,7 +253,7 @@ class ClientBaseTest(unittest.TestCase):
       self.client._decode_response_string_and_validate_format(0, None)
 
   def test_rpc_response_missing_fields(self):
-    """Test parsing a RPC response that misses some required fields."""
+    """Test parsing an RPC response that misses some required fields."""
     mock_resp_without_id = '{"result": 123, "error": null, "callback": null}'
     with self.assertRaisesRegex(
         errors.ProtocolError,
@@ -283,7 +283,7 @@ class ClientBaseTest(unittest.TestCase):
           10, mock_resp_without_callback)
 
   def test_rpc_response_error(self):
-    """Test parsing a RPC response with a non-empty error field."""
+    """Test parsing an RPC response with a non-empty error field."""
     mock_resp_with_error = {
         'id': 10,
         'result': 123,
@@ -326,7 +326,7 @@ class ClientBaseTest(unittest.TestCase):
       mock_handle_callback.assert_not_called()
 
   def test_rpc_response_id_mismatch(self):
-    """Test parsing a RPC response with wrong id."""
+    """Test parsing an RPC response with wrong id."""
     right_id = 5
     wrong_id = 20
     resp = f'{{"id": {right_id}, "result": 1, "error": null, "callback": null}}'

--- a/tests/mobly/snippet/client_base_test.py
+++ b/tests/mobly/snippet/client_base_test.py
@@ -326,7 +326,7 @@ class ClientBaseTest(unittest.TestCase):
       mock_handle_callback.assert_not_called()
 
   def test_rpc_response_id_mismatch(self):
-    """Test parsing an RPC response with wrong id."""
+    """Test parsing an RPC response with a wrong id."""
     right_id = 5
     wrong_id = 20
     resp = f'{{"id": {right_id}, "result": 1, "error": null, "callback": null}}'


### PR DESCRIPTION
Part of #793, refactor the function `ClientBase#start_server`.

Mainly include:
* Renamed the `start_server` function and its stages to make it more reasonable. Deleted the last stage `after_starting_server` as the things should be done in the previous stage.
* Modified related log statements, comments and unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/806)
<!-- Reviewable:end -->
