### PR TITLE
Refactor snippet client v2's stop server method

### DIFF
--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -420,7 +420,7 @@ class ClientBase(abc.ABC):
 
   @abc.abstractmethod
   def stop(self):
-    """Stops the snippet server and releases all the requested resources."""
+    """Releases all the resources acquired in `initialize`."""
 
   @abc.abstractmethod
   def close_connection(self):

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -62,8 +62,8 @@ class ClientBase(abc.ABC):
 
   Connects to a remote device running a JSON RPC compatible server. Users call
   the function `start_server` to start the server on the remote device before
-  sending any RPC. After sending all RPCs, users call the function `stop_server`
-  to stop all the running instances.
+  sending any RPC. After sending all RPCs, users call the function `stop`
+  to stop the snippet server and release all the requested resources.
 
   Attributes:
     package: str, the user-visible name of the snippet library being
@@ -135,11 +135,11 @@ class ClientBase(abc.ABC):
           'Error occurred trying to start and connect to the snippet server '
           'of %s.', self.package)
       try:
-        self.stop_server()
+        self.stop()
       except Exception:  # pylint: disable=broad-except
         # Only prints this exception and re-raises the original exception
         self.log.exception(
-            'Failed to stop the snippet server of %s after failure to start '
+            'Failed to stop the snippet package %s after failure to start '
             'and connect.', self.package)
 
       raise
@@ -419,8 +419,8 @@ class ClientBase(abc.ABC):
     """
 
   @abc.abstractmethod
-  def stop_server(self):
-    """Kills any running instance of the server."""
+  def stop(self):
+    """Stops the snippet server and releases all the requested resources."""
 
   @abc.abstractmethod
   def close_connection(self):

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -418,14 +418,8 @@ class ClientBase(abc.ABC):
       The callback handler object.
     """
 
-  def stop_server(self):
-    """Proxy function of do_stop_server."""
-    self.log.debug('Stopping snippet %s.', self.package)
-    self.do_stop_server()
-    self.log.debug('Snippet %s stopped.', self.package)
-
   @abc.abstractmethod
-  def do_stop_server(self):
+  def stop_server(self):
     """Kills any running instance of the server."""
 
   @abc.abstractmethod

--- a/tests/mobly/snippet/client_base_test.py
+++ b/tests/mobly/snippet/client_base_test.py
@@ -84,7 +84,7 @@ class FakeClient(client_base.ClientBase):
   def handle_callback(self, callback_id, ret_value, rpc_func_name):
     pass
 
-  def do_stop_server(self):
+  def stop_server(self):
     pass
 
   def close_connection(self):

--- a/tests/mobly/snippet/client_base_test.py
+++ b/tests/mobly/snippet/client_base_test.py
@@ -84,7 +84,7 @@ class FakeClient(client_base.ClientBase):
   def handle_callback(self, callback_id, ret_value, rpc_func_name):
     pass
 
-  def stop_server(self):
+  def stop(self):
     pass
 
   def close_connection(self):
@@ -119,38 +119,37 @@ class ClientBaseTest(unittest.TestCase):
     ]
     self.assertListEqual(order_manager.mock_calls, expected_call_order)
 
-  @mock.patch.object(FakeClient, 'stop_server')
+  @mock.patch.object(FakeClient, 'stop')
   @mock.patch.object(FakeClient, 'before_starting_server')
   def test_init_server_before_starting_server_fail(self, mock_before_func,
-                                                   mock_stop_server):
+                                                   mock_stop_func):
     """Test before_starting_server stage of initialization fails."""
     mock_before_func.side_effect = Exception('ha')
 
     with self.assertRaisesRegex(Exception, 'ha'):
       self.client.initialize()
-    mock_stop_server.assert_not_called()
+    mock_stop_func.assert_not_called()
 
-  @mock.patch.object(FakeClient, 'stop_server')
+  @mock.patch.object(FakeClient, 'stop')
   @mock.patch.object(FakeClient, 'start_server')
-  def test_init_server_start_server_fail(self, mock_start_func,
-                                         mock_stop_server):
+  def test_init_server_start_server_fail(self, mock_start_func, mock_stop_func):
     """Test start_server stage of initialization fails."""
     mock_start_func.side_effect = Exception('ha')
 
     with self.assertRaisesRegex(Exception, 'ha'):
       self.client.initialize()
-    mock_stop_server.assert_called()
+    mock_stop_func.assert_called()
 
-  @mock.patch.object(FakeClient, 'stop_server')
+  @mock.patch.object(FakeClient, 'stop')
   @mock.patch.object(FakeClient, '_make_connection')
   def test_init_server_make_connection_fail(self, mock_make_conn_func,
-                                            mock_stop_server):
+                                            mock_stop_func):
     """Test _make_connection stage of initialization fails."""
     mock_make_conn_func.side_effect = Exception('ha')
 
     with self.assertRaisesRegex(Exception, 'ha'):
       self.client.initialize()
-    mock_stop_server.assert_called()
+    mock_stop_func.assert_called()
 
   @mock.patch.object(FakeClient, 'check_server_proc_running')
   @mock.patch.object(FakeClient, '_gen_rpc_request')


### PR DESCRIPTION
There are two methods `stop_server` and `do_stop_server` in `ClientBase`, which sounds strange.

This is because `stop_server` is the proxy function of `do_stop_server` but both of them should be public methods. 

Currently, compared with `do_stop_sever`, `stop_server` is only responsible for printing log information. So we can remove the proxy function for now. 

We may refine this to use a decorator or something else when we need to collect metadata of snippet clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/807)
<!-- Reviewable:end -->
