### PR TITLE
Add Snippet Client V2 for Android, Step 2

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -457,7 +457,7 @@ class SnippetClientV2(client_base.ClientBase):
     """Receives the server's response of an RPC message.
 
     Returns:
-      Raw byte string of the response.
+      Raw bytes of the response.
 
     Raises:
       errors.Error: if a socket error occurred during the read.
@@ -470,6 +470,17 @@ class SnippetClientV2(client_base.ClientBase):
           f'Encountered socket error "{e}" reading RPC response') from e
 
   def _decode_socket_response_bytes(self, response):
+    """Returns a string decoded from the socket response bytes.
+
+    Args:
+      response: bytes, the response to be decoded.
+
+    Returns:
+      The string decoded from the given bytes.
+
+    Raises:
+      UnicodeError: if failed to decode the given bytes using encoding utf8.
+    """
     try:
       return str(response, encoding='utf8')
     except UnicodeError:

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -435,17 +435,33 @@ class SnippetClientV2(client_base.ClientBase):
                                  errors.ProtocolError.NO_RESPONSE_FROM_SERVER)
     return self._decode_socket_response_bytes(response)
 
-  def _client_send(self, request):
+  def _client_send(self, message):
+    """Sends an RPC message through the connection.
+
+    Args:
+      msg: str, the message to send.
+
+    Raises:
+      errors.Error: if a socket error occurred during the send.
+    """
     try:
-      self._client.write(f'{request}\n'.encode('utf8'))
+      self._client.write(f'{message}\n'.encode('utf8'))
       self._client.flush()
     except socket.error as e:
       raise errors.Error(
           self._device,
-          f'Encountered socket error "{e}" sending RPC message "{request}"'
+          f'Encountered socket error "{e}" sending RPC message "{message}"'
       ) from e
 
   def _client_receive(self):
+    """Receives the server's response of an RPC message.
+
+    Returns:
+      Raw byte string of the response.
+
+    Raises:
+      errors.Error: if a socket error occurred during the read.
+    """
     try:
       return self._client.readline()
     except socket.error as e:

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -439,7 +439,7 @@ class SnippetClientV2(client_base.ClientBase):
     """Sends an RPC message through the connection.
 
     Args:
-      msg: str, the message to send.
+      message: str, the message to send.
 
     Raises:
       errors.Error: if a socket error occurred during the send.

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -528,7 +528,7 @@ class SnippetClientV2(client_base.ClientBase):
                                           device_port,
                                           uid=UNKNOWN_UID,
                                           cmd=ConnectionHandshakeCommand.INIT):
-    """Makes a connection to the server with forwarded port.
+    """Makes a connection to the server with the given forwarded port.
 
     This process assumes that a device port has already been forwarded to a
     host port, and it only makes a connection to the snippet server based on

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Snippet Client V2 for Interacting with Snippet Server on Android Device."""
 
+import enum
 import json
 import re
 import socket
@@ -72,7 +73,7 @@ _SOCKET_CONNECTION_TIMEOUT = 60
 _SOCKET_READ_TIMEOUT = callback_handler.MAX_TIMEOUT
 
 
-class ConnectionHandshakeCommand:
+class ConnectionHandshakeCommand(enum.Enum):
   """Commands to send to the server when sending the handshake request.
 
   After creating the socket connection, the client must send a handshake request
@@ -382,14 +383,15 @@ class SnippetClientV2(client_base.ClientBase):
     Args:
       uid: int, the uid of the server session to continue. It will be ignored
         if the `cmd` requires the server to create a new session.
-      cmd: str, the handshake command for the server, which requires the server
-        to create a new session or use the current session.
+      cmd: ConnectionHandshakeCommand, the handshake command Enum for the
+        server, which requires the server to create a new session or use the
+        current session.
 
     Raises:
       errors.ProtocolError: something went wrong when sending the handshake
         request.
     """
-    request = json.dumps({'cmd': cmd, 'uid': uid})
+    request = json.dumps({'cmd': cmd.value, 'uid': uid})
     self.log.debug('Sending handshake request %s.', request)
     self._client_send(request)
     response = self._client_receive()
@@ -508,8 +510,9 @@ class SnippetClientV2(client_base.ClientBase):
     Args:
       uid: int, the uid of the server session to continue. It will be ignored
         if the `cmd` requires the server to create a new session.
-      cmd: str, the handshake command for the server, which requires the server
-        to create a new session or use the current session.
+      cmd: ConnectionHandshakeCommand, the handshake command Enum for the
+        server, which requires the server to create a new session or use the
+        current session.
     """
     self._event_client.host_port = self.host_port
     self._event_client.device_port = self.device_port

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -366,7 +366,7 @@ class SnippetClientV2(client_base.ClientBase):
     """Makes a connection to the snippet server on the remote device.
 
     This function makes a persistent connection to the server. This connection
-    will be used for all the RPCs, and must be closed before deconstruction.
+    will be used for all the RPCs, and must be closed when deconstructing.
 
     To connect to the Android device, it first forwards the device port to a
     host port. Then, it creates a socket connection to the server on the device.
@@ -387,12 +387,12 @@ class SnippetClientV2(client_base.ClientBase):
     """Creates a socket connection to the server.
 
     After creating the connection successfully, it sets two attributes:
-    * `self._conn`: the create socket object, which is used to close the created
-      connection.
-    * `self._client`: the socket file, which is used to send and receive
+    * `self._conn`: the created socket object, which will be used when it needs
+      to close the connection.
+    * `self._client`: the socket file, which will be used to send and receive
       messages.
 
-    This function only creates a socket connection and doesn't send any message
+    This function only creates a socket connection without sending any message
     to the server.
     """
     try:
@@ -415,8 +415,8 @@ class SnippetClientV2(client_base.ClientBase):
     """Sends a handshake request to the server to prepare for the communication.
 
     Through the handshake response, this function checks whether the server
-    is ready for the communication. If ready, it sets `self.uid` to the uid
-    of the server session. Otherwise, it sets `self.uid` to `UNKNOWN_UID`.
+    is ready for the communication. If ready, it sets `self.uid` to the
+    server session id. Otherwise, it sets `self.uid` to `UNKNOWN_UID`.
 
     Args:
       uid: int, the uid of the server session to continue. It will be ignored
@@ -464,7 +464,7 @@ class SnippetClientV2(client_base.ClientBase):
       self._stop_port_forwarding()
 
   def _stop_port_forwarding(self):
-    """Stops the adb port forwarding of the host port used by this client."""
+    """Stops the adb port forwarding used by this client."""
     if self.host_port:
       self._device.adb.forward(['--remove', f'tcp:{self.host_port}'])
       self.host_port = None
@@ -485,7 +485,7 @@ class SnippetClientV2(client_base.ClientBase):
       The string of the RPC response.
 
     Raises:
-      errors.Error: if failed to send the request or receive the response.
+      errors.Error: if failed to send the request or receive a response.
       errors.ProtocolError: if received an empty response from the server.
       UnicodeError: if failed to decode the received response.
     """
@@ -543,8 +543,7 @@ class SnippetClientV2(client_base.ClientBase):
 
     As the server is already started by the snippet server on which this
     function is called, the created event client connects to the same session
-    as the snippet server. It also reuses the same host port and device port to
-    connect to the device.
+    as the snippet server. It also reuses the same host port and device port.
     """
     self._event_client = SnippetClientV2(package=self.package, ad=self._device)
     self._make_connection_for_event_client(self.uid,

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -78,10 +78,10 @@ class ConnectionHandshakeCommand:
   After creating the socket connection, the client must send a handshake request
   to the server. When receiving the handshake request, the server will prepare
   to communicate with the client. According to the command in the request,
-  the server will create a new session or reuse current session.
+  the server will create a new session or reuse the current session.
 
   INIT: Initiates a new session and makes a connection with this session.
-  CONTINUE: Makes a connection with current session.
+  CONTINUE: Makes a connection with the current session.
   """
   INIT = 'initiate'
   CONTINUE = 'continue'
@@ -431,7 +431,7 @@ class SnippetClientV2(client_base.ClientBase):
     try:
       request = json.dumps({'cmd': cmd, 'uid': uid})
       self.log.debug('Sending handshake request %s.', request)
-      resp = self.send_rpc_request(request)
+      response = self.send_rpc_request(request)
     except errors.ProtocolError as e:
       if errors.ProtocolError.NO_RESPONSE_FROM_SERVER in str(e):
         raise errors.ProtocolError(
@@ -439,11 +439,11 @@ class SnippetClientV2(client_base.ClientBase):
 
       raise
 
-    if not resp:
+    if not response:
       raise errors.ProtocolError(
           self._device, errors.ProtocolError.NO_RESPONSE_FROM_HANDSHAKE)
 
-    result = json.loads(resp)
+    result = json.loads(response)
     if result['status']:
       self.uid = result['uid']
     else:
@@ -460,7 +460,7 @@ class SnippetClientV2(client_base.ClientBase):
         self._conn.close()
         self._conn = None
     finally:
-      # Always clear the host port as part of the disconnect step.
+      # Always clear the host port as part of the close step
       self._stop_port_forwarding()
 
   def _stop_port_forwarding(self):
@@ -597,7 +597,7 @@ class SnippetClientV2(client_base.ClientBase):
       self._make_connection()
     except Exception as e:
       # Log the original error and raise ServerRestoreConnectionError.
-      self.log.error('Failed to re-connect to server.')
+      self.log.error('Failed to re-connect to the server.')
       raise errors.ServerRestoreConnectionError(
           self._device,
           (f'Failed to restore server connection for {self.package} at '
@@ -609,10 +609,10 @@ class SnippetClientV2(client_base.ClientBase):
     self._restore_event_client()
 
   def _restore_event_client(self):
-    """Restores previously created event client or creates a new one.
+    """Restores the previously created event client or creates a new one.
 
     This function restores the connection of the previously created event
-    client, or create a new client and makes a connection if it didn't
+    client, or creates a new client and makes a connection if it didn't
     exist before.
 
     The event client to restore reuses the same host port and device port

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -661,9 +661,7 @@ class SnippetClientV2(client_base.ClientBase):
     The event client to restore reuses the same host port and device port
     with the client on which function is called.
     """
-    if not self._event_client:
-      self._create_event_client()
-    else:
+    if self._event_client:
       self._event_client.make_connection_with_forwarded_port(
           self.host_port, self.device_port)
 

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -326,6 +326,10 @@ class SnippetClientV2(client_base.ClientBase):
     host port. Then, it creates a socket connection to the server on the device.
     Finally, it sends a handshake request to the server, which requests the
     server to prepare for the communication with the client.
+
+    This function uses self.host_port for communicating with the server. If
+    self.host_port is 0 or None, this function finds an available host port to
+    make the connection and set self.host_port to the found port.
     """
     self._forward_device_port()
     self.create_socket_connection()
@@ -350,6 +354,9 @@ class SnippetClientV2(client_base.ClientBase):
     to the server.
     """
     try:
+      self.log.debug('Snippet client is creating socket connection to the '
+                     'snippet server of %s through host port %d.',
+                     self.package, self.host_port)
       self._conn = socket.create_connection(('localhost', self.host_port),
                                             _SOCKET_CONNECTION_TIMEOUT)
     except ConnectionRefusedError as err:

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -62,7 +62,7 @@ class _MockAdbProxy(mock_android_device.MockAdbProxy):
     if f'am instrument --user 0 -w -e action stop {MOCK_SERVER_PATH}' in args:
       return b'OK (0 tests)'
 
-    # For other commands, hand over it to the base class.
+    # For other commands, hand it over to the base class.
     return super().shell(*args, **kwargs)
 
   def forward(self, *args, **kwargs):
@@ -75,7 +75,7 @@ class _MockSocketFile:
 
 
   Attributes:
-    writed_messages: list, all the messages wrote to this socket file.
+    writed_messages: list, all the messages written to this socket file.
   """
 
   def __init__(self, resp):
@@ -93,7 +93,7 @@ class _MockSocketFile:
     self.writed_messages = []
 
   def write(self, msg):
-    """Records all the messages wrote to this socket file."""
+    """Records all the messages written to this socket file."""
     self.writed_messages.append(msg)
 
   def readline(self):
@@ -707,7 +707,7 @@ class SnippetClientV2Test(unittest.TestCase):
         ['--remove', 'tcp:12345'])
 
   def test_close_connection_normally(self):
-    """Tests that close connection works normally."""
+    """Tests that closing connection works normally."""
     self._make_client()
     mock_conn = mock.Mock()
     self.client._conn = mock_conn
@@ -854,7 +854,7 @@ class SnippetClientV2Test(unittest.TestCase):
               'utils.get_available_host_port')
   def test_restore_event_client(self, mock_get_port, mock_start_subprocess,
                                 mock_socket_create_conn):
-    """Tests restoring event client."""
+    """Tests restoring the event client."""
     mock_get_port.return_value = 12345
     socket_resp = [
         # response of handshake when initializing the client
@@ -920,7 +920,7 @@ class SnippetClientV2Test(unittest.TestCase):
     self.assertEqual(next(self.client._event_client._counter), 0)
 
     # if unable to reconnect for any reason, a
-    # jsonrpc_client_base.AppRestoreConnectionError is raised.
+    # errors.ServerRestoreConnectionError is raised.
     mock_socket_create_conn.side_effect = IOError('socket timed out')
     with self.assertRaisesRegex(
         errors.ServerRestoreConnectionError,
@@ -1044,7 +1044,7 @@ class SnippetClientV2Test(unittest.TestCase):
 
   @mock.patch('socket.create_connection')
   def test_make_connection_io_error(self, mock_socket_create_conn):
-    """Tests IOError occurred trying to create socket connection."""
+    """Tests IOError occurred trying to create a socket connection."""
     mock_socket_create_conn.side_effect = IOError()
     with self.assertRaises(IOError):
       self._make_client()
@@ -1053,7 +1053,7 @@ class SnippetClientV2Test(unittest.TestCase):
 
   @mock.patch('socket.create_connection')
   def test_make_connection_timeout(self, mock_socket_create_conn):
-    """Tests timeout occurred trying to create socket connection."""
+    """Tests timeout occurred trying to create a socket connection."""
     mock_socket_create_conn.side_effect = socket.timeout
     with self.assertRaises(socket.timeout):
       self._make_client()

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -938,30 +938,6 @@ class SnippetClientV2Test(unittest.TestCase):
     mock_send_handshake_func.assert_called_once_with(
         -1, snippet_client_v2.ConnectionHandshakeCommand.INIT)
 
-  @mock.patch.object(snippet_client_v2.SnippetClientV2, '_make_connection')
-  @mock.patch.object(snippet_client_v2.SnippetClientV2,
-                     'send_handshake_request')
-  @mock.patch.object(snippet_client_v2.SnippetClientV2,
-                     'create_socket_connection')
-  def test_restore_server_connection_without_event_client(
-      self, mock_create_socket_conn_func, mock_send_handshake_func,
-      mock_make_connection):
-    """Tests restoring server connection when event client is None."""
-    self._make_client()
-    self.client._event_client = None
-    self.client.device_port = 54321
-    self.client.uid = 5
-
-    self.client.restore_server_connection(port=12345)
-
-    mock_make_connection.assert_called_once_with()
-    self.assertEqual(self.client._event_client.host_port, 12345)
-    self.assertEqual(self.client._event_client.device_port, 54321)
-    self.assertEqual(next(self.client._event_client._counter), 0)
-    mock_create_socket_conn_func.assert_called_once_with()
-    mock_send_handshake_func.assert_called_once_with(
-        5, snippet_client_v2.ConnectionHandshakeCommand.CONTINUE)
-
   @mock.patch('builtins.print')
   def test_help_rpc_when_printing_by_default(self, mock_print):
     """Tests the `help` method when it prints the output by default."""

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -920,7 +920,7 @@ class SnippetClientV2Test(unittest.TestCase):
   def test_restore_server_connection_with_event_client(
       self, mock_create_socket_conn_func, mock_send_handshake_func,
       mock_make_connection):
-    """Tests restoring server connection when event client is not None."""
+    """Tests restoring server connection when the event client is not None."""
     self._make_client()
     event_client = snippet_client_v2.SnippetClientV2('mock-package',
                                                      mock.Mock())
@@ -1229,7 +1229,7 @@ class SnippetClientV2Test(unittest.TestCase):
   def test_make_conn_with_forwarded_port_init(self,
                                               mock_create_socket_conn_func,
                                               mock_send_handshake_func):
-    """Test make_connection_with_forwarded_port initiates a new session."""
+    """Tests make_connection_with_forwarded_port initiates a new session."""
     self._make_client()
     self.client._counter = None
     self.client.make_connection_with_forwarded_port(12345, 54321)
@@ -1248,7 +1248,7 @@ class SnippetClientV2Test(unittest.TestCase):
   def test_make_conn_with_forwarded_port_continue(self,
                                                   mock_create_socket_conn_func,
                                                   mock_send_handshake_func):
-    """Test make_connection_with_forwarded_port continues current session."""
+    """Tests make_connection_with_forwarded_port continues current session."""
     self._make_client()
     self.client._counter = None
     self.client.make_connection_with_forwarded_port(

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -794,7 +794,7 @@ class SnippetClientV2Test(unittest.TestCase):
     self.assertEqual(self.client._event_client.device_port, MOCK_DEVICE_PORT)
     self.assertEqual(self.client._event_client.uid, self.client.uid)
 
-    # Ensure the event client have reset its own RPC id counter
+    # Ensure the event client has reset its own RPC id counter
     self.assertEqual(next(self.client._counter), 1)
     self.assertEqual(next(self.client._event_client._counter), 0)
 

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -743,8 +743,7 @@ class SnippetClientV2Test(unittest.TestCase):
 
     self.assertEqual(rpc_result, 123)
     self.mock_socket_file.write.assert_called_with(
-        b'{"id": 0, "method": "some_rpc", "params": [1, 2, "hello"]}\n'
-    )
+        b'{"id": 0, "method": "some_rpc", "params": [1, 2, "hello"]}\n')
 
   @mock.patch('socket.create_connection')
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -128,12 +128,11 @@ class SnippetClientV2Test(unittest.TestCase):
   """Unit tests for SnippetClientV2."""
 
   def _make_client(self, adb_proxy=None, mock_properties=None):
-    if adb_proxy is None:
-      adb_proxy = _MockAdbProxy(instrumented_packages=[
-          (MOCK_PACKAGE_NAME, snippet_client_v2._INSTRUMENTATION_RUNNER_PACKAGE,
-           MOCK_PACKAGE_NAME)
-      ],
-                                mock_properties=mock_properties)
+    adb_proxy = adb_proxy or _MockAdbProxy(instrumented_packages=[
+        (MOCK_PACKAGE_NAME, snippet_client_v2._INSTRUMENTATION_RUNNER_PACKAGE,
+         MOCK_PACKAGE_NAME)
+    ],
+                                           mock_properties=mock_properties)
     self.adb = adb_proxy
 
     device = mock.Mock()
@@ -157,10 +156,9 @@ class SnippetClientV2Test(unittest.TestCase):
   def _mock_server_process_starting_response(self,
                                              mock_start_subprocess,
                                              resp_lines=None):
-    if resp_lines is None:
-      resp_lines = [
-          b'SNIPPET START, PROTOCOL 1 0', b'SNIPPET SERVING, PORT 1234'
-      ]
+    resp_lines = resp_lines or [
+        b'SNIPPET START, PROTOCOL 1 0', b'SNIPPET SERVING, PORT 1234'
+    ]
     mock_proc = mock_start_subprocess.return_value
     mock_proc.stdout.readline.side_effect = resp_lines
 
@@ -339,12 +337,11 @@ class SnippetClientV2Test(unittest.TestCase):
                   method_name='some_async_rpc',
                   ad=self.device),
     ]
+    self.assertListEqual(rpc_results, rpc_results_expected)
+    mock_callback_class.assert_has_calls(mock_callback_class_calls_expected)
     self._assert_client_resources_released(mock_start_subprocess,
                                            mock_stop_standing_subprocess,
                                            mock_get_port)
-
-    self.assertListEqual(rpc_results, rpc_results_expected)
-    mock_callback_class.assert_has_calls(mock_callback_class_calls_expected)
 
   def test_check_app_installed_normally(self):
     """Tests that app checker runs normally when app installed correctly."""
@@ -1104,7 +1101,7 @@ class SnippetClientV2Test(unittest.TestCase):
     self.client._make_connection()
     self.assertEqual(self.client.uid, -1)
 
-  def test_rpc_send_to_socket(self):
+  def test_rpc_sending_and_receiving(self):
     """Test RPC sending and receiving.
 
     Tests that when sending and receiving an RPC the correct data is used.


### PR DESCRIPTION
Part of issue #793, the second step of adding snippet client v2. The previous step is PR #804.

This step includes building socket connection, sending RPC and restoring connection after device got reconnected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/808)
<!-- Reviewable:end -->
