### PR TITLE
Fix typo in run_command

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -477,7 +477,7 @@ def run_command(cmd,
   if timer is not None:
     timer.cancel()
   if timer_triggered.is_set():
-    raise subprocess.TimeoutExpired(cmd=cwd,
+    raise subprocess.TimeoutExpired(cmd=cmd,
                                     timeout=timeout,
                                     output=out,
                                     stderr=err)


### PR DESCRIPTION
Currently, if there's a timeout, the `cmd` field of the exception is set to `cwd`, which results in messages like:

```
Command 'None' timed out after 20 seconds
```

when the `cwd` param isn't set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/809)
<!-- Reviewable:end -->
