### PR TITLE
Fix typo in run_command

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -477,7 +477,7 @@ def run_command(cmd,
   if timer is not None:
     timer.cancel()
   if timer_triggered.is_set():
-    raise subprocess.TimeoutExpired(cmd=cwd,
+    raise subprocess.TimeoutExpired(cmd=cmd,
                                     timeout=timeout,
                                     output=out,
                                     stderr=err)

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -223,7 +223,7 @@ class UtilsTest(unittest.TestCase):
     self.assertEqual(ret, 0)
 
   def test_run_command_with_timeout_expired(self):
-    with self.assertRaises(subprocess.TimeoutExpired):
+    with self.assertRaisesRegex(subprocess.TimeoutExpired, 'sleep'):
       _ = utils.run_command(self.sleep_cmd(4), timeout=0.01)
 
   @mock.patch('threading.Timer')


### PR DESCRIPTION
Currently, if there's a timeout, the `cmd` field of the exception is set to `cwd`, which results in confusing error messages like:

```
Command 'None' timed out after 20 seconds
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/810)
<!-- Reviewable:end -->
