### PR TITLE
ClientBase should call "stop" if "before_starting_server" failed

### DIFF
--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -101,6 +101,9 @@ class ClientBase(abc.ABC):
       2. starting the snippet server on the remote device.
       3. making a connection to the snippet server.
 
+    If error occurs at any stage, this function will abort the initialization
+    process and call `stop` to clean up.
+
     Raises:
       errors.ProtocolError: something went wrong when exchanging data with the
         server.
@@ -116,10 +119,11 @@ class ClientBase(abc.ABC):
     self.log.info('Initializing the snippet package %s.', self.package)
     start_time = time.perf_counter()
 
-    self.log.debug('Preparing to start the snippet server of %s.', self.package)
-    self.before_starting_server()
-
     try:
+      self.log.debug('Preparing to start the snippet server of %s.',
+                     self.package)
+      self.before_starting_server()
+
       self.log.debug('Starting the snippet server of %s.', self.package)
       self.start_server()
 

--- a/tests/mobly/snippet/client_base_test.py
+++ b/tests/mobly/snippet/client_base_test.py
@@ -128,7 +128,7 @@ class ClientBaseTest(unittest.TestCase):
 
     with self.assertRaisesRegex(Exception, 'ha'):
       self.client.initialize()
-    mock_stop_func.assert_not_called()
+    mock_stop_func.assert_called()
 
   @mock.patch.object(FakeClient, 'stop')
   @mock.patch.object(FakeClient, 'start_server')


### PR DESCRIPTION
Part of issue #793. This change **is related to** the implementation of **Windows client**.

When implementing the Windows client, we found that we need to improve some behaviors of `ClientBase`.

**Changed content**: We modified the `ClientBase#initialize` function. If error occurs at any stage, this function will abort the initialization process and call `stop` to clean up.

**Reason for the change**: Previously we thought that if the `ClientBase#before_starting_server` stage fails, `ClientBase` doesn't need to call `stop` to clean up. But this is wrong, because `before_starting_server` may also perform some operations that need to be cleaned up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/813)
<!-- Reviewable:end -->
