### PR TITLE
Remove the host_port and device_port attributes from ClientBase

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -62,11 +62,16 @@ _NOHUP_COMMAND = 'nohup'
 class SnippetClientV2(client_base.ClientBase):
   """Snippet client V2 for interacting with snippet server on Android Device.
 
-  See base class documentation for a list of public attributes and communication
-  protocols.
-
   For a description of the launch protocols, see the documentation in
   mobly-snippet-lib, SnippetRunner.java.
+
+  We only list the public attributes introduced in this class. See base class
+  documentation for other public attributes and communication protocols.
+
+  Attributes:
+    host_port: int, the host port used for communicating with the snippet
+      server.
+    device_port: int, the device port listened by the snippet server.
   """
 
   def __init__(self, package, ad):
@@ -77,6 +82,8 @@ class SnippetClientV2(client_base.ClientBase):
       ad: AndroidDevice, the android device object associated with this client.
     """
     super().__init__(package=package, device=ad)
+    self.host_port = None
+    self.device_port = None
     self._adb = ad.adb
     self._user_id = None
     self._proc = None

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -68,8 +68,6 @@ class ClientBase(abc.ABC):
   Attributes:
     package: str, the user-visible name of the snippet library being
       communicated with.
-    host_port: int, the host port of this RPC client.
-    device_port: int, the device port of this RPC client.
     log: Logger, the logger of the corresponding device controller.
     verbose_logging: bool, if True, prints more detailed log
       information. Default is True.
@@ -85,8 +83,6 @@ class ClientBase(abc.ABC):
     """
 
     self.package = package
-    self.host_port = None
-    self.device_port = None
     self.log = device.log
     self.verbose_logging = True
     self._device = device
@@ -104,9 +100,6 @@ class ClientBase(abc.ABC):
       1. preparing to start the snippet server.
       2. starting the snippet server on the remote device.
       3. making a connection to the snippet server.
-
-    After this, the self.host_port and self.device_port attributes must be
-    set.
 
     Raises:
       errors.ProtocolError: something went wrong when exchanging data with the
@@ -148,10 +141,8 @@ class ClientBase(abc.ABC):
 
       raise
 
-    self.log.debug(
-        'Snippet package %s initialized after %.1fs on host port %d.',
-        self.package,
-        time.perf_counter() - start_time, self.host_port)
+    self.log.debug('Snippet package %s initialized after %.1fs.', self.package,
+                   time.perf_counter() - start_time)
 
   @abc.abstractmethod
   def before_starting_server(self):
@@ -193,10 +184,6 @@ class ClientBase(abc.ABC):
     * The client makes a connection in this stage and uses it for all the RPCs.
       In this case, the client should implement `close_connection` to close
       the connection.
-
-    This function uses self.host_port for communicating with the server. If
-    self.host_port is 0 or None, this function finds an available host port to
-    make the connection and set self.host_port to the found port.
 
     Raises:
       errors.ProtocolError: something went wrong when exchanging data with the
@@ -240,7 +227,7 @@ class ClientBase(abc.ABC):
     """Reconnects to the server after the device was disconnected.
 
     Instead of creating a new instance of the client:
-      - Uses the given port (or finds a new available host_port if 0 or None is
+      - Uses the given port (or finds a new available host port if 0 or None is
       given).
       - Tries to connect to the remote server with the selected port.
 


### PR DESCRIPTION
Part of issue #793. This change **is related to** the implementation of **Windows client**.

When implementing the Windows client, we found that we need to improve some behaviors of `ClientBase`.

**Changed content**: Removed the host_port and device_port attributes from ClientBase. Some of the deleted comments will be moved to PR #808.

**Reason for the change**: 
1. These 2 attributes are implementation details related to the connection. For example, the Windows client builds a new connection each time it wants to send an RPC, so it doesn't have a fixed host port. 
2. There doesn't seem to be much benefit of providing these 2 attributes in `ClientBase`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/814)
<!-- Reviewable:end -->
