### PR TITLE
Event client clears host_port and device_port attribute

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -262,6 +262,11 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
     """Releases all the resources acquired in `_start_event_client`."""
     if self._event_client:
       self._event_client.close_socket_connection()
+      # Without cleaning host_port of event_client, event client will try to
+      # stop the port forwarding when deconstructed, which should only be
+      # stopped by snippet client.
+      self._event_client.host_port = None
+      self._event_client.device_port = None
       self._event_client = None
 
   def _restore_event_client(self):

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -262,9 +262,9 @@ class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):
     """Releases all the resources acquired in `_start_event_client`."""
     if self._event_client:
       self._event_client.close_socket_connection()
-      # Without cleaning host_port of event_client, event client will try to
+      # Without cleaning host_port of event_client, the event client will try to
       # stop the port forwarding when deconstructed, which should only be
-      # stopped by snippet client.
+      # stopped by the corresponding snippet client.
       self._event_client.host_port = None
       self._event_client.device_port = None
       self._event_client = None

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -240,7 +240,7 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
     client.device_port = 67890
 
     event_client = client._start_event_client()
-    # Mock adb proxy of event client to valite forward call
+    # Mock adb proxy of event client to validate forward call
     event_client._ad = mock.MagicMock()
     event_client._adb = event_client._ad.adb
     client._event_client = event_client


### PR DESCRIPTION
Without cleaning host_port and device_port attribute of event client, there will be a caught exception during `teardown_class` process. Because the event client and snippet client will clean up the port forwarding configuration for the same port. 

This problem occurs whenever the user uses an async RPC. But this exception will be caught, so it won't cause the test to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/822)
<!-- Reviewable:end -->
