### PR TITLE
Remove the dependency of client v2's unit test on subprocess

### DIFF
--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -14,13 +14,11 @@
 """Unit tests for mobly.controllers.android_device_lib.snippet_client_v2."""
 
 import socket
-import subprocess
 import unittest
 from unittest import mock
 
 from mobly.controllers.android_device_lib import adb
-from mobly.controllers.android_device_lib import \
-    errors as android_device_lib_errors
+from mobly.controllers.android_device_lib import errors as android_device_lib_errors
 from mobly.controllers.android_device_lib import snippet_client_v2
 from mobly.snippet import errors
 from tests.lib import mock_android_device
@@ -93,15 +91,6 @@ def _setup_mock_socket_file(mock_socket_create_conn, resp):
 
 class SnippetClientV2Test(unittest.TestCase):
   """Unit tests for SnippetClientV2."""
-
-  def setUp(self):
-    # self.mock_subprocess = mock.patch('subprocess', spec_set=[])
-    # self.mock_subprocess.start()
-    pass
-
-  def tearDown(self):
-    # self.mock_subprocess.stop()
-    pass
 
   def _make_client(self, adb_proxy=None, mock_properties=None):
     adb_proxy = adb_proxy or _MockAdbProxy(instrumented_packages=[
@@ -737,13 +726,15 @@ class SnippetClientV2Test(unittest.TestCase):
         ['--remove', 'tcp:123'])
 
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
-              'utils.get_available_host_port', return_value=12345)
+              'utils.get_available_host_port',
+              return_value=12345)
   @mock.patch('socket.create_connection')
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
               'utils.start_standing_subprocess')
   def test_send_sync_rpc_normally(self, mock_start_subprocess,
                                   mock_socket_create_conn, mock_get_port):
     """Tests that sending a sync RPC works normally."""
+    del mock_get_port
     socket_resp = [
         b'{"status": true, "uid": 1}',
         b'{"id": 0, "result": 123, "error": null, "callback": null}',
@@ -1063,11 +1054,13 @@ class SnippetClientV2Test(unittest.TestCase):
         snippet_client_v2._SOCKET_READ_TIMEOUT)
 
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
-              'utils.get_available_host_port', return_value=12345)
+              'utils.get_available_host_port',
+              return_value=12345)
   @mock.patch('socket.create_connection')
   def test_make_connection_io_error(self, mock_socket_create_conn,
                                     mock_get_port):
     """Tests IOError occurred trying to create a socket connection."""
+    del mock_get_port
     mock_socket_create_conn.side_effect = IOError()
     with self.assertRaises(IOError):
       self._make_client()
@@ -1075,10 +1068,13 @@ class SnippetClientV2Test(unittest.TestCase):
       self.client.make_connection()
 
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
-              'utils.get_available_host_port', return_value=12345)
+              'utils.get_available_host_port',
+              return_value=12345)
   @mock.patch('socket.create_connection')
-  def test_make_connection_timeout(self, mock_socket_create_conn, mock_get_port):
+  def test_make_connection_timeout(self, mock_socket_create_conn,
+                                   mock_get_port):
     """Tests timeout occurred trying to create a socket connection."""
+    del mock_get_port
     mock_socket_create_conn.side_effect = socket.timeout
     with self.assertRaises(socket.timeout):
       self._make_client()
@@ -1086,13 +1082,15 @@ class SnippetClientV2Test(unittest.TestCase):
       self.client.make_connection()
 
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
-              'utils.get_available_host_port', return_value=12345)
+              'utils.get_available_host_port',
+              return_value=12345)
   @mock.patch('socket.create_connection')
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
               'utils.start_standing_subprocess')
   def test_make_connection_receives_none_handshake_response(
       self, mock_start_subprocess, mock_socket_create_conn, mock_get_port):
     """Tests make_connection receives None as the handshake response."""
+    del mock_get_port
     socket_resp = [None]
     self._make_client_and_mock_socket_conn(mock_socket_create_conn, socket_resp)
     self._mock_server_process_starting_response(mock_start_subprocess)
@@ -1102,13 +1100,15 @@ class SnippetClientV2Test(unittest.TestCase):
       self.client.make_connection()
 
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
-              'utils.get_available_host_port', return_value=12345)
+              'utils.get_available_host_port',
+              return_value=12345)
   @mock.patch('socket.create_connection')
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
               'utils.start_standing_subprocess')
   def test_make_connection_receives_empty_handshake_response(
       self, mock_start_subprocess, mock_socket_create_conn, mock_get_port):
     """Tests make_connection receives an empty handshake response."""
+    del mock_get_port
     socket_resp = [b'']
     self._make_client_and_mock_socket_conn(mock_socket_create_conn, socket_resp)
     self._mock_server_process_starting_response(mock_start_subprocess)
@@ -1118,13 +1118,15 @@ class SnippetClientV2Test(unittest.TestCase):
       self.client.make_connection()
 
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
-              'utils.get_available_host_port', return_value=12345)
+              'utils.get_available_host_port',
+              return_value=12345)
   @mock.patch('socket.create_connection')
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
               'utils.start_standing_subprocess')
   def test_make_connection_receives_invalid_handshake_response(
       self, mock_start_subprocess, mock_socket_create_conn, mock_get_port):
     """Tests make_connection receives an invalid handshake response."""
+    del mock_get_port
     socket_resp = [b'{"status": false, "uid": 1}']
     self._make_client_and_mock_socket_conn(mock_socket_create_conn, socket_resp)
     self._mock_server_process_starting_response(mock_start_subprocess)
@@ -1133,13 +1135,17 @@ class SnippetClientV2Test(unittest.TestCase):
     self.assertEqual(self.client.uid, -1)
 
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
-              'utils.get_available_host_port', return_value=12345)
+              'utils.get_available_host_port',
+              return_value=12345)
   @mock.patch('socket.create_connection')
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
               'utils.start_standing_subprocess')
-  def test_make_connection_send_handshake_request_error(
-      self, mock_start_subprocess, mock_socket_create_conn, mock_get_port):
+  def test_make_connection_send_handshake_request_error(self,
+                                                        mock_start_subprocess,
+                                                        mock_socket_create_conn,
+                                                        mock_get_port):
     """Tests that an error occurred trying to send a handshake request."""
+    del mock_get_port
     self._make_client_and_mock_socket_conn(mock_socket_create_conn)
     self._mock_server_process_starting_response(mock_start_subprocess)
     self.mock_socket_file.write.side_effect = socket.error('Socket write error')
@@ -1148,13 +1154,15 @@ class SnippetClientV2Test(unittest.TestCase):
       self.client.make_connection()
 
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
-              'utils.get_available_host_port', return_value=12345)
+              'utils.get_available_host_port',
+              return_value=12345)
   @mock.patch('socket.create_connection')
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
               'utils.start_standing_subprocess')
   def test_make_connection_receive_handshake_response_error(
       self, mock_start_subprocess, mock_socket_create_conn, mock_get_port):
     """Tests that an error occurred trying to receive a handshake response."""
+    del mock_get_port
     self._make_client_and_mock_socket_conn(mock_socket_create_conn)
     self._mock_server_process_starting_response(mock_start_subprocess)
     self.mock_socket_file.readline.side_effect = socket.error(
@@ -1164,13 +1172,15 @@ class SnippetClientV2Test(unittest.TestCase):
       self.client.make_connection()
 
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
-              'utils.get_available_host_port', return_value=12345)
+              'utils.get_available_host_port',
+              return_value=12345)
   @mock.patch('socket.create_connection')
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
               'utils.start_standing_subprocess')
   def test_make_connection_decode_handshake_response_bytes_error(
       self, mock_start_subprocess, mock_socket_create_conn, mock_get_port):
     """Tests that an error occurred trying to decode a handshake response."""
+    del mock_get_port
     self._make_client_and_mock_socket_conn(mock_socket_create_conn)
     self._mock_server_process_starting_response(mock_start_subprocess)
     self.client.log = mock.Mock()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/823)
<!-- Reviewable:end -->
