### PR TITLE
Alias error classes of snippet client v1 to the new ones in snippet package

### DIFF
--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -58,6 +58,7 @@ import threading
 
 from mobly.controllers.android_device_lib import callback_handler
 from mobly.controllers.android_device_lib import errors
+from mobly.snippet import errors as errors
 
 # UID of the 'unknown' jsonrpc session. Will cause creation of a new session.
 UNKNOWN_UID = -1
@@ -73,28 +74,12 @@ _SOCKET_READ_TIMEOUT = callback_handler.MAX_TIMEOUT
 _MAX_RPC_RESP_LOGGING_LENGTH = 1024
 
 
-class Error(errors.DeviceError):
-  pass
-
-
-class AppStartError(Error):
-  """Raised when the app is not able to be started."""
-
-
-class AppRestoreConnectionError(Error):
-  """Raised when failed to restore app from disconnection."""
-
-
-class ApiError(Error):
-  """Raised when remote API reports an error."""
-
-
-class ProtocolError(Error):
-  """Raised when there is some error in exchanging data with server."""
-  NO_RESPONSE_FROM_HANDSHAKE = 'No response from handshake.'
-  NO_RESPONSE_FROM_SERVER = ('No response from server. '
-                             'Check the device logcat for crashes.')
-  MISMATCHED_API_ID = 'RPC request-response ID mismatch.'
+# Aliases of error types for backward compatibility.
+Error = errors.Error
+AppStartError = errors.ServerStartError
+AppRestoreConnectionError = errors.ServerRestoreConnectionError
+ApiError = errors.ApiError
+ProtocolError = errors.ProtocolError
 
 
 class JsonRpcCommand:

--- a/mobly/controllers/android_device_lib/jsonrpc_client_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_client_base.py
@@ -57,8 +57,7 @@ import socket
 import threading
 
 from mobly.controllers.android_device_lib import callback_handler
-from mobly.controllers.android_device_lib import errors
-from mobly.snippet import errors as errors
+from mobly.snippet import errors
 
 # UID of the 'unknown' jsonrpc session. Will cause creation of a new session.
 UNKNOWN_UID = -1
@@ -72,7 +71,6 @@ _SOCKET_READ_TIMEOUT = callback_handler.MAX_TIMEOUT
 # Maximum logging length of Rpc response in DEBUG level when verbose logging is
 # off.
 _MAX_RPC_RESP_LOGGING_LENGTH = 1024
-
 
 # Aliases of error types for backward compatibility.
 Error = errors.Error

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -20,6 +20,7 @@ from mobly import utils
 from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import errors
 from mobly.controllers.android_device_lib import jsonrpc_client_base
+from mobly.snippet import errors as snippet_errors
 
 _INSTRUMENTATION_RUNNER_PACKAGE = (
     'com.google.android.mobly.snippet.SnippetRunner')
@@ -56,13 +57,9 @@ _SETSID_COMMAND = 'setsid'
 
 _NOHUP_COMMAND = 'nohup'
 
-
-class AppStartPreCheckError(jsonrpc_client_base.Error):
-  """Raised when pre checks for the snippet failed."""
-
-
-class ProtocolVersionError(jsonrpc_client_base.AppStartError):
-  """Raised when the protocol reported by the snippet is unknown."""
+# Aliases of error types for backward compatibility.
+AppStartPreCheckError = snippet_errors.ServerStartPreCheckError
+ProtocolVersionError = snippet_errors.ServerStartProtocolError
 
 
 class SnippetClient(jsonrpc_client_base.JsonRpcClientBase):


### PR DESCRIPTION
Part of #793.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/824)
<!-- Reviewable:end -->
