### PR TITLE
ClientBase shouldn't call "stop" if "before_starting_server" failed

### DIFF
--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -154,6 +154,10 @@ class ClientBase(abc.ABC):
     For example, subclass can check or modify the device settings at this
     stage.
 
+    NOTE: Do not acquire resources in this function, as this should only contain
+    preparation steps and any error at this stage will abort the initialization
+    without cleanup.
+
     Raises:
       errors.ServerStartPreCheckError: when prechecks for starting the server
         failed.

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -97,13 +97,13 @@ class ClientBase(abc.ABC):
     """Initializes the snippet client to interact with the remote device.
 
     This function contains following stages:
-      1. before_starting_server: preparing to start the snippet server.
-      2. start_server: starting the snippet server on the remote device.
-      3. make_connection: making a connection to the snippet server.
+      1. before starting server: preparing to start the snippet server.
+      2. start server: starting the snippet server on the remote device.
+      3. make connection: making a connection to the snippet server.
 
     An error occurring at any stage will abort the initialization. Only errors
-    at the start_server and make_connection stages will trigger `stop` to clean
-    up.
+    at the `start_server` and `make_connection` stages will trigger `stop` to
+    clean up.
 
     Raises:
       errors.ProtocolError: something went wrong when exchanging data with the

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -101,7 +101,7 @@ class ClientBase(abc.ABC):
       2. starting the snippet server on the remote device.
       3. making a connection to the snippet server.
 
-    An error occurs at any stage will abort the initialization. Only errors in
+    An error occurs at any stage will abort the initialization. Only errors at
     the second and third stages will trigger `stop` to clean up.
 
     Raises:

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -97,12 +97,13 @@ class ClientBase(abc.ABC):
     """Initializes the snippet client to interact with the remote device.
 
     This function contains following stages:
-      1. preparing to start the snippet server.
-      2. starting the snippet server on the remote device.
-      3. making a connection to the snippet server.
+      1. before_starting_server: preparing to start the snippet server.
+      2. start_server: starting the snippet server on the remote device.
+      3. make_connection: making a connection to the snippet server.
 
-    An error occurs at any stage will abort the initialization. Only errors at
-    the second and third stages will trigger `stop` to clean up.
+    An error occurring at any stage will abort the initialization. Only errors
+    at the start_server and make_connection stages will trigger `stop` to clean
+    up.
 
     Raises:
       errors.ProtocolError: something went wrong when exchanging data with the

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -101,8 +101,8 @@ class ClientBase(abc.ABC):
       2. starting the snippet server on the remote device.
       3. making a connection to the snippet server.
 
-    If error occurs at any stage, this function will abort the initialization
-    process and call `stop` to clean up.
+    An error occurs at any stage will abort the initialization. Only errors in
+    the second and third stages will trigger `stop` to clean up.
 
     Raises:
       errors.ProtocolError: something went wrong when exchanging data with the
@@ -119,11 +119,10 @@ class ClientBase(abc.ABC):
     self.log.info('Initializing the snippet package %s.', self.package)
     start_time = time.perf_counter()
 
-    try:
-      self.log.debug('Preparing to start the snippet server of %s.',
-                     self.package)
-      self.before_starting_server()
+    self.log.debug('Preparing to start the snippet server of %s.', self.package)
+    self.before_starting_server()
 
+    try:
       self.log.debug('Starting the snippet server of %s.', self.package)
       self.start_server()
 

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -154,9 +154,9 @@ class ClientBase(abc.ABC):
     For example, subclass can check or modify the device settings at this
     stage.
 
-    NOTE: Do not acquire resources in this function, as this should only contain
-    preparation steps and any error at this stage will abort the initialization
-    without cleanup.
+    NOTE: Any error at this stage will abort the initialization without cleanup.
+    So do not acquire resources in this function, or this function should
+    release the acquired resources if an error occurs.
 
     Raises:
       errors.ServerStartPreCheckError: when prechecks for starting the server

--- a/tests/mobly/snippet/client_base_test.py
+++ b/tests/mobly/snippet/client_base_test.py
@@ -128,7 +128,7 @@ class ClientBaseTest(unittest.TestCase):
 
     with self.assertRaisesRegex(Exception, 'ha'):
       self.client.initialize()
-    mock_stop_func.assert_called()
+    mock_stop_func.assert_not_called()
 
   @mock.patch.object(FakeClient, 'stop')
   @mock.patch.object(FakeClient, 'start_server')


### PR DESCRIPTION
Part of #793.

Reason for change:
* Keep the same logic as Android snippet client v1.
* Previously I thought it was ok to call "stop" to make sure everything is cleaned. But in fact this causes different behavior from client v1, which is wrong. e.g., when "before_starting_server" fails without installing the snippet apk, "stop" will fail and raise a new error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/834)
<!-- Reviewable:end -->
