### PR TITLE
Add termination signal type to record.

### DIFF
--- a/mobly/records.py
+++ b/mobly/records.py
@@ -176,6 +176,7 @@ class TestResultEnums:
   RECORD_EXTRAS = 'Extras'
   RECORD_EXTRA_ERRORS = 'Extra Errors'
   RECORD_DETAILS = 'Details'
+  RECORD_TERMINATION_SIGNAL_TYPE = 'Termination Signal Type'
   RECORD_STACKTRACE = 'Stacktrace'
   RECORD_SIGNATURE = 'Signature'
   RECORD_RETRY_PARENT = 'Retry Parent'
@@ -345,6 +346,16 @@ class TestResultRecord:
       return self.termination_signal.details
 
   @property
+  def termination_singal_type(self):
+    """Type name of the signal that caused the test's termination.
+
+    Note a passed test can have this as well due to the explicit pass
+    signal. If the test passed implicitly, this field would be None.
+    """
+    if self.termination_signal:
+      return self.termination_signal.type
+
+  @property
   def stacktrace(self):
     """The stacktrace string for the exception that terminated the test.
     """
@@ -492,6 +503,8 @@ class TestResultRecord:
       RECORD_RETRY_PARENT] = self.retry_parent.signature if self.retry_parent else None
     d[TestResultEnums.RECORD_EXTRAS] = self.extras
     d[TestResultEnums.RECORD_DETAILS] = self.details
+    d[TestResultEnums.
+      RECORD_TERMINATION_SIGNAL_TYPE] = self.termination_singal_type
     d[TestResultEnums.RECORD_EXTRA_ERRORS] = {
         key: value.to_dict() for (key, value) in self.extra_errors.items()
     }

--- a/mobly/records.py
+++ b/mobly/records.py
@@ -346,7 +346,7 @@ class TestResultRecord:
       return self.termination_signal.details
 
   @property
-  def termination_singal_type(self):
+  def termination_signal_type(self):
     """Type name of the signal that caused the test's termination.
 
     Note a passed test can have this as well due to the explicit pass
@@ -504,7 +504,7 @@ class TestResultRecord:
     d[TestResultEnums.RECORD_EXTRAS] = self.extras
     d[TestResultEnums.RECORD_DETAILS] = self.details
     d[TestResultEnums.
-      RECORD_TERMINATION_SIGNAL_TYPE] = self.termination_singal_type
+      RECORD_TERMINATION_SIGNAL_TYPE] = self.termination_signal_type
     d[TestResultEnums.RECORD_EXTRA_ERRORS] = {
         key: value.to_dict() for (key, value) in self.extra_errors.items()
     }

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -55,14 +55,14 @@ class RecordsTest(unittest.TestCase):
                     result,
                     details,
                     extras,
-                    termination_singal_type=None,
+                    termination_signal_type=None,
                     stacktrace=None):
     record.update_record()
     # Verify each field.
     self.assertEqual(record.test_name, self.tn)
     self.assertEqual(record.result, result)
     self.assertEqual(record.details, details)
-    self.assertEqual(record.termination_singal_type, termination_singal_type)
+    self.assertEqual(record.termination_signal_type, termination_signal_type)
     self.assertEqual(record.extras, extras)
     self.assertTrue(record.begin_time, 'begin time should not be empty.')
     self.assertTrue(record.end_time, 'end time should not be empty.')
@@ -74,7 +74,7 @@ class RecordsTest(unittest.TestCase):
     d[records.TestResultEnums.RECORD_RESULT] = result
     d[records.TestResultEnums.RECORD_DETAILS] = details
     d[records.TestResultEnums.
-      RECORD_TERMINATION_SIGNAL_TYPE] = termination_singal_type
+      RECORD_TERMINATION_SIGNAL_TYPE] = termination_signal_type
     d[records.TestResultEnums.RECORD_EXTRAS] = extras
     d[records.TestResultEnums.RECORD_BEGIN_TIME] = record.begin_time
     d[records.TestResultEnums.RECORD_END_TIME] = record.end_time
@@ -114,7 +114,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_PASS,
                        details=self.details,
-                       termination_singal_type='TestPass',
+                       termination_signal_type='TestPass',
                        extras=self.float_extra)
 
   def test_result_record_explicit_pass_with_json_extra(self):
@@ -125,7 +125,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_PASS,
                        details=self.details,
-                       termination_singal_type='TestPass',
+                       termination_signal_type='TestPass',
                        extras=self.json_extra)
 
   def test_result_record_fail_none(self):
@@ -151,7 +151,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_FAIL,
                        details='Something failed.',
-                       termination_singal_type='Exception',
+                       termination_signal_type='Exception',
                        extras=None,
                        stacktrace='in test_result_record_fail_stacktrace\n    '
                        'raise Exception(\'Something failed.\')\nException: '
@@ -165,7 +165,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_FAIL,
                        details=self.details,
-                       termination_singal_type='TestFailure',
+                       termination_signal_type='TestFailure',
                        extras=self.float_extra)
 
   def test_result_record_fail_with_unicode_test_signal(self):
@@ -177,7 +177,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_FAIL,
                        details=details,
-                       termination_singal_type='TestFailure',
+                       termination_signal_type='TestFailure',
                        extras=self.float_extra)
 
   def test_result_record_fail_with_unicode_exception(self):
@@ -189,7 +189,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_FAIL,
                        details=details,
-                       termination_singal_type='Exception',
+                       termination_signal_type='Exception',
                        extras=None)
 
   def test_result_record_fail_with_json_extra(self):
@@ -200,7 +200,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_FAIL,
                        details=self.details,
-                       termination_singal_type='TestFailure',
+                       termination_signal_type='TestFailure',
                        extras=self.json_extra)
 
   def test_result_record_skip_none(self):
@@ -220,7 +220,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_SKIP,
                        details=self.details,
-                       termination_singal_type='TestSkip',
+                       termination_signal_type='TestSkip',
                        extras=self.float_extra)
 
   def test_result_record_skip_with_json_extra(self):
@@ -231,7 +231,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_SKIP,
                        details=self.details,
-                       termination_singal_type='TestSkip',
+                       termination_signal_type='TestSkip',
                        extras=self.json_extra)
 
   def test_result_add_operator_success(self):

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -50,12 +50,19 @@ class RecordsTest(unittest.TestCase):
   def tearDown(self):
     shutil.rmtree(self.tmp_path)
 
-  def verify_record(self, record, result, details, extras, stacktrace=None):
+  def verify_record(self,
+                    record,
+                    result,
+                    details,
+                    extras,
+                    termination_singal_type=None,
+                    stacktrace=None):
     record.update_record()
     # Verify each field.
     self.assertEqual(record.test_name, self.tn)
     self.assertEqual(record.result, result)
     self.assertEqual(record.details, details)
+    self.assertEqual(record.termination_singal_type, termination_singal_type)
     self.assertEqual(record.extras, extras)
     self.assertTrue(record.begin_time, 'begin time should not be empty.')
     self.assertTrue(record.end_time, 'end time should not be empty.')
@@ -66,6 +73,8 @@ class RecordsTest(unittest.TestCase):
     d[records.TestResultEnums.RECORD_NAME] = self.tn
     d[records.TestResultEnums.RECORD_RESULT] = result
     d[records.TestResultEnums.RECORD_DETAILS] = details
+    d[records.TestResultEnums.
+      RECORD_TERMINATION_SIGNAL_TYPE] = termination_singal_type
     d[records.TestResultEnums.RECORD_EXTRAS] = extras
     d[records.TestResultEnums.RECORD_BEGIN_TIME] = record.begin_time
     d[records.TestResultEnums.RECORD_END_TIME] = record.end_time
@@ -88,7 +97,7 @@ class RecordsTest(unittest.TestCase):
     self.assertTrue(str(record), 'str of the record should not be empty.')
     self.assertTrue(repr(record), "the record's repr shouldn't be empty.")
 
-  def test_result_record_pass_none(self):
+  def test_result_record_implicit_pass(self):
     record = records.TestResultRecord(self.tn)
     record.test_begin()
     record.test_pass()
@@ -97,7 +106,7 @@ class RecordsTest(unittest.TestCase):
                        details=None,
                        extras=None)
 
-  def test_result_record_pass_with_float_extra(self):
+  def test_result_record_explicit_pass_with_float_extra(self):
     record = records.TestResultRecord(self.tn)
     record.test_begin()
     s = signals.TestPass(self.details, self.float_extra)
@@ -105,9 +114,10 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_PASS,
                        details=self.details,
+                       termination_singal_type='TestPass',
                        extras=self.float_extra)
 
-  def test_result_record_pass_with_json_extra(self):
+  def test_result_record_explicit_pass_with_json_extra(self):
     record = records.TestResultRecord(self.tn)
     record.test_begin()
     s = signals.TestPass(self.details, self.json_extra)
@@ -115,9 +125,11 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_PASS,
                        details=self.details,
+                       termination_singal_type='TestPass',
                        extras=self.json_extra)
 
   def test_result_record_fail_none(self):
+    """Verifies that `test_fail` can be called without an error object."""
     record = records.TestResultRecord(self.tn)
     record.test_begin()
     record.test_fail()
@@ -139,6 +151,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_FAIL,
                        details='Something failed.',
+                       termination_singal_type='Exception',
                        extras=None,
                        stacktrace='in test_result_record_fail_stacktrace\n    '
                        'raise Exception(\'Something failed.\')\nException: '
@@ -152,6 +165,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_FAIL,
                        details=self.details,
+                       termination_singal_type='TestFailure',
                        extras=self.float_extra)
 
   def test_result_record_fail_with_unicode_test_signal(self):
@@ -163,6 +177,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_FAIL,
                        details=details,
+                       termination_singal_type='TestFailure',
                        extras=self.float_extra)
 
   def test_result_record_fail_with_unicode_exception(self):
@@ -174,6 +189,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_FAIL,
                        details=details,
+                       termination_singal_type='Exception',
                        extras=None)
 
   def test_result_record_fail_with_json_extra(self):
@@ -184,6 +200,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_FAIL,
                        details=self.details,
+                       termination_singal_type='TestFailure',
                        extras=self.json_extra)
 
   def test_result_record_skip_none(self):
@@ -203,6 +220,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_SKIP,
                        details=self.details,
+                       termination_singal_type='TestSkip',
                        extras=self.float_extra)
 
   def test_result_record_skip_with_json_extra(self):
@@ -213,6 +231,7 @@ class RecordsTest(unittest.TestCase):
     self.verify_record(record=record,
                        result=records.TestResultEnums.TEST_RESULT_SKIP,
                        details=self.details,
+                       termination_singal_type='TestSkip',
                        extras=self.json_extra)
 
   def test_result_add_operator_success(self):


### PR DESCRIPTION
So this information can be parsed more easily.
Without this field, the parsers would need to use regex magic or
make assumptions of the trace's format to get this info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/837)
<!-- Reviewable:end -->
