### PR TITLE
Remove argv check. Check is already done in parse_cli_args.

### DIFF
--- a/mobly/suite_runner.py
+++ b/mobly/suite_runner.py
@@ -138,8 +138,6 @@ def run_suite_class(argv=None):
   Args:
     argv: A list that is then parsed as CLI args. If None, defaults to sys.argv.
   """
-  if argv is None:
-    argv = sys.argv
   cli_args = _parse_cli_args(argv)
   test_configs = config_parser.load_test_config_file(cli_args.config)
   config_count = len(test_configs)

--- a/tests/mobly/suite_runner_test.py
+++ b/tests/mobly/suite_runner_test.py
@@ -146,7 +146,7 @@ class SuiteRunnerTest(unittest.TestCase):
               MagicDevice: '*'
       """)
 
-    mock_cli_args = [f'--config={tmp_file_path}']
+    mock_cli_args = ['test_binary', f'--config={tmp_file_path}']
 
     with mock.patch.object(sys, 'argv', new=mock_cli_args):
       suite_runner.run_suite_class()


### PR DESCRIPTION
And it should use sys.argv[1:] instead of sys.argv.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/838)
<!-- Reviewable:end -->
