### PR TITLE
Deprecate legacy snippet modules after snippet client v2 migration

### DIFF
--- a/mobly/controllers/android_device_lib/callback_handler.py
+++ b/mobly/controllers/android_device_lib/callback_handler.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import time
 
 from mobly.controllers.android_device_lib import snippet_event
 from mobly.snippet import errors
+
+logging.warning(
+    'The module mobly.controllers.android_device_lib.callback_handler is '
+    'deprecated and will be removed in a future version. Use module '
+    'mobly.controllers.android_device_lib.callback_handler_v2 instead.')
 
 # The max timeout cannot be larger than the max time the socket waits for a
 # response message. Otherwise, the socket would timeout before the Rpc call

--- a/mobly/controllers/android_device_lib/services/snippet_management_service.py
+++ b/mobly/controllers/android_device_lib/services/snippet_management_service.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Module for the snippet management service."""
 from mobly.controllers.android_device_lib import errors
-from mobly.controllers.android_device_lib import snippet_client
 from mobly.controllers.android_device_lib import snippet_client_v2
 from mobly.controllers.android_device_lib.services import base_service
 
@@ -117,6 +116,8 @@ class SnippetManagementService(base_service.BaseService):
                                                  ad=self._device)
       client.initialize()
     else:
+      # Only import snippet_client when needed, since it is deprecated.
+      from mobly.controllers.android_device_lib import snippet_client
       client = snippet_client.SnippetClient(package=package, ad=self._device)
       client.start_app_and_connect()
     self._snippet_clients[name] = client

--- a/mobly/controllers/android_device_lib/snippet_client.py
+++ b/mobly/controllers/android_device_lib/snippet_client.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """JSON RPC interface to Mobly Snippet Lib."""
 
+import logging
 import re
 import time
 
@@ -21,6 +22,11 @@ from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import errors
 from mobly.controllers.android_device_lib import jsonrpc_client_base
 from mobly.snippet import errors as snippet_errors
+
+logging.warning('The module mobly.controllers.android_device_lib.snippet_client'
+                ' is deprecated and will be removed in a future version. Use'
+                ' module mobly.controllers.android_device_lib.snippet_client_v2'
+                ' instead.')
 
 _INSTRUMENTATION_RUNNER_PACKAGE = (
     'com.google.android.mobly.snippet.SnippetRunner')

--- a/mobly/controllers/android_device_lib/snippet_event.py
+++ b/mobly/controllers/android_device_lib/snippet_event.py
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+
+logging.warning('The module mobly.controllers.android_device_lib.snippet_event '
+                'is deprecated and will be removed in a future version. Use '
+                'module mobly.snippet.callback_event instead.')
 
 
 def from_dict(event_dict):


### PR DESCRIPTION
Part of #793.