### PR TITLE
Rename the `setup_generated_tests` stage to `pre_run`.

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -36,6 +36,8 @@ TEST_STAGE_BEGIN_LOG_TEMPLATE = '[{parent_token}]#{child_token} >>> BEGIN >>>'
 TEST_STAGE_END_LOG_TEMPLATE = '[{parent_token}]#{child_token} <<< END <<<'
 
 # Names of execution stages, in the order they happen during test runs.
+STAGE_NAME_PRE_RUN = 'pre_run'
+# Deprecated, use `STAGE_NAME_PRE_RUN` instead.
 STAGE_NAME_SETUP_GENERATED_TESTS = 'setup_generated_tests'
 STAGE_NAME_SETUP_CLASS = 'setup_class'
 STAGE_NAME_SETUP_TEST = 'setup_test'
@@ -339,22 +341,26 @@ class BaseTestClass:
       self.summary_writer.dump(record.to_dict(),
                                records.TestSummaryEntryType.CONTROLLER_INFO)
 
-  def _setup_generated_tests(self):
-    """Proxy function to guarantee the base implementation of
-    setup_generated_tests is called.
+  def _pre_run(self):
+    """Proxy function to guarantee the base implementation of `pre_run` is
+    called.
 
     Returns:
       True if setup is successful, False otherwise.
     """
-    stage_name = STAGE_NAME_SETUP_GENERATED_TESTS
+    stage_name = STAGE_NAME_PRE_RUN
     record = records.TestResultRecord(stage_name, self.TAG)
     record.test_begin()
     self.current_test_info = runtime_test_info.RuntimeTestInfo(
         stage_name, self.log_path, record)
     try:
       with self._log_test_stage(stage_name):
+        self.pre_run()
+      # TODO(angli): Remove this context block after the full deprecation of
+      # `setup_generated_tests`.
+      with self._log_test_stage(stage_name):
         self.setup_generated_tests()
-        return True
+      return True
     except Exception as e:
       logging.exception('%s failed for %s.', stage_name, self.TAG)
       record.test_error(e)
@@ -363,8 +369,21 @@ class BaseTestClass:
                                records.TestSummaryEntryType.RECORD)
       return False
 
-  def setup_generated_tests(self):
+  def pre_run(self):
     """Preprocesses that need to be done before setup_class.
+
+    This phase is used to do pre-test processes like generating tests.
+    This is the only place `self.generate_tests` should be called.
+
+    If this function throws an error, the test class will be marked failure
+    and the "Requested" field will be 0 because the number of tests
+    requested is unknown at this point.
+    """
+
+  def setup_generated_tests(self):
+    """[DEPRECATED] Use `pre_run` instead.
+
+    Preprocesses that need to be done before setup_class.
 
     This phase is used to do pre-test processes like generating tests.
     This is the only place `self.generate_tests` should be called.
@@ -854,7 +873,7 @@ class BaseTestClass:
         arguments as the test logic function and returns a string that
         is the corresponding UID.
     """
-    self._assert_function_name_in_stack(STAGE_NAME_SETUP_GENERATED_TESTS)
+    self._assert_function_name_in_stack(STAGE_NAME_PRE_RUN)
     root_msg = 'During test generation of "%s":' % test_logic.__name__
     for args in arg_sets:
       test_name = name_func(*args)
@@ -866,8 +885,8 @@ class BaseTestClass:
       # decorators, copy the attributes added by the decorators to the
       # generated test methods as well, so the generated test methods
       # also have the retry/repeat behavior.
-      for attr_name in (
-        ATTR_MAX_RETRY_CNT, ATTR_MAX_CONSEC_ERROR, ATTR_REPEAT_CNT):
+      for attr_name in (ATTR_MAX_RETRY_CNT, ATTR_MAX_CONSEC_ERROR,
+                        ATTR_REPEAT_CNT):
         attr = getattr(test_logic, attr_name, None)
         if attr is not None:
           setattr(test_func, attr_name, attr)
@@ -987,7 +1006,7 @@ class BaseTestClass:
     """
     logging.log_path = self.log_path
     # Executes pre-setup procedures, like generating test methods.
-    if not self._setup_generated_tests():
+    if not self._pre_run():
       return self.results
     logging.info('==========> %s <==========', self.TAG)
     # Devise the actual test methods to run in the test class.

--- a/mobly/logger.py
+++ b/mobly/logger.py
@@ -168,7 +168,7 @@ def get_log_file_timestamp(delta=None):
   return _get_timestamp('%m-%d-%Y_%H-%M-%S-%f', delta)
 
 
-def _setup_test_logger(log_path, prefix=None):
+def _setup_test_logger(log_path, console_level, prefix=None):
   """Customizes the root logger for a test run.
 
   The logger object has a stream handler and a file handler. The stream
@@ -177,6 +177,9 @@ def _setup_test_logger(log_path, prefix=None):
 
   Args:
     log_path: Location of the log file.
+    console_level: Log level threshold used for log messages printed
+      to the console. Logs with a level less severe than
+      console_level will not be printed to the console.
     prefix: A prefix for each log line in terminal.
     filename: Name of the log file. The default is the time the logger
       is requested.
@@ -192,7 +195,7 @@ def _setup_test_logger(log_path, prefix=None):
   c_formatter = logging.Formatter(terminal_format, log_line_time_format)
   ch = logging.StreamHandler(sys.stdout)
   ch.setFormatter(c_formatter)
-  ch.setLevel(logging.INFO)
+  ch.setLevel(console_level)
   # Log everything to file
   f_formatter = logging.Formatter(log_line_format, log_line_time_format)
   # Write logger output to files
@@ -237,7 +240,10 @@ def create_latest_log_alias(actual_path, alias):
   utils.create_alias(actual_path, alias_path)
 
 
-def setup_test_logger(log_path, prefix=None, alias='latest'):
+def setup_test_logger(log_path,
+                      prefix=None,
+                      alias='latest',
+                      console_level=logging.INFO):
   """Customizes the root logger for a test run.
 
   In addition to configuring the Mobly logging handlers, this also sets two
@@ -256,9 +262,12 @@ def setup_test_logger(log_path, prefix=None, alias='latest'):
       will not be created, which is useful to save storage space when the
       storage system (e.g. ZIP files) does not properly support
       shortcut/symlinks.
+    console_level: optional logging level, log level threshold used for log
+      messages printed to the console. Logs with a level less severe than
+      console_level will not be printed to the console.
   """
   utils.create_dir(log_path)
-  _setup_test_logger(log_path, prefix)
+  _setup_test_logger(log_path, console_level, prefix)
   logging.debug('Test output folder: "%s"', log_path)
   if alias:
     create_latest_log_alias(log_path, alias=alias)

--- a/tests/mobly/logger_test.py
+++ b/tests/mobly/logger_test.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import tempfile
 import unittest
+import logging
 from unittest import mock
 
 from mobly import logger
@@ -56,7 +57,8 @@ class LoggerTest(unittest.TestCase):
                                                mock_create_latest_log_alias,
                                                mock__setup_test_logger):
     logger.setup_test_logger(self.log_dir)
-    mock__setup_test_logger.assert_called_once_with(self.log_dir, None)
+    mock__setup_test_logger.assert_called_once_with(self.log_dir, logging.INFO,
+                                                    None)
     mock_create_latest_log_alias.assert_called_once_with(self.log_dir,
                                                          alias='latest')
 


### PR DESCRIPTION
Users have identified more legit use cases where operations before
`setup_class` are needed. The `setup_generated_tests` stage is
essentially the stage before `setup_class`.

Hence we are renaming it more properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/844)
<!-- Reviewable:end -->
