### PR TITLE
Always create the `AndroidDevice` object specific log directory.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -491,10 +491,9 @@ class AndroidDevice:
   def __init__(self, serial=''):
     self._serial = str(serial)
     # logging.log_path only exists when this is used in an Mobly test run.
-    self._log_path_base = getattr(logging, 'log_path', '/tmp/logs')
-    self._log_path = os.path.join(self._log_path_base,
+    _log_path_base = utils.abs_path(getattr(logging, 'log_path', '/tmp/logs'))
+    self._log_path = os.path.join(_log_path_base,
                                   'AndroidDevice%s' % self._normalized_serial)
-    utils.create_dir(self._log_path)
     self._debug_tag = self._serial
     self.log = AndroidDeviceLoggerAdapter(logging.getLogger(),
                                           {'tag': self.debug_tag})
@@ -622,6 +621,8 @@ class AndroidDevice:
   def log_path(self):
     """A string that is the path for all logs collected from this device.
     """
+    if not os.path.exists(self._log_path):
+      utils.create_dir(self._log_path)
     return self._log_path
 
   @log_path.setter

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -494,6 +494,7 @@ class AndroidDevice:
     self._log_path_base = getattr(logging, 'log_path', '/tmp/logs')
     self._log_path = os.path.join(self._log_path_base,
                                   'AndroidDevice%s' % self._normalized_serial)
+    utils.create_dir(self._log_path)
     self._debug_tag = self._serial
     self.log = AndroidDeviceLoggerAdapter(logging.getLogger(),
                                           {'tag': self.debug_tag})

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -494,7 +494,6 @@ class AndroidDevice:
     _log_path_base = utils.abs_path(getattr(logging, 'log_path', '/tmp/logs'))
     self._log_path = os.path.join(_log_path_base,
                                   'AndroidDevice%s' % self._normalized_serial)
-    utils.create_dir(self._log_path)
     self._debug_tag = self._serial
     self.log = AndroidDeviceLoggerAdapter(logging.getLogger(),
                                           {'tag': self.debug_tag})

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -601,6 +601,7 @@ class AndroidDeviceTest(unittest.TestCase):
       self, sanitize_filename_mock, get_log_file_timestamp_mock, MockFastboot,
       MockAdbProxy):
     mock_serial = 1
+    sanitize_filename_mock.return_value = '1'
     ad = android_device.AndroidDevice(serial=mock_serial)
     get_log_file_timestamp_mock.return_value = '07-22-2019_17-53-34-450'
     filename = ad.generate_filename('MagicLog')
@@ -1098,8 +1099,7 @@ class AndroidDeviceTest(unittest.TestCase):
     """
     expected_e = Exception('start failed.')
     MockSnippetClient.initialize = mock.Mock(side_effect=expected_e)
-    MockSnippetClient.stop = mock.Mock(
-        side_effect=Exception('stop failed.'))
+    MockSnippetClient.stop = mock.Mock(side_effect=Exception('stop failed.'))
     ad = android_device.AndroidDevice(serial='1')
     try:
       ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME)


### PR DESCRIPTION
`AndroidDevice#log_path` is not always created, but it's accessible by user code.
This is ok most of the time because `logcat_service` is usually used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/848)
<!-- Reviewable:end -->
