### PR TITLE
Remove unused dependencies

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -33,8 +33,13 @@ import traceback
 from typing import Tuple, overload
 
 import portpicker
-# TODO(ericth): Use Literal from typing if we only run on Python 3.8 or later.
-from typing_extensions import Literal
+
+# TODO(#851): Remove this try/except statement and typing_extensions from
+# install_requires when Python 3.8 is the minimum version we support.
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 # File name length is limited to 255 chars on some OS, so we need to make sure
 # the file names we output fits within the limit.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ from setuptools.command import test
 import sys
 
 install_requires = [
-    'portpicker', 'pyserial', 'pyyaml', 'timeout_decorator', 'typing_extensions>=4.1.1'
+    'portpicker',
+    'pyyaml',
+    'typing_extensions>=4.1.1; python_version<"3.8"',
 ]
 
 if platform.system() == 'Windows':


### PR DESCRIPTION
Remove pyserial and timeout_decorator from install_requires, as they were not being imported/used. While here, mark typing_extensions as only necessary for Python versions below 3.8.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/850)
<!-- Reviewable:end -->
