### PR TITLE
Expose the method to set new log prefix in PrefixLoggerAdapter

### DIFF
--- a/mobly/logger.py
+++ b/mobly/logger.py
@@ -427,4 +427,5 @@ class PrefixLoggerAdapter(logging.LoggerAdapter):
     Args:
       prefix: The new log prefix.
     """
+    self.debug('Setting the log prefix to "%s".', prefix)
     self.extra[PrefixLoggerAdapter.EXTRA_KEY_LOG_PREFIX] = prefix

--- a/mobly/logger.py
+++ b/mobly/logger.py
@@ -412,11 +412,19 @@ class PrefixLoggerAdapter(logging.LoggerAdapter):
     """Processes the logging call to insert contextual information.
 
     Args:
-      msg: the logging message
-      kwargs: keyword arguments passed in to a logging call
+      msg: The logging message.
+      kwargs: Keyword arguments passed in to a logging call.
 
     Returns:
-      the message and kwargs modified.
+      The message and kwargs modified.
     """
     new_msg = f'{self.extra[PrefixLoggerAdapter.EXTRA_KEY_LOG_PREFIX]} {msg}'
     return (new_msg, kwargs)
+
+  def set_log_prefix(self, prefix: str) -> None:
+    """Sets the log prefix to the given string.
+
+    Args:
+      prefix: The new log prefix.
+    """
+    self.extra[PrefixLoggerAdapter.EXTRA_KEY_LOG_PREFIX] = prefix

--- a/tests/mobly/logger_test.py
+++ b/tests/mobly/logger_test.py
@@ -223,6 +223,20 @@ class LoggerTest(unittest.TestCase):
     self.assertEqual(processed_log, '[MOCK_PREFIX] mock log line')
     self.assertIs(processed_kwargs, kwargs)
 
+  def test_prefix_logger_adapter_modify_prefix(self):
+    extra = {
+        logger.PrefixLoggerAdapter.EXTRA_KEY_LOG_PREFIX: 'MOCK_PREFIX',
+    }
+    adapted_logger = logger.PrefixLoggerAdapter(mock.Mock(), extra)
+    adapted_logger.set_log_prefix('[NEW]')
+
+    kwargs = mock.Mock()
+    processed_log, processed_kwargs = adapted_logger.process('mock log line',
+                                                             kwargs=kwargs)
+
+    self.assertEqual(processed_log, '[NEW] mock log line')
+    self.assertIs(processed_kwargs, kwargs)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Why we need this? We need to modify the log prefix when changing the debug tag of device controllers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/852)
<!-- Reviewable:end -->
