### PR TITLE
Add check for Cuttlefish devices in `is_emulator`

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -863,10 +863,11 @@ class AndroidDevice:
       # as emulators in addition to other things, so only return True on
       # an exact match.
       return True
-    elif self.build_info['hardware'] in ['ranchu', 'goldfish']:
+    elif self.build_info['hardware'] in ['ranchu', 'goldfish', 'cutf_cvm']:
       # Ranchu and Goldfish are the hardware properties that the AOSP
       # emulators report, so if the device says it's an AOSP emulator, it
-      # probably is one.
+      # probably is one. Cuttlefish emulators report 'cutf_cvm` as the
+      # hardware property.
       return True
     else:
       return False


### PR DESCRIPTION
Add a check for the `cutf_cvm` hardware property in `is_emulator`, so that both regular Android emulator and Cuttlefish devices are covered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/860)
<!-- Reviewable:end -->
