### PR TITLE
Progressively increase delay between adb root retries and fix Typo

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -29,7 +29,7 @@ ADB_PORT_LOCK = threading.Lock()
 
 # Number of attempts to execute "adb root", and seconds for interval time of
 # this commands.
-ADB_ROOT_RETRY_ATTMEPTS = 3
+ADB_ROOT_RETRY_ATTEMPTS = 3
 ADB_ROOT_RETRY_ATTEMPT_INTERVAL_SEC = 10
 
 # Qualified class name of the default instrumentation test runner.
@@ -517,7 +517,8 @@ class AdbProxy:
     Raises:
       AdbError: If the command exit code is not 0.
     """
-    for attempt in range(ADB_ROOT_RETRY_ATTMEPTS):
+    retry_interval = ADB_ROOT_RETRY_ATTEMPT_INTERVAL_SEC
+    for attempt in range(ADB_ROOT_RETRY_ATTEMPTS):
       try:
         return self._exec_adb_cmd('root',
                                   args=None,
@@ -525,12 +526,13 @@ class AdbProxy:
                                   timeout=None,
                                   stderr=None)
       except AdbError as e:
-        if attempt + 1 < ADB_ROOT_RETRY_ATTMEPTS:
+        if attempt + 1 < ADB_ROOT_RETRY_ATTEMPTS:
           logging.debug('Retry the command "%s" since Error "%s" occurred.' %
                         (utils.cli_cmd_to_string(
                             e.cmd), e.stderr.decode('utf-8').strip()))
           # Buffer between "adb root" commands.
-          time.sleep(ADB_ROOT_RETRY_ATTEMPT_INTERVAL_SEC)
+          time.sleep(retry_interval)
+          retry_interval *= 2
         else:
           raise e
 

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -769,8 +769,8 @@ class AdbTest(unittest.TestCase):
                                        shell=False,
                                        timeout=None,
                                        stderr=None)
-    self.assertEqual(mock_sleep.call_count, 2)
-    mock_sleep.assert_called_with(10)
+    self.assertEqual(mock_sleep.call_count, adb.ADB_ROOT_RETRY_ATTEMPTS - 1)
+    mock_sleep.assert_has_calls([mock.call(10), mock.call(20)])
 
   def test_has_shell_command_called_correctly(self):
     with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:


### PR DESCRIPTION
Some low-end devices take more than 3 retries to reconnect after issuing an adb root command

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/867)
<!-- Reviewable:end -->
