### PR TITLE
Fix unhandling of possible recursion error on `ExceptionRecord.__deepcopy__`

### DIFF
--- a/mobly/records.py
+++ b/mobly/records.py
@@ -277,7 +277,7 @@ class ExceptionRecord:
     """
     try:
       exception = copy.deepcopy(self.exception)
-    except TypeError:
+    except (TypeError, RecursionError):
       # If the exception object cannot be copied, use the original
       # exception object.
       exception = self.exception

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -36,6 +36,19 @@ class RecordTestError(Exception):
     self._something = something
 
 
+class RecordTestRecursiveError(Exception):
+  """Error class with self recursion.
+
+  Used for ExceptionRecord tests.
+  """
+
+  def __init__(self):
+    super().__init__(self)  # create a self recursion here.
+
+  def __str__(self):
+    return 'Oh ha!'
+
+
 class RecordsTest(unittest.TestCase):
   """This test class tests the implementation of classes in mobly.records.
   """
@@ -426,6 +439,19 @@ class RecordsTest(unittest.TestCase):
     self.assertIsNot(er, new_er)
     self.assertDictEqual(er.to_dict(), new_er.to_dict())
     self.assertEqual(er.type, 'RecordTestError')
+
+  def test_recursive_exception_record_deepcopy(self):
+    """Makes sure ExceptionRecord wrapper handles deep copy properly in case of
+    recursive exception.
+    """
+    try:
+      raise RecordTestRecursiveError()
+    except RecordTestRecursiveError as e:
+      er = records.ExceptionRecord(e)
+    new_er = copy.deepcopy(er)
+    self.assertIsNot(er, new_er)
+    self.assertDictEqual(er.to_dict(), new_er.to_dict())
+    self.assertEqual(er.type, 'RecordTestRecursiveError')
 
   def test_add_controller_info_record(self):
     tr = records.TestResult()


### PR DESCRIPTION
While using mobly and aio gRPC, the following very long trace pop on gRPC aio error. Although this might not be Mobly related, since `deepcopy` can trigger a `RecursionError` I think it make sense to handle it. This change fix that.

Trace (cut for readability):
```
AioRpcError
[ExampleTest] 02-06 15:47:34.895 ERROR Exception happened when executing on_fail for test.
Traceback (most recent call last):
  File "venv/lib/python3.10/site-packages/mobly/base_test.py", line 640, in _exec_procedure_func
    func(copy.deepcopy(tr_record))
  File "/usr/lib/python3.10/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.10/copy.py", line 271, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib/python3.10/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/usr/lib/python3.10/copy.py", line 231, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib/python3.10/copy.py", line 153, in deepcopy
    y = copier(memo)
  File "venv/lib/python3.10/site-packages/mobly/records.py", line 280, in __deepcopy__
    exception = copy.deepcopy(self.exception)
  File "/usr/lib/python3.10/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.10/copy.py", line 265, in _reconstruct
    y = func(*args)
  File "/usr/lib/python3.10/copy.py", line 264, in <genexpr>
    args = (deepcopy(arg, memo) for arg in args)
  File "/usr/lib/python3.10/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.10/copy.py", line 265, in _reconstruct
    y = func(*args)
  File "/usr/lib/python3.10/copy.py", line 264, in <genexpr>
    args = (deepcopy(arg, memo) for arg in args)
  ...
RecursionError: maximum recursion depth exceeded  
 ```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/870)
<!-- Reviewable:end -->
