### PR TITLE
[WIP] Utilize tcp:0 to find available adb port instead of portpicker

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 import re
 import subprocess
 import threading
@@ -132,6 +133,12 @@ def list_occupied_adb_ports():
       continue
     used_ports.append(int(tokens[1]))
   return used_ports
+
+
+def can_adb_pick_available_port():
+  if os.path.basename(ADB) == 'adb':
+    return True
+  return False
 
 
 class AdbProxy:

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -21,6 +21,7 @@ import time
 
 from mobly import utils
 
+
 # Command to use for running ADB commands.
 ADB = 'adb'
 
@@ -136,9 +137,9 @@ def list_occupied_adb_ports():
 
 
 def can_adb_pick_available_forwarding_port():
-  """True if the ADB binary can pick available forwarding port; False otherwise.
+  """True if the ADB can pick an available forwarding port; False otherwise.
 
-  By default, the ADB binary support this feature, i.e. it supports passing 0
+  By default, the ADB binary supports this feature, i.e. it supports passing 0
   as host port when doing port forwarding.
 
   But sometimes users override the `ADB` variable to use a customized variant to

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -135,7 +135,16 @@ def list_occupied_adb_ports():
   return used_ports
 
 
-def can_adb_pick_available_port():
+def can_adb_pick_available_forwarding_port():
+  """True if the ADB binary can pick available forwarding port; False otherwise.
+
+  By default, the ADB binary support this feature, i.e. it supports passing 0
+  as host port when doing port forwarding.
+
+  But sometimes users override the `ADB` variable to use a customized variant to
+  replace the ADB binary, e.g. waterfall binary. In these scenarios, this will
+  return False.
+  """
   if os.path.basename(ADB) == 'adb':
     return True
   return False

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -342,12 +342,14 @@ class SnippetClientV2(client_base.ClientBase):
 
   def _forward_device_port(self):
     """Forwards the device port to a host port."""
-    if adb.can_adb_pick_available_port():
+    if adb.can_adb_pick_available_forwarding_port():
       host_port = self.host_port if self.host_port else 0
-      output = self._adb.forward([f'tcp:{host_port}', f'tcp:{self.device_port}'])
+      output = self._adb.forward(
+          [f'tcp:{host_port}', f'tcp:{self.device_port}']
+      )
       try:
         self.host_port = int(str(output, encoding='utf8').strip())
-      except (UnicodeError, ValueError):
+      except UnicodeError:
         self.log.error(
             'Failed to parse the output of port forwarding: "%s".', output
         )

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -343,6 +343,7 @@ class SnippetClientV2(client_base.ClientBase):
   def _forward_device_port(self):
     """Forwards the device port to a host port."""
     if adb.can_adb_pick_available_forwarding_port():
+      # If not specified, pass tcp:0 to let adb pick an available port
       host_port = self.host_port if self.host_port else 0
       output = self._adb.forward(
           [f'tcp:{host_port}', f'tcp:{self.device_port}']

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -342,15 +342,21 @@ class SnippetClientV2(client_base.ClientBase):
 
   def _forward_device_port(self):
     """Forwards the device port to a host port."""
-    host_port = self.host_port if self.host_port else 0
-    output = self._adb.forward([f'tcp:{host_port}', f'tcp:{self.device_port}'])
-    try:
-      self.host_port = int(str(output, encoding='utf8'))
-    except UnicodeError:
-      self.log.error(
-          'Failed to parse the output of port forwarding: "%s".', output
-      )
-      raise
+    if adb.can_adb_pick_available_port():
+      host_port = self.host_port if self.host_port else 0
+      output = self._adb.forward([f'tcp:{host_port}', f'tcp:{self.device_port}'])
+      try:
+        self.host_port = int(str(output, encoding='utf8').strip())
+      except (UnicodeError, ValueError):
+        self.log.error(
+            'Failed to parse the output of port forwarding: "%s".', output
+        )
+        raise
+
+    else:
+      if not self.host_port:
+        self.host_port = utils.get_available_host_port()
+      self._adb.forward([f'tcp:{self.host_port}', f'tcp:{self.device_port}'])
 
   def create_socket_connection(self):
     """Creates a socket connection to the server.

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -81,16 +81,16 @@ class AdbTest(unittest.TestCase):
     mock_run_command.return_value = (0, ''.encode('utf-8'), ''.encode('utf-8'))
     self.assertFalse(adb.is_adb_available())
 
-  def test_can_adb_pick_available_port_default(self):
-    self.assertTrue(adb.can_adb_pick_available_port())
+  def test_can_adb_pick_available_forwarding_port(self):
+    self.assertTrue(adb.can_adb_pick_available_forwarding_port())
 
   @mock.patch.object(adb, 'ADB', new='/usr/local/bin/adb')
-  def test_can_adb_pick_available_port_positive(self):
-    self.assertTrue(adb.can_adb_pick_available_port())
+  def test_can_adb_pick_available_forwarding_port_positive(self):
+    self.assertTrue(adb.can_adb_pick_available_forwarding_port())
 
   @mock.patch.object(adb, 'ADB', new='/usr/local/bin/waterfull_bin')
-  def test_can_adb_pick_available_port_negative(self):
-    self.assertFalse(adb.can_adb_pick_available_port())
+  def test_can_adb_pick_available_forwarding_port_negative(self):
+    self.assertFalse(adb.can_adb_pick_available_forwarding_port())
 
 
   @mock.patch('mobly.utils.run_command')

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 from mobly.controllers.android_device_lib import adb
 
+
 # Mock parameters for instrumentation.
 MOCK_INSTRUMENTATION_PACKAGE = 'com.my.instrumentation.tests'
 MOCK_INSTRUMENTATION_RUNNER = 'com.my.instrumentation.runner'
@@ -88,10 +89,9 @@ class AdbTest(unittest.TestCase):
   def test_can_adb_pick_available_forwarding_port_positive(self):
     self.assertTrue(adb.can_adb_pick_available_forwarding_port())
 
-  @mock.patch.object(adb, 'ADB', new='/usr/local/bin/waterfull_bin')
+  @mock.patch.object(adb, 'ADB', new='/usr/local/bin/waterfall_bin')
   def test_can_adb_pick_available_forwarding_port_negative(self):
     self.assertFalse(adb.can_adb_pick_available_forwarding_port())
-
 
   @mock.patch('mobly.utils.run_command')
   def test_exec_cmd_no_timeout_success(self, mock_run_command):

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -81,6 +81,18 @@ class AdbTest(unittest.TestCase):
     mock_run_command.return_value = (0, ''.encode('utf-8'), ''.encode('utf-8'))
     self.assertFalse(adb.is_adb_available())
 
+  def test_can_adb_pick_available_port_default(self):
+    self.assertTrue(adb.can_adb_pick_available_port())
+
+  @mock.patch.object(adb, 'ADB', new='/usr/local/bin/adb')
+  def test_can_adb_pick_available_port_positive(self):
+    self.assertTrue(adb.can_adb_pick_available_port())
+
+  @mock.patch.object(adb, 'ADB', new='/usr/local/bin/waterfull_bin')
+  def test_can_adb_pick_available_port_negative(self):
+    self.assertFalse(adb.can_adb_pick_available_port())
+
+
   @mock.patch('mobly.utils.run_command')
   def test_exec_cmd_no_timeout_success(self, mock_run_command):
     mock_run_command.return_value = (0, MOCK_DEFAULT_STDOUT.encode('utf-8'),

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -22,6 +22,7 @@ from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import errors as android_device_lib_errors
 from mobly.controllers.android_device_lib import snippet_client_v2
 from mobly.snippet import errors
+
 from tests.lib import mock_android_device
 
 
@@ -112,7 +113,8 @@ class SnippetClientV2Test(unittest.TestCase):
   def setUp(self):
     super().setUp()
     self.can_adb_pick_available_port = mock.patch.object(
-        adb, 'can_adb_pick_available_forwarding_port', return_value=True).start()
+        adb, 'can_adb_pick_available_forwarding_port', return_value=True
+    ).start()
     self.addCleanup(mock.patch.stopall)
 
   def _make_client(self, adb_proxy=None, mock_properties=None):
@@ -1076,9 +1078,9 @@ class SnippetClientV2Test(unittest.TestCase):
   @mock.patch('socket.create_connection')
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
               'utils.start_standing_subprocess')
-  def test_make_connection_uses_utils_to_find_available_port(
+  def test_make_connection_finds_an_available_port_manually(
       self, mock_start_subprocess, mock_socket_create_conn, *_):
-    """Tests that making a connection works normally."""
+    """Tests make_connection finds an available forwarding port manually."""
     self.can_adb_pick_available_port.return_value = False
     socket_resp = [b'{"status": true, "uid": 1}']
     self._make_client_and_mock_socket_conn(mock_socket_create_conn, socket_resp)
@@ -1098,9 +1100,9 @@ class SnippetClientV2Test(unittest.TestCase):
   @mock.patch('socket.create_connection')
   @mock.patch('mobly.controllers.android_device_lib.snippet_client_v2.'
               'utils.start_standing_subprocess')
-  def test_make_connection_uses_utils_to_find_available_port(
+  def test_make_connection_cannot_decode_adb_forward_output(
       self, mock_start_subprocess, mock_socket_create_conn, *_):
-    """Tests that making a connection works normally."""
+    """Tests that make_connection cannot decode adb forward output."""
     socket_resp = [b'{"status": true, "uid": 1}']
     self._make_client_and_mock_socket_conn(mock_socket_create_conn, socket_resp)
     self._mock_server_process_starting_response(mock_start_subprocess)

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -22,7 +22,6 @@ from mobly.controllers.android_device_lib import adb
 from mobly.controllers.android_device_lib import errors as android_device_lib_errors
 from mobly.controllers.android_device_lib import snippet_client_v2
 from mobly.snippet import errors
-
 from tests.lib import mock_android_device
 
 


### PR DESCRIPTION
When using adb, we can utilize tcp:0 to find available adb port instead of portpicker.

However, when using other ADB alternatives (i.e. waterfall), portpicker is still used, because waterfall forward doesn't print out which port it picked.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/871)
<!-- Reviewable:end -->
