### PR TITLE
record: emit explicit end when appending to summary 

### DIFF
--- a/mobly/records.py
+++ b/mobly/records.py
@@ -156,6 +156,7 @@ class TestSummaryWriter:
         yaml.safe_dump(new_content,
                        f,
                        explicit_start=True,
+                       explicit_end=True,
                        allow_unicode=True,
                        indent=4)
 


### PR DESCRIPTION
While trying to handle test events in real-time, by reading additions the test summary file, I encountered incomplete `yaml` data.
The following change might fix that behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/872)
<!-- Reviewable:end -->
