### PR TITLE
record: add `TestClassList` to emitted records

### DIFF
--- a/mobly/records.py
+++ b/mobly/records.py
@@ -77,6 +77,11 @@ class TestSummaryEntryType(enum.Enum):
   The idea is similar to how `TestResult.json_str` categorizes different
   sections of a `TestResult` object in the serialized format.
   """
+  # A list of all the test classes requested for a test run.
+  # This is dumped at the beginning of a summary file so we know what was
+  # requested in case the run is interrupted and the final summary is not
+  # created.
+  TEST_CLASS_LIST = 'TestClassList'
   # A list of all the tests requested for a test run.
   # This is dumped at the beginning of a summary file so we know what was
   # requested in case the test is interrupted and the final summary is not

--- a/tests/mobly/records_test.py
+++ b/tests/mobly/records_test.py
@@ -429,6 +429,21 @@ class RecordsTest(unittest.TestCase):
     self.assertEqual(contents[0]['a'], user_data1['a'])
     self.assertEqual(contents[1]['b'], user_data2['b'])
 
+  def test_summary_test_class_list(self):
+    test_classes = {'Classes': [{'Name': 'Foo', 'Tests': ['test_a', 'test_b']},
+                                {'Name': 'Bar', 'Tests': ['test_c', 'test_d']}]}
+    dump_path = os.path.join(self.tmp_path, 'ha.yaml')
+    writer = records.TestSummaryWriter(dump_path)
+    writer.dump(test_classes, records.TestSummaryEntryType.TEST_CLASS_LIST)
+    with io.open(dump_path, 'r', encoding='utf-8') as f:
+      contents = []
+      for c in yaml.safe_load_all(f):
+        contents.append(c)
+    for content in contents:
+      self.assertEqual(content['Type'],
+                       records.TestSummaryEntryType.TEST_CLASS_LIST.value)
+    self.assertEqual(contents[0]['Classes'], test_classes['Classes'])
+
   def test_exception_record_deepcopy(self):
     """Makes sure ExceptionRecord wrapper handles deep copy properly."""
     try:

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -137,15 +137,17 @@ class TestRunnerTest(unittest.TestCase):
                                 records.OUTPUT_FILE_SUMMARY)
     with io.open(summary_path, 'r', encoding='utf-8') as f:
       summary_entries = list(yaml.safe_load_all(f))
-    self.assertEqual(len(summary_entries), 4)
+    self.assertEqual(len(summary_entries), 5)
     # Verify the first entry is the list of test names.
     self.assertEqual(summary_entries[0]['Type'],
-                     records.TestSummaryEntryType.TEST_NAME_LIST.value)
+                     records.TestSummaryEntryType.TEST_CLASS_LIST.value)
     self.assertEqual(summary_entries[1]['Type'],
-                     records.TestSummaryEntryType.RECORD.value)
+                     records.TestSummaryEntryType.TEST_NAME_LIST.value)
     self.assertEqual(summary_entries[2]['Type'],
-                     records.TestSummaryEntryType.CONTROLLER_INFO.value)
+                     records.TestSummaryEntryType.RECORD.value)
     self.assertEqual(summary_entries[3]['Type'],
+                     records.TestSummaryEntryType.CONTROLLER_INFO.value)
+    self.assertEqual(summary_entries[4]['Type'],
                      records.TestSummaryEntryType.SUMMARY.value)
 
   def test_run(self):


### PR DESCRIPTION
When running multiple test classes in the test runner, it actually emit multiple `TestNameList` but one `Summary`. Which make impossible for a reader of the summary file to retrieve the complete list of tests before they had been executed.

To solve this a `TestClassList` record is now emitted before the run, which contains the full list of tests in the following format:
```yaml
Classes:
- Name: Foo
  Tests:
  - test_a
  - test_b
- Name: Bar
  Tests:
  - test_c
  - test_d
```

It was chosen to add a new record and to to not change the actual `TestNameList` record to not break the actual behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/873)
<!-- Reviewable:end -->
