### PR TITLE
Fix unused 'name' argument in AttenuatorPath constructor

### DIFF
--- a/mobly/controllers/attenuator.py
+++ b/mobly/controllers/attenuator.py
@@ -129,6 +129,7 @@ class AttenuatorPath:
     self.model = attenuation_device.model
     self.attenuation_device = attenuation_device
     self.idx = idx
+    self.name = name
     if (self.idx >= attenuation_device.path_count):
       raise IndexError("Attenuator index out of range!")
 


### PR DESCRIPTION
store the path name for future usage

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/877)
<!-- Reviewable:end -->
