### PR TITLE
Do not start logcat service when the Andriod device is in fastboot mode.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -874,6 +874,10 @@ class AndroidDevice:
     else:
       return False
 
+  @property
+  def is_fastboot(self):
+    return self.serial in list_fastboot_devices()
+
   def load_config(self, config):
     """Add attributes to the AndroidDevice object based on config.
 

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -874,10 +874,6 @@ class AndroidDevice:
     else:
       return False
 
-  @property
-  def is_fastboot(self):
-    return self.serial in list_fastboot_devices()
-
   def load_config(self, config):
     """Add attributes to the AndroidDevice object based on config.
 

--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -201,6 +201,10 @@ class Logcat(base_service.BaseService):
 
     The collection runs in a separate subprocess and saves logs in a file.
     """
+    if self._ad.is_fastboot:
+      self._ad.log.warning(
+          'Skip starting logcat because the device is in fastboot mode.')
+      return
     self._assert_not_running()
     if self._config.clear_log:
       self.clear_adb_log()

--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -201,7 +201,7 @@ class Logcat(base_service.BaseService):
 
     The collection runs in a separate subprocess and saves logs in a file.
     """
-    if self._ad.is_fastboot:
+    if self._ad.is_bootloader:
       self._ad.log.warning(
           'Skip starting logcat because the device is in fastboot mode.')
       return

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -133,6 +133,23 @@ class LogcatTest(unittest.TestCase):
               return_value=mock_android_device.MockAdbProxy('1'))
   @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
               return_value=mock_android_device.MockFastbootProxy('1'))
+  @mock.patch('mobly.utils.start_standing_subprocess')
+  @mock.patch('mobly.controllers.android_device.list_fastboot_devices',
+              return_value='1')
+  def test_start_in_fastboot_mode(self, _, start_proc_mock, FastbootProxy,
+                                  MockAdbProxy):
+    mock_serial = '1'
+    ad = android_device.AndroidDevice(serial=mock_serial)
+    logcat_service = logcat.Logcat(ad)
+    logcat_service.start()
+    # Verify start is not performed
+    self.assertFalse(logcat_service._adb_logcat_process)
+    start_proc_mock.assert_not_called()
+
+  @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
+              return_value=mock_android_device.MockAdbProxy('1'))
+  @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+              return_value=mock_android_device.MockFastbootProxy('1'))
   @mock.patch('mobly.utils.create_dir')
   @mock.patch('mobly.utils.start_standing_subprocess', return_value='process')
   @mock.patch('mobly.utils.stop_standing_subprocess')

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -581,6 +581,16 @@ class AndroidDeviceTest(unittest.TestCase):
               return_value=mock_android_device.MockAdbProxy('1'))
   @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
               return_value=mock_android_device.MockFastbootProxy('1'))
+  @mock.patch('mobly.controllers.android_device.list_fastboot_devices',
+              return_value='1')
+  def test_AndroidDevice_is_fastboot(self, _, MockFastboot, MockAdbProxy):
+    ad = android_device.AndroidDevice(serial='1')
+    self.assertTrue(ad.is_fastboot)
+
+  @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
+              return_value=mock_android_device.MockAdbProxy('1'))
+  @mock.patch('mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+              return_value=mock_android_device.MockFastbootProxy('1'))
   @mock.patch('mobly.logger.get_log_file_timestamp')
   def test_AndroidDevice_generate_filename_default(self,
                                                    get_log_file_timestamp_mock,

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -585,7 +585,7 @@ class AndroidDeviceTest(unittest.TestCase):
               return_value='1')
   def test_AndroidDevice_is_fastboot(self, _, MockFastboot, MockAdbProxy):
     ad = android_device.AndroidDevice(serial='1')
-    self.assertTrue(ad.is_fastboot)
+    self.assertTrue(ad.is_bootloader)
 
   @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
               return_value=mock_android_device.MockAdbProxy('1'))


### PR DESCRIPTION
Also adding a property in `AndroidDevice` to check if it's in fastboot mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/881)
<!-- Reviewable:end -->
