### PR TITLE
Fix a doc typo in records.py

### DIFF
--- a/mobly/records.py
+++ b/mobly/records.py
@@ -321,7 +321,7 @@ class TestResultRecord:
     termination_signal: ExceptionRecord, the main exception of the test.
     extra_errors: OrderedDict, all exceptions occurred during the entire
       test lifecycle. The order of occurrence is preserved.
-    result: TestResultEnum.TEAT_RESULT_*, PASS/FAIL/SKIP.
+    result: TestResultEnum.TEST_RESULT_*, PASS/FAIL/SKIP.
   """
 
   def __init__(self, t_name, t_class=None):


### PR DESCRIPTION
- Single letter typo in an enum.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/889)
<!-- Reviewable:end -->
