### PR TITLE
Add logcat start info into Mobly main log

### DIFF
--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -210,6 +210,7 @@ class Logcat(base_service.BaseService):
       self.clear_adb_log()
     self._start()
     self._open_logcat_file()
+    self._ad.log.info(self._generate_logcat_start_log())
 
   def _start(self):
     """The actual logic of starting logcat."""
@@ -262,3 +263,23 @@ class Logcat(base_service.BaseService):
     # Not clearing the log regardless of the config when resuming.
     # Otherwise the logs during the paused time will be lost.
     self._start()
+
+  # LINT.IfChange(logcat_starting)
+  def _generate_logcat_start_log(self):
+    """Gets the log when logcat service start.
+
+    Returns:
+      The log contains logcat starting time.
+    """
+    device_time = str(
+        self._ad.adb.shell(
+            'echo $(date +%Y-%m-%dT%T)${EPOCHREALTIME:10:4}'
+        ).replace(b'\n', b''),
+        'UTF-8',
+    )
+    return f'INFO:{self._ad.serial} Start logcat {device_time}'
+
+
+# LINT.ThenChange(
+#   //depot/google3/testing/web/fission/client/extensions/mobly/mobly_log_analyzer.ts:logcat_starting
+# )

--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -264,7 +264,6 @@ class Logcat(base_service.BaseService):
     # Otherwise the logs during the paused time will be lost.
     self._start()
 
-  # LINT.IfChange(logcat_starting)
   def _generate_logcat_start_log(self):
     """Gets the log when logcat service start.
 
@@ -278,8 +277,3 @@ class Logcat(base_service.BaseService):
         'UTF-8',
     )
     return f'INFO:{self._ad.serial} Start logcat {device_time}'
-
-
-# LINT.ThenChange(
-#   //depot/google3/testing/web/fission/client/extensions/mobly/mobly_log_analyzer.ts:logcat_starting
-# )

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -127,6 +127,8 @@ class MockAdbProxy:
           ]), 'utf-8')
     elif 'which' in params:
       return b''
+    elif params == 'echo $(date +%Y-%m-%dT%T)${EPOCHREALTIME:10:4}':
+      return b'2020-01-01T00:00:00.000'
 
   def getprop(self, params):
     if params in self.mock_properties:

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -128,6 +128,15 @@ class LogcatTest(unittest.TestCase):
     stop_proc_mock.assert_called_with('process')
     self.assertIsNone(logcat_service._adb_logcat_process)
     self.assertEqual(logcat_service.adb_logcat_file_path, expected_log_path)
+    # Expect log info when start logcat
+    ad.log = logging.Logger('test')
+    with self.assertLogs(ad.log, level='INFO') as log_output:
+      logcat_service.start()
+    self.assertIn(
+        'INFO:1 Start logcat 2020-01-01T00:00:00.000',
+        ''.join(log_output.output),
+        'Logcat starting message is absent in log info.',
+    )
 
   @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy',
               return_value=mock_android_device.MockAdbProxy('1'))


### PR DESCRIPTION
To correct logcat time offset with other logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/890)
<!-- Reviewable:end -->
