### PR TITLE
Adding ability to run adb reverse via mobly AdbProxy, fixes #900

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -459,6 +459,12 @@ class AdbProxy:
           'forward', args, shell, timeout=None, stderr=None
       )
 
+  def reverse(self, args=None, shell=False) -> bytes:
+    with ADB_PORT_LOCK:
+      return self._exec_adb_cmd(
+          'reverse', args, shell, timeout=None, stderr=None
+      )
+
   def instrument(
       self, package, options=None, runner=None, handler=None
   ) -> bytes:

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -709,6 +709,7 @@ class AdbTest(unittest.TestCase):
           timeout=None,
           stderr=None,
       )
+
   def test_reverse(self):
     with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
       adb.AdbProxy().reverse(['tcp:12345', 'tcp:98765'])

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -702,7 +702,22 @@ class AdbTest(unittest.TestCase):
 
   def test_forward(self):
     with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
-      adb.AdbProxy().forward(MOCK_SHELL_COMMAND)
+      adb.AdbProxy().forward(['tcp:12345', 'tcp:98765'])
+      mock_exec_cmd.assert_called_with(
+          ['adb', 'forward', 'tcp:12345', 'tcp:98765'],
+          shell=False,
+          timeout=None,
+          stderr=None,
+      )
+  def test_reverse(self):
+    with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:
+      adb.AdbProxy().reverse(['tcp:12345', 'tcp:98765'])
+      mock_exec_cmd.assert_called_with(
+          ['adb', 'reverse', 'tcp:12345', 'tcp:98765'],
+          shell=False,
+          timeout=None,
+          stderr=None,
+      )
 
   def test_instrument_without_parameters(self):
     """Verifies the AndroidDevice object's instrument command is correct in


### PR DESCRIPTION
- Adding ability to run AdbProxy.reverse()
  - adding tests
- fixing test for AdbProxy.forward()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/903)
<!-- Reviewable:end -->
