### PR TITLE
Bump min Python ver to 3.11.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ While developed by Googlers, Mobly is not an official Google product.
 
 ## Compatibility
 
-Mobly requires *python 3.6* or newer.
+Mobly requires *python 3.11* or newer.
 
 Mobly tests could run on the following platforms:
   - Ubuntu 14.04+
@@ -33,10 +33,8 @@ Mobly tests could run on the following platforms:
 
 ## System dependencies
   - adb (1.0.40+ recommended)
-  - python3.7+
+  - python3.11+
   - python-setuptools
-
-*To use Python3, use `pip3` and `python3` (or python3.x) accordingly.*
 
 ## Installation
 You can install the released package from pip

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -20,10 +20,10 @@ import inspect
 import io
 import logging
 import os
-import pipes
 import platform
 import random
 import re
+import shlex
 import signal
 import string
 import subprocess
@@ -664,7 +664,7 @@ def cli_cmd_to_string(args):
   if isinstance(args, str):
     # Return directly if it's already a string.
     return args
-  return ' '.join([pipes.quote(arg) for arg in args])
+  return ' '.join([shlex.quote(arg) for arg in args])
 
 
 def get_settable_properties(cls):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import sys
 install_requires = [
     'portpicker',
     'pyyaml',
-    'typing_extensions>=4.1.1; python_version<"3.8"',
+    'typing_extensions>=4.1.1; python_version>="3.11"',
 ]
 
 if platform.system() == 'Windows':

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -124,13 +124,10 @@ class MockAdbProxy:
       )
     elif 'pm list instrumentation' in params:
       return bytes(
-          '\n'.join(
-              [
-                  'instrumentation:%s/%s (target=%s)'
-                  % (package, runner, target)
-                  for package, runner, target in self.instrumented_packages
-              ]
-          ),
+          '\n'.join([
+              'instrumentation:%s/%s (target=%s)' % (package, runner, target)
+              for package, runner, target in self.instrumented_packages
+          ]),
           'utf-8',
       )
     elif 'which' in params:

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -1607,15 +1607,12 @@ class SnippetClientV2Test(unittest.TestCase):
     with self.assertRaises(UnicodeError):
       self.client.make_connection()
 
-    self.client.log.error.assert_has_calls(
-        [
-            mock.call(
-                'Failed to decode socket response bytes using encoding'
-                ' utf8: %s',
-                socket_response,
-            )
-        ]
-    )
+    self.client.log.error.assert_has_calls([
+        mock.call(
+            'Failed to decode socket response bytes using encoding utf8: %s',
+            socket_response,
+        )
+    ])
 
   def test_rpc_sending_and_receiving(self):
     """Test RPC sending and receiving.
@@ -1681,15 +1678,12 @@ class SnippetClientV2Test(unittest.TestCase):
     with self.assertRaises(UnicodeError):
       self.client.send_rpc_request(rpc_request)
 
-    self.client.log.error.assert_has_calls(
-        [
-            mock.call(
-                'Failed to decode socket response bytes using encoding'
-                ' utf8: %s',
-                socket_response,
-            )
-        ]
-    )
+    self.client.log.error.assert_has_calls([
+        mock.call(
+            'Failed to decode socket response bytes using encoding utf8: %s',
+            socket_response,
+        )
+    ])
 
   @mock.patch.object(
       snippet_client_v2.SnippetClientV2, 'send_handshake_request'


### PR DESCRIPTION
Now that Python3 releases regularly, we will start bumping Mobly's required min Python version more frequently.

Currently 3.11 is the oldest `bugfix` support level ver. So we are bumping to 3.11.

Removing `pipes` usage as it's deprecated in 3.11 and will be removed in 3.13.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/909)
<!-- Reviewable:end -->
