### PR TITLE
Cache `AndroidDevice#model` to reduce fastboot calls

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -850,7 +850,6 @@ class AndroidDevice:
   def model(self):
     """The Android code name for the device."""
     # If device is in bootloader mode, get mode name from fastboot.
-    print(self.is_bootloader)
     if self.is_bootloader:
       out = self.fastboot.getvar('product').strip()
       # 'out' is never empty because of the 'total time' message fastboot

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -14,6 +14,7 @@
 
 import contextlib
 import enum
+import functools
 import logging
 import os
 import re
@@ -845,10 +846,11 @@ class AndroidDevice:
   def is_rootable(self):
     return not self.is_bootloader and self.build_info['debuggable'] == '1'
 
-  @property
+  @functools.cached_property
   def model(self):
     """The Android code name for the device."""
     # If device is in bootloader mode, get mode name from fastboot.
+    print(self.is_bootloader)
     if self.is_bootloader:
       out = self.fastboot.getvar('product').strip()
       # 'out' is never empty because of the 'total time' message fastboot

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -495,6 +495,30 @@ class AndroidDeviceTest(unittest.TestCase):
 
   @mock.patch(
       'mobly.controllers.android_device_lib.adb.AdbProxy',
+      return_value=mock_android_device.MockAdbProxy('1'),
+  )
+  @mock.patch(
+      'mobly.controllers.android_device.list_fastboot_devices',
+      return_value=mock.MagicMock(),
+  )
+  def test_AndroidDevice_model_property_is_cached(
+      self, mock_list_fastboot_devices, _
+  ):
+    """Accessing `model` a second time shouldn't invoke all the fastboot/adb
+    calls again.
+    """
+    mock_serial = 1
+    # mock returns '2' so the device is not considered in bootloader mode.
+    mock_list_fastboot_devices.return_value = ['2']
+    ad = android_device.AndroidDevice(serial=mock_serial)
+    ad.model
+    mock_count_first = mock_list_fastboot_devices.call_count
+    ad.model  # access `model` again.
+    mock_count_second = mock_list_fastboot_devices.call_count
+    self.assertEqual(mock_count_first, mock_count_second)
+
+  @mock.patch(
+      'mobly.controllers.android_device_lib.adb.AdbProxy',
       return_value=mock_android_device.MockAdbProxy(
           '1',
           mock_properties={


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/910)
<!-- Reviewable:end -->
