### PR TITLE
Fix ps check of child pids on BSD-based MacOS. Use pgrep instead.

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -274,18 +274,33 @@ def _collect_process_tree(starting_pid):
   while stack:
     pid = stack.pop()
     try:
-      ps_results = (
-          subprocess.check_output([
-              'ps',
-              '-o',
-              'pid',
-              '--ppid',
-              str(pid),
-              '--noheaders',
-          ])
-          .decode()
-          .strip()
-      )
+      if platform.system() == 'Darwin':
+        ps_results = (
+            subprocess.check_output(
+                [
+                    'pgrep',
+                    '-P',
+                    str(pid),
+                ]
+            )
+            .decode()
+            .strip()
+        )
+      else:
+        ps_results = (
+            subprocess.check_output(
+                [
+                    'ps',
+                    '-o',
+                    'pid',
+                    '--ppid',
+                    str(pid),
+                    '--noheaders',
+                ]
+            )
+            .decode()
+            .strip()
+        )
     except subprocess.CalledProcessError:
       # Ignore if there is not child process.
       continue


### PR DESCRIPTION
Issue:

Unregistering a service results in the following error:
```
ps: illegal option -- -
usage: ps [-AaCcEefhjlMmrSTvwXx] [-O fmt | -o fmt] [-G gid[,gid...]]
          [-g grp[,grp...]] [-u [uid,uid...]]
          [-p pid[,pid...]] [-t tty[,tty...]] [-U user[,user...]]
       ps [-L]
```

Call-stack:

_collect_process_tree (lib/python3.12/site-packages/mobly/utils.py:271) _kill_process_tree (lib/python3.12/site-packages/mobly/utils.py:316) stop_standing_subprocess (lib/python3.12/site-packages/mobly/utils.py:555) _stop_server (lib/python3.12/site-packages/mobly/controllers/android_device_lib/snippet_client_v2.py:699) stop (python3.12/site-packages/mobly/controllers/android_device_lib/snippet_client_v2.py:660) remove_snippet_client (lib/python3.12/site-packages/mobly/controllers/android_device_lib/services/snippet_management_service.py:110) unload_snippet (lib/python3.12/site-packages/mobly/controllers/android_device.py:963) stop (lib/python3.12/site-packages/snippet_uiautomator/uiautomator.py:227) unregister (lib/python3.12/site-packages/mobly/controllers/android_device_lib/service_manager.py:109)

Sample code:

```
from mobly.controllers import android_device
from snippet_uiautomator import uiautomator

ad = android_device.AndroidDevice(sn)
ui = uiautomator.UiAutomatorService
ad.services.register(uiautomator.ANDROID_SERVICE_NAME, ui)
...    
ad.services.unregister(uiautomator.ANDROID_SERVICE_NAME)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/916)
<!-- Reviewable:end -->

Co-authored-by: stuartmiles@google.com