### PR TITLE
Log the command execution result in utils.run_command

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -198,13 +198,6 @@ class AdbProxy:
 
     if stderr:
       stderr.write(err)
-    logging.debug(
-        'cmd: %s, stdout: %s, stderr: %s, ret: %s',
-        utils.cli_cmd_to_string(args),
-        out,
-        err,
-        ret,
-    )
     if ret == 0:
       return out
     else:

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -499,6 +499,13 @@ def run_command(
     raise subprocess.TimeoutExpired(
         cmd=cmd, timeout=timeout, output=out, stderr=err
     )
+  logging.debug(
+      'cmd: %s, stdout: %s, stderr: %s, ret: %s',
+      cli_cmd_to_string(cmd),
+      out,
+      err,
+      process.returncode,
+  )
   return process.returncode, out, err
 
 


### PR DESCRIPTION
We can log the command execution result in each call of utils.run_command.

With this, we no longer need to print them in adb module.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/917)
<!-- Reviewable:end -->
