### PR TITLE
Set pyink to a fixed version and fix format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,6 @@ jobs:
 
     - name: Check formatting
       run: |
-        python -m pip install pyink==23.10.0
+        python -m pip install pyink==24.3.0
         pyink --check .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,6 @@ jobs:
 
     - name: Check formatting
       run: |
-        python -m pip install pyink
+        python -m pip install pyink==24.3.0
         pyink --check .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,6 @@ jobs:
 
     - name: Check formatting
       run: |
-        python -m pip install pyink==24.3.0
+        python -m pip install pyink==23.10.0
         pyink --check .
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Before pushing your changes, you need to lint the code style via `pyink`
 To install `pyink`:
 
 ```sh
-$ pip3 install pyink
+$ pip3 install pyink==24.3.0
 ```
 
 To lint the code:

--- a/mobly/controllers/android_device_lib/jsonrpc_shell_base.py
+++ b/mobly/controllers/android_device_lib/jsonrpc_shell_base.py
@@ -61,8 +61,7 @@ class JsonRpcShellBase:
       else:
         raise Error(
             'Expected one phone, but %d found. Use the -s flag or '
-            'specify ANDROID_SERIAL.'
-            % len(serials)
+            'specify ANDROID_SERIAL.' % len(serials)
         )
     if serial not in serials:
       raise Error('Device "%s" is not found by adb.' % serial)

--- a/mobly/controllers/sniffer_lib/local/local_base.py
+++ b/mobly/controllers/sniffer_lib/local/local_base.py
@@ -81,12 +81,14 @@ class SnifferLocalBase(sniffer.Sniffer):
 
     if sniffer.Sniffer.CONFIG_KEY_CHANNEL in final_configs:
       try:
-        subprocess.check_call([
-            "iwconfig",
-            self._interface,
-            "channel",
-            str(final_configs[sniffer.Sniffer.CONFIG_KEY_CHANNEL]),
-        ])
+        subprocess.check_call(
+            [
+                "iwconfig",
+                self._interface,
+                "channel",
+                str(final_configs[sniffer.Sniffer.CONFIG_KEY_CHANNEL]),
+            ]
+        )
       except Exception as err:
         raise sniffer.ExecutionError(err)
 

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -275,14 +275,16 @@ def _collect_process_tree(starting_pid):
     pid = stack.pop()
     try:
       ps_results = (
-          subprocess.check_output([
-              'ps',
-              '-o',
-              'pid',
-              '--ppid',
-              str(pid),
-              '--noheaders',
-          ])
+          subprocess.check_output(
+              [
+                  'ps',
+                  '-o',
+                  'pid',
+                  '--ppid',
+                  str(pid),
+                  '--noheaders',
+              ]
+          )
           .decode()
           .strip()
       )
@@ -303,13 +305,15 @@ def _kill_process_tree(proc):
     # The taskkill command with "/T" option ends the specified process and any
     # child processes started by it:
     # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/taskkill
-    subprocess.check_output([
-        'taskkill',
-        '/F',
-        '/T',
-        '/PID',
-        str(proc.pid),
-    ])
+    subprocess.check_output(
+        [
+            'taskkill',
+            '/F',
+            '/T',
+            '/PID',
+            str(proc.pid),
+        ]
+    )
     return
 
   failed = []

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -124,10 +124,13 @@ class MockAdbProxy:
       )
     elif 'pm list instrumentation' in params:
       return bytes(
-          '\n'.join([
-              'instrumentation:%s/%s (target=%s)' % (package, runner, target)
-              for package, runner, target in self.instrumented_packages
-          ]),
+          '\n'.join(
+              [
+                  'instrumentation:%s/%s (target=%s)'
+                  % (package, runner, target)
+                  for package, runner, target in self.instrumented_packages
+              ]
+          ),
           'utf-8',
       )
     elif 'which' in params:

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -23,10 +23,12 @@ from mobly.controllers.android_device_lib import adb
 # Mock parameters for instrumentation.
 MOCK_INSTRUMENTATION_PACKAGE = 'com.my.instrumentation.tests'
 MOCK_INSTRUMENTATION_RUNNER = 'com.my.instrumentation.runner'
-MOCK_INSTRUMENTATION_OPTIONS = collections.OrderedDict([
-    ('option1', 'value1'),
-    ('option2', 'value2'),
-])
+MOCK_INSTRUMENTATION_OPTIONS = collections.OrderedDict(
+    [
+        ('option1', 'value1'),
+        ('option2', 'value2'),
+    ]
+)
 # Mock android instrumentation commands.
 MOCK_BASIC_INSTRUMENTATION_COMMAND = (
     'am instrument -r -w  com.my'
@@ -638,12 +640,14 @@ class AdbTest(unittest.TestCase):
           b'[sys.wifitracing.started]: [1]\n'
           b'[telephony.lteOnCdmaDevice]: [1]\n\n'
       )
-      actual_output = adb.AdbProxy().getprops([
-          'sys.wifitracing.started',  # "numeric" value
-          'sys.uidcpupower',  # empty value
-          'sendbug.preferred.domain',  # string value
-          'nonExistentProp',
-      ])
+      actual_output = adb.AdbProxy().getprops(
+          [
+              'sys.wifitracing.started',  # "numeric" value
+              'sys.uidcpupower',  # empty value
+              'sendbug.preferred.domain',  # string value
+              'nonExistentProp',
+          ]
+      )
       self.assertEqual(
           actual_output,
           {

--- a/tests/mobly/controllers/android_device_lib/callback_handler_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/callback_handler_v2_test.py
@@ -108,10 +108,12 @@ class CallbackHandlerV2Test(unittest.TestCase):
 
     event = handler.waitForEvent('AsyncTaskResult', some_condition, 0.01)
     self.assert_event_correct(event, MOCK_RAW_EVENT)
-    mock_event_client.eventWaitAndGet.assert_has_calls([
-        mock.call(MOCK_CALLBACK_ID, 'AsyncTaskResult', mock.ANY),
-        mock.call(MOCK_CALLBACK_ID, 'AsyncTaskResult', mock.ANY),
-    ])
+    mock_event_client.eventWaitAndGet.assert_has_calls(
+        [
+            mock.call(MOCK_CALLBACK_ID, 'AsyncTaskResult', mock.ANY),
+            mock.call(MOCK_CALLBACK_ID, 'AsyncTaskResult', mock.ANY),
+        ]
+    )
 
   def test_get_all(self):
     mock_event_client = mock.Mock()

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -335,8 +335,7 @@ class LogcatTest(unittest.TestCase):
           '{test_name}-{test_begin_time}'.format(
               test_name=test_name, test_begin_time=test_begin_time
           ),
-          'logcat,{mock_serial},fakemodel,{test_name}-{test_begin_time}.txt'
-          .format(
+          'logcat,{mock_serial},fakemodel,{test_name}-{test_begin_time}.txt'.format(
               mock_serial=mock_serial,
               test_name=test_name,
               test_begin_time=test_begin_time,
@@ -470,10 +469,12 @@ class LogcatTest(unittest.TestCase):
     ad = android_device.AndroidDevice(serial=mock_serial)
     logcat_service = logcat.Logcat(ad)
     logcat_service._enable_logpersist()
-    mock_adb_proxy.shell.assert_has_calls([
-        mock.call('logpersist.stop --clear'),
-        mock.call('logpersist.start'),
-    ])
+    mock_adb_proxy.shell.assert_has_calls(
+        [
+            mock.call('logpersist.stop --clear'),
+            mock.call('logpersist.start'),
+        ]
+    )
 
   @mock.patch(
       'mobly.controllers.android_device_lib.adb.AdbProxy',
@@ -570,9 +571,11 @@ class LogcatTest(unittest.TestCase):
     ad = android_device.AndroidDevice(serial=mock_serial)
     logcat_service = logcat.Logcat(ad)
     logcat_service._enable_logpersist()
-    mock_adb_proxy.shell.assert_has_calls([
-        mock.call('logpersist.stop --clear'),
-    ])
+    mock_adb_proxy.shell.assert_has_calls(
+        [
+            mock.call('logpersist.stop --clear'),
+        ]
+    )
 
   @mock.patch(
       'mobly.controllers.android_device_lib.adb.AdbProxy',

--- a/tests/mobly/controllers/android_device_lib/snippet_client_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_test.py
@@ -59,11 +59,13 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
   def test_check_app_installed_fail_target_not_installed(self):
     sc = self._make_client(
         mock_android_device.MockAdbProxy(
-            instrumented_packages=[(
-                MOCK_PACKAGE_NAME,
-                snippet_client._INSTRUMENTATION_RUNNER_PACKAGE,
-                MOCK_MISSING_PACKAGE_NAME,
-            )]
+            instrumented_packages=[
+                (
+                    MOCK_PACKAGE_NAME,
+                    snippet_client._INSTRUMENTATION_RUNNER_PACKAGE,
+                    MOCK_MISSING_PACKAGE_NAME,
+                )
+            ]
         )
     )
     expected_msg = (
@@ -545,11 +547,13 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
         MOCK_PACKAGE_NAME,
         snippet_client._INSTRUMENTATION_RUNNER_PACKAGE,
     )
-    mock_do_start_app.assert_has_calls([
-        mock.call(cmd_setsid),
-        mock.call(cmd_nohup),
-        mock.call(cmd_not_persist),
-    ])
+    mock_do_start_app.assert_has_calls(
+        [
+            mock.call(cmd_setsid),
+            mock.call(cmd_nohup),
+            mock.call(cmd_not_persist),
+        ]
+    )
 
   @mock.patch('socket.create_connection')
   @mock.patch(
@@ -687,11 +691,13 @@ class SnippetClientTest(jsonrpc_client_test_base.JsonRpcClientTestBase):
 
   def _make_client(self, adb_proxy=None):
     adb_proxy = adb_proxy or mock_android_device.MockAdbProxy(
-        instrumented_packages=[(
-            MOCK_PACKAGE_NAME,
-            snippet_client._INSTRUMENTATION_RUNNER_PACKAGE,
-            MOCK_PACKAGE_NAME,
-        )]
+        instrumented_packages=[
+            (
+                MOCK_PACKAGE_NAME,
+                snippet_client._INSTRUMENTATION_RUNNER_PACKAGE,
+                MOCK_PACKAGE_NAME,
+            )
+        ]
     )
     ad = mock.Mock()
     ad.adb = adb_proxy

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -112,11 +112,13 @@ class SnippetClientV2Test(unittest.TestCase):
 
   def _make_client(self, adb_proxy=None, mock_properties=None, config=None):
     adb_proxy = adb_proxy or _MockAdbProxy(
-        instrumented_packages=[(
-            MOCK_PACKAGE_NAME,
-            snippet_client_v2._INSTRUMENTATION_RUNNER_PACKAGE,
-            MOCK_PACKAGE_NAME,
-        )],
+        instrumented_packages=[
+            (
+                MOCK_PACKAGE_NAME,
+                snippet_client_v2._INSTRUMENTATION_RUNNER_PACKAGE,
+                MOCK_PACKAGE_NAME,
+            )
+        ],
         mock_properties=mock_properties,
     )
     self.adb = adb_proxy
@@ -424,11 +426,13 @@ class SnippetClientV2Test(unittest.TestCase):
     """Tests that app checker fails without installing instrumentation."""
     self._make_client(
         _MockAdbProxy(
-            instrumented_packages=[(
-                MOCK_PACKAGE_NAME,
-                snippet_client_v2._INSTRUMENTATION_RUNNER_PACKAGE,
-                'not.installed',
-            )]
+            instrumented_packages=[
+                (
+                    MOCK_PACKAGE_NAME,
+                    snippet_client_v2._INSTRUMENTATION_RUNNER_PACKAGE,
+                    'not.installed',
+                )
+            ]
         )
     )
     expected_msg = '.* Instrumentation target not.installed is not installed.'
@@ -437,10 +441,12 @@ class SnippetClientV2Test(unittest.TestCase):
 
   def test_disable_hidden_api_normally(self):
     """Tests the disabling hidden api process works normally."""
-    self._make_client_with_extra_adb_properties({
-        'ro.build.version.codename': 'S',
-        'ro.build.version.sdk': '31',
-    })
+    self._make_client_with_extra_adb_properties(
+        {
+            'ro.build.version.codename': 'S',
+            'ro.build.version.sdk': '31',
+        }
+    )
     self.device.is_rootable = True
     self.client._disable_hidden_api_blocklist()
     self.adb.mock_shell_func.assert_called_with(
@@ -449,20 +455,24 @@ class SnippetClientV2Test(unittest.TestCase):
 
   def test_disable_hidden_api_low_sdk(self):
     """Tests it doesn't disable hidden api with low SDK."""
-    self._make_client_with_extra_adb_properties({
-        'ro.build.version.codename': 'O',
-        'ro.build.version.sdk': '26',
-    })
+    self._make_client_with_extra_adb_properties(
+        {
+            'ro.build.version.codename': 'O',
+            'ro.build.version.sdk': '26',
+        }
+    )
     self.device.is_rootable = True
     self.client._disable_hidden_api_blocklist()
     self.adb.mock_shell_func.assert_not_called()
 
   def test_disable_hidden_api_non_rootable(self):
     """Tests it doesn't disable hidden api with non-rootable device."""
-    self._make_client_with_extra_adb_properties({
-        'ro.build.version.codename': 'S',
-        'ro.build.version.sdk': '31',
-    })
+    self._make_client_with_extra_adb_properties(
+        {
+            'ro.build.version.codename': 'S',
+            'ro.build.version.sdk': '31',
+        }
+    )
     self.device.is_rootable = False
     self.client._disable_hidden_api_blocklist()
     self.adb.mock_shell_func.assert_not_called()
@@ -1607,12 +1617,15 @@ class SnippetClientV2Test(unittest.TestCase):
     with self.assertRaises(UnicodeError):
       self.client.make_connection()
 
-    self.client.log.error.assert_has_calls([
-        mock.call(
-            'Failed to decode socket response bytes using encoding utf8: %s',
-            socket_response,
-        )
-    ])
+    self.client.log.error.assert_has_calls(
+        [
+            mock.call(
+                'Failed to decode socket response bytes using encoding'
+                ' utf8: %s',
+                socket_response,
+            )
+        ]
+    )
 
   def test_rpc_sending_and_receiving(self):
     """Test RPC sending and receiving.
@@ -1678,12 +1691,15 @@ class SnippetClientV2Test(unittest.TestCase):
     with self.assertRaises(UnicodeError):
       self.client.send_rpc_request(rpc_request)
 
-    self.client.log.error.assert_has_calls([
-        mock.call(
-            'Failed to decode socket response bytes using encoding utf8: %s',
-            socket_response,
-        )
-    ])
+    self.client.log.error.assert_has_calls(
+        [
+            mock.call(
+                'Failed to decode socket response bytes using encoding'
+                ' utf8: %s',
+                socket_response,
+            )
+        ]
+    )
 
   @mock.patch.object(
       snippet_client_v2.SnippetClientV2, 'send_handshake_request'

--- a/tests/mobly/suite_runner_test.py
+++ b/tests/mobly/suite_runner_test.py
@@ -100,7 +100,8 @@ class SuiteRunnerTest(unittest.TestCase):
   def test_run_suite(self, mock_exit):
     tmp_file_path = os.path.join(self.tmp_dir, 'config.yml')
     with io.open(tmp_file_path, 'w', encoding='utf-8') as f:
-      f.write("""
+      f.write(
+          """
         TestBeds:
           # A test bed where adb will find Android devices.
           - Name: SampleTestBed
@@ -109,7 +110,8 @@ class SuiteRunnerTest(unittest.TestCase):
             TestParams:
               icecream: 42
               extra_param: 'haha'
-      """)
+      """
+      )
     suite_runner.run_suite(
         [integration_test.IntegrationTest], argv=['-c', tmp_file_path]
     )
@@ -119,13 +121,15 @@ class SuiteRunnerTest(unittest.TestCase):
   def test_run_suite_with_failures(self, mock_exit):
     tmp_file_path = os.path.join(self.tmp_dir, 'config.yml')
     with io.open(tmp_file_path, 'w', encoding='utf-8') as f:
-      f.write("""
+      f.write(
+          """
         TestBeds:
           # A test bed where adb will find Android devices.
           - Name: SampleTestBed
             Controllers:
               MagicDevice: '*'
-      """)
+      """
+      )
     suite_runner.run_suite(
         [integration_test.IntegrationTest], argv=['-c', tmp_file_path]
     )
@@ -151,13 +155,15 @@ class SuiteRunnerTest(unittest.TestCase):
 
     tmp_file_path = os.path.join(self.tmp_dir, 'config.yml')
     with io.open(tmp_file_path, 'w', encoding='utf-8') as f:
-      f.write("""
+      f.write(
+          """
         TestBeds:
           # A test bed where adb will find Android devices.
           - Name: SampleTestBed
             Controllers:
               MagicDevice: '*'
-      """)
+      """
+      )
 
     mock_cli_args = ['test_binary', f'--config={tmp_file_path}']
 

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -343,7 +343,8 @@ class TestRunnerTest(unittest.TestCase):
   def test_main(self, mock_exit, mock_find_test):
     tmp_file_path = os.path.join(self.tmp_dir, 'config.yml')
     with io.open(tmp_file_path, 'w', encoding='utf-8') as f:
-      f.write("""
+      f.write(
+          """
         TestBeds:
           # A test bed where adb will find Android devices.
           - Name: SampleTestBed
@@ -352,7 +353,8 @@ class TestRunnerTest(unittest.TestCase):
             TestParams:
               icecream: 42
               extra_param: 'haha'
-      """)
+      """
+      )
     test_runner.main(['-c', tmp_file_path])
     mock_exit.assert_not_called()
 
@@ -364,13 +366,15 @@ class TestRunnerTest(unittest.TestCase):
   def test_main_with_failures(self, mock_exit, mock_find_test):
     tmp_file_path = os.path.join(self.tmp_dir, 'config.yml')
     with io.open(tmp_file_path, 'w', encoding='utf-8') as f:
-      f.write("""
+      f.write(
+          """
         TestBeds:
           # A test bed where adb will find Android devices.
           - Name: SampleTestBed
             Controllers:
               MagicDevice: '*'
-      """)
+      """
+      )
     test_runner.main(['-c', tmp_file_path])
     mock_exit.assert_called_once_with(1)
 

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -47,11 +47,13 @@ def _is_process_running(pid):
   if os.name == 'nt':
     return (
         str(pid)
-        in subprocess.check_output([
-            'tasklist',
-            '/fi',
-            f'PID eq {pid}',
-        ]).decode()
+        in subprocess.check_output(
+            [
+                'tasklist',
+                '/fi',
+                f'PID eq {pid}',
+            ]
+        ).decode()
     )
 
   try:
@@ -169,11 +171,13 @@ class UtilsTest(unittest.TestCase):
     with mock.patch.object(os, 'name', new='posix'):
       utils._kill_process_tree(mock_proc)
 
-    mock_os_kill.assert_has_calls([
-        mock.call(799, signal.SIGTERM),
-        mock.call(888, signal.SIGTERM),
-        mock.call(890, signal.SIGTERM),
-    ])
+    mock_os_kill.assert_has_calls(
+        [
+            mock.call(799, signal.SIGTERM),
+            mock.call(888, signal.SIGTERM),
+            mock.call(890, signal.SIGTERM),
+        ]
+    )
     mock_proc.kill.assert_called_once()
 
   @mock.patch.object(os, 'kill')
@@ -215,13 +219,15 @@ class UtilsTest(unittest.TestCase):
     with mock.patch.object(os, 'name', new='nt'):
       utils._kill_process_tree(mock_proc)
 
-    mock_check_output.assert_called_once_with([
-        'taskkill',
-        '/F',
-        '/T',
-        '/PID',
-        '123',
-    ])
+    mock_check_output.assert_called_once_with(
+        [
+            'taskkill',
+            '/F',
+            '/T',
+            '/PID',
+            '123',
+        ]
+    )
 
   def test_run_command(self):
     ret, _, _ = utils.run_command(self.sleep_cmd(0.01))


### PR DESCRIPTION
Currently it's using the latest version of pyink so each time we create a PR it may has format problem.

This PR sets it to the currently latest version 24.3.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/918)
<!-- Reviewable:end -->
