### PR TITLE
Fix utils.stop_standing_subprocess error on Mac OS

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -274,20 +274,33 @@ def _collect_process_tree(starting_pid):
   while stack:
     pid = stack.pop()
     try:
-      ps_results = (
-          subprocess.check_output(
-              [
-                  'ps',
-                  '-o',
-                  'pid',
-                  '--ppid',
-                  str(pid),
-                  '--noheaders',
-              ]
-          )
-          .decode()
-          .strip()
-      )
+      if platform.system() == 'Darwin':
+        ps_results = (
+            subprocess.check_output(
+                [
+                    'pgrep',
+                    '-P',
+                    str(pid),
+                ]
+            )
+            .decode()
+            .strip()
+        )
+      else:
+        ps_results = (
+            subprocess.check_output(
+                [
+                    'ps',
+                    '-o',
+                    'pid',
+                    '--ppid',
+                    str(pid),
+                    '--noheaders',
+                ]
+            )
+            .decode()
+            .strip()
+        )
     except subprocess.CalledProcessError:
       # Ignore if there is not child process.
       continue

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -332,6 +332,7 @@ def _kill_process_tree(proc):
   failed = []
   for child_pid in _collect_process_tree(proc.pid):
     try:
+      print('killing pid', child_pid)
       os.kill(child_pid, signal.SIGTERM)
     except Exception:  # pylint: disable=broad-except
       failed.append(child_pid)

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -274,33 +274,17 @@ def _collect_process_tree(starting_pid):
   while stack:
     pid = stack.pop()
     try:
-      if platform.system() == 'Darwin':
-        ps_results = (
-            subprocess.check_output(
-                [
-                    'pgrep',
-                    '-P',
-                    str(pid),
-                ]
-            )
-            .decode()
-            .strip()
-        )
-      else:
-        ps_results = (
-            subprocess.check_output(
-                [
-                    'ps',
-                    '-o',
-                    'pid',
-                    '--ppid',
-                    str(pid),
-                    '--noheaders',
-                ]
-            )
-            .decode()
-            .strip()
-        )
+      ps_results = (
+          subprocess.check_output(
+              [
+                  'pgrep',
+                  '-P',
+                  str(pid),
+              ]
+          )
+          .decode()
+          .strip()
+      )
     except subprocess.CalledProcessError:
       # Ignore if there is not child process.
       continue
@@ -332,7 +316,6 @@ def _kill_process_tree(proc):
   failed = []
   for child_pid in _collect_process_tree(proc.pid):
     try:
-      print('killing pid', child_pid)
       os.kill(child_pid, signal.SIGTERM)
     except Exception:  # pylint: disable=broad-except
       failed.append(child_pid)

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -404,13 +404,19 @@ class UtilsTest(unittest.TestCase):
     output = utils.run_command(['pgrep', '-P', str(subprocess_a.pid)])
     self.assertEqual(output[0], 0, msg='Process a should be running.')
     if output[0] == 0:
-      subprocess_ids = [subprocess_a.pid] + list(map(int, output[1].decode('utf-8').strip().split('\n')))
+      subprocess_ids = [subprocess_a.pid] + list(
+          map(int, output[1].decode('utf-8').strip().split('\n'))
+      )
 
     utils.stop_standing_subprocess(mock_subprocess_a_popen)
 
     for pid in subprocess_ids:
       output = utils.run_command(['pgrep', '-P', str(pid)])
-      self.assertEqual(output[0], 1, msg=f'Process pid={pid} is still alive after util.stop_standing_subprocess.')
+      self.assertEqual(
+          output[0],
+          1,
+          msg=f'Process pid={pid} is still alive after util.stop_standing_subprocess.',
+      )
 
     subprocess_a.join(timeout=1)
 

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -74,15 +74,19 @@ def _fork_children_processes(name, successors):
     successors: The args for the descendant processes.
   """
   logging.info('Process "%s" started, PID: %d!', name, os.getpid())
+  print('Process "%s" starting, PID: %d!', name, os.getpid())
   children_process = [
       multiprocessing.Process(target=_fork_children_processes, args=args)
       for args in successors
   ]
+  print('Process "%s" starting - 2, PID: %d!', name, os.getpid())
   for child_process in children_process:
     child_process.start()
+  print('Process "%s" sleeping, PID: %d!', name, os.getpid())
 
   if 'child' in name:
     time.sleep(10)
+  print('Process "%s" sleepped, PID: %d!', name, os.getpid())
 
   for child_process in children_process:
     child_process.join()

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,5 @@ deps =
     pytest
     pytz
 commands =
-    pytest --capture=tee-sys -k test_stop_standing_subproc_and_descendants
+    pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,5 @@ deps =
     pytest
     pytz
 commands =
-    pytest
+    pytest --capture=tee-sys -k test_stop_standing_subproc_and_descendants
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,5 @@ deps =
     pytest
     pytz
 commands =
-    pytest
+    pytest --capture=tee-sys
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,5 @@ deps =
     pytest
     pytz
 commands =
-    pytest --capture=tee-sys
+    pytest
 


### PR DESCRIPTION
Forked from #916 and improved it.

Now `utils.stop_standing_subprocess` uses some arguments of `ps` which is only supported on Linux, but not on Mac OS. Use `pgrep` instead bc it works for both Linux and Mac OS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/920)
<!-- Reviewable:end -->
