### PR TITLE
Fix the error that not all Linux hosts has pgrep installed

### DIFF
--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -273,18 +273,19 @@ def _collect_process_tree(starting_pid):
 
   while stack:
     pid = stack.pop()
+    if platform.system() == 'Darwin':
+      command = ['pgrep', '-P', str(pid)]
+    else:
+      command = [
+          'ps',
+          '-o',
+          'pid',
+          '--ppid',
+          str(pid),
+          '--noheaders',
+      ]
     try:
-      ps_results = (
-          subprocess.check_output(
-              [
-                  'pgrep',
-                  '-P',
-                  str(pid),
-              ]
-          )
-          .decode()
-          .strip()
-      )
+      ps_results = subprocess.check_output(command).decode().strip()
     except subprocess.CalledProcessError:
       # Ignore if there is not child process.
       continue


### PR DESCRIPTION
In #920, we modified `utils.stop_standing_subprocess` to use `pgrep` to collect subprocess tree. While it turned out that not all Linux hosts has `pgrep` installed.

Thus, this PR changes to use `pgrep` for Mac OS while `ps` for Linux. I verified that most Mac OS hosts have `pgrep` installed, otherwise we can let users install it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/921)
<!-- Reviewable:end -->
