### PR TITLE
Add snippet client stop timeout

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -45,6 +45,9 @@ _STOP_CMD = (
     f'{_INSTRUMENTATION_RUNNER_PACKAGE}'
 )
 
+# The default timeout for running `_STOP_CMD`.
+_STOP_CMD_TIMEOUT_SEC = 30
+
 # Major version of the launch and communication protocol being used by this
 # client.
 # Incrementing this means that compatibility with clients using the older
@@ -703,7 +706,8 @@ class SnippetClientV2(client_base.ClientBase):
     out = self._adb.shell(
         _STOP_CMD.format(
             snippet_package=self.package, user=self._get_user_command_string()
-        )
+        ),
+        timeout=_STOP_CMD_TIMEOUT_SEC,
     ).decode('utf-8')
 
     if 'OK (0 tests)' not in out:

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -182,7 +182,8 @@ class SnippetClientV2Test(unittest.TestCase):
     self.assertIs(self.client._proc, None)
     self.adb.mock_shell_func.assert_any_call(
         f'am instrument --user {MOCK_USER_ID} -w -e action stop '
-        f'{MOCK_SERVER_PATH}'
+        f'{MOCK_SERVER_PATH}',
+        timeout=mock.ANY,
     )
     mock_stop_standing_subprocess.assert_called_once_with(
         mock_start_subprocess.return_value
@@ -789,7 +790,8 @@ class SnippetClientV2Test(unittest.TestCase):
     self.assertIs(self.client._proc, None)
     self.adb.mock_shell_func.assert_called_once_with(
         f'am instrument --user {MOCK_USER_ID} -w -e action stop '
-        f'{MOCK_SERVER_PATH}'
+        f'{MOCK_SERVER_PATH}',
+        timeout=mock.ANY,
     )
     mock_stop_standing_subprocess.assert_called_once_with(mock_proc)
     self.assertFalse(self.client.is_alive)
@@ -875,7 +877,8 @@ class SnippetClientV2Test(unittest.TestCase):
     mock_stop_standing_subprocess.assert_called_once_with(mock_proc)
     mock_adb_shell.assert_called_once_with(
         f'am instrument --user {MOCK_USER_ID} -w -e action stop '
-        f'{MOCK_SERVER_PATH}'
+        f'{MOCK_SERVER_PATH}',
+        timeout=mock.ANY,
     )
     self.assertFalse(self.client.is_alive)
     self.assertIs(self.client._conn, None)


### PR DESCRIPTION
Add a timeout arg to avoid test stucks when there's something wrong happened in the adb stop command execution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/922)
<!-- Reviewable:end -->
