### PR TITLE
Use self.is_adb_detectable() to prevent build_info from None

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -844,7 +844,7 @@ class AndroidDevice:
 
   @property
   def is_rootable(self):
-    return not self.is_bootloader and self.build_info['debuggable'] == '1'
+    return self.is_adb_detectable() and self.build_info['debuggable'] == '1'
 
   @functools.cached_property
   def model(self):

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -87,6 +87,7 @@ class MockAdbProxy:
       mock_properties=None,
       installed_packages=None,
       instrumented_packages=None,
+      adb_detectable=True,
   ):
     self.serial = serial
     self.fail_br = fail_br
@@ -101,6 +102,7 @@ class MockAdbProxy:
     self.installed_packages = installed_packages
     if instrumented_packages is None:
       instrumented_packages = []
+    self.adb_detectable = adb_detectable
     self.installed_packages = installed_packages
     self.instrumented_packages = instrumented_packages
 
@@ -153,6 +155,12 @@ class MockAdbProxy:
     )
     if expected not in args:
       raise Error('"Expected "%s", got "%s"' % (expected, args))
+
+  def devices(self):
+    out = b'xxxx\tdevice\nyyyy\tdevice'
+    if self.adb_detectable:
+      out += f'\n{self.serial}\tdevice'.encode()
+    return out
 
   def __getattr__(self, name):
     """All calls to the none-existent functions in adb proxy would

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -149,7 +149,7 @@ class LogcatTest(unittest.TestCase):
 
   @mock.patch(
       'mobly.controllers.android_device_lib.adb.AdbProxy',
-      return_value=mock_android_device.MockAdbProxy('1'),
+      return_value=mock_android_device.MockAdbProxy('1', adb_detectable=False),
   )
   @mock.patch(
       'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
@@ -457,6 +457,7 @@ class LogcatTest(unittest.TestCase):
   def test__enable_logpersist_with_logpersist(self, MockFastboot, MockAdbProxy):
     mock_serial = '1'
     mock_adb_proxy = MockAdbProxy.return_value
+    mock_adb_proxy.devices.return_value = f'{mock_serial}\tdevice'.encode()
     mock_adb_proxy.getprops.return_value = {
         'ro.build.id': 'AB42',
         'ro.build.type': 'userdebug',
@@ -489,6 +490,7 @@ class LogcatTest(unittest.TestCase):
   ):
     mock_serial = '1'
     mock_adb_proxy = MockAdbProxy.return_value
+    mock_adb_proxy.devices.return_value = f'{mock_serial}\tdevice'.encode()
     mock_adb_proxy.getprops.return_value = {
         'ro.build.id': 'AB42',
         'ro.build.type': 'user',
@@ -524,6 +526,7 @@ class LogcatTest(unittest.TestCase):
 
     mock_serial = '1'
     mock_adb_proxy = MockAdbProxy.return_value
+    mock_adb_proxy.devices.return_value = f'{mock_serial}\tdevice'.encode()
     mock_adb_proxy.getprops.return_value = {
         'ro.build.id': 'AB42',
         'ro.build.type': 'userdebug',
@@ -558,6 +561,7 @@ class LogcatTest(unittest.TestCase):
 
     mock_serial = '1'
     mock_adb_proxy = MockAdbProxy.return_value
+    mock_adb_proxy.devices.return_value = f'{mock_serial}\tdevice'.encode()
     mock_adb_proxy.getprops.return_value = {
         'ro.build.id': 'AB42',
         'ro.build.type': 'userdebug',
@@ -596,6 +600,7 @@ class LogcatTest(unittest.TestCase):
 
     mock_serial = '1'
     mock_adb_proxy = MockAdbProxy.return_value
+    mock_adb_proxy.devices.return_value = f'{mock_serial}\tdevice'.encode()
     mock_adb_proxy.getprops.return_value = {
         'ro.build.id': 'AB42',
         'ro.build.type': 'userdebug',
@@ -611,7 +616,10 @@ class LogcatTest(unittest.TestCase):
     logcat_service._enable_logpersist()
     mock_adb_proxy.shell.assert_not_called()
 
-  @mock.patch('mobly.controllers.android_device_lib.adb.AdbProxy')
+  @mock.patch(
+      'mobly.controllers.android_device_lib.adb.AdbProxy',
+      return_value=mock_android_device.MockAdbProxy('1'),
+  )
   @mock.patch(
       'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
       return_value=mock_android_device.MockFastbootProxy('1'),

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -717,7 +717,7 @@ class AndroidDeviceTest(unittest.TestCase):
 
   @mock.patch(
       'mobly.controllers.android_device_lib.adb.AdbProxy',
-      return_value=mock_android_device.MockAdbProxy('1'),
+      return_value=mock_android_device.MockAdbProxy('1', adb_detectable=False),
   )
   @mock.patch(
       'mobly.controllers.android_device_lib.fastboot.FastbootProxy',


### PR DESCRIPTION
The logic now is trying to use build_info when it is not in bootloader, but if the device isn't detectable in neither adb nor fastboot, the exception occurs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/923)
<!-- Reviewable:end -->
