### PR TITLE
[WIP] Make AndroidDevice#build_info strictly returns a dict

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -815,7 +815,7 @@ class AndroidDevice:
     """
     if self.is_bootloader:
       self.log.error('Device is in fastboot mode, could not get build info.')
-      return
+      return dict()
     if self._build_info is None or self._is_rebooting:
       info = {}
       build_info = self.adb.getprops(CACHED_SYSTEM_PROPS)


### PR DESCRIPTION
Now AndroidDevice#build_info returns a None when in fastboot and a dict otherwise.

I'm not quite sure if we were intentionally returning a None when the device is in fastboot. But I think making it strictly return a dict looks more reliable. So users won't get errors like 

"TypeError: 'NoneType' object is not subscriptable"

WDYT @xpconanfan ?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/924)
<!-- Reviewable:end -->
