### PR TITLE
Include k-v pairs from device config as `user_added_info` by default.

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -139,8 +139,19 @@ def get_info(ads):
 
   Returns:
     A list of dict, each representing info for an AndroidDevice objects.
+    Everything in this dict should be yaml serializable.
   """
-  return [ad.device_info for ad in ads]
+  infos = []
+  # The values of user_added_info can be arbitrary types, so we shall sanitize
+  # them here to ensure they are yaml serializable.
+  for ad in ads:
+    device_info = ad.device_info
+    user_added_info = {
+        k: str(v) for (k, v) in device_info['user_added_info'].items()
+    }
+    device_info['user_added_info'] = user_added_info
+    infos.append(device_info)
+  return infos
 
 
 def _validate_device_existence(serials):

--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -908,6 +908,7 @@ class AndroidDevice:
             % (k, getattr(self, k)),
         )
       setattr(self, k, v)
+      self.add_device_info(k, v)
 
   def root_adb(self):
     """Change adb to root mode for this device if allowed.

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -507,7 +507,13 @@ def run_command(
   return process.returncode, out, err
 
 
-def start_standing_subprocess(cmd, shell=False, env=None):
+def start_standing_subprocess(
+    cmd,
+    shell=False,
+    env=None,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+):
   """Starts a long-running subprocess.
 
   This is not a blocking call and the subprocess started by it should be
@@ -519,10 +525,14 @@ def start_standing_subprocess(cmd, shell=False, env=None):
   Args:
     cmd: string, the command to start the subprocess with.
     shell: bool, True to run this command through the system shell,
-      False to invoke it directly. See subprocess.Proc() docs.
+      False to invoke it directly. See subprocess.Popen() docs.
     env: dict, a custom environment to run the standing subprocess. If not
       specified, inherits the current environment. See subprocess.Popen()
       docs.
+    stdout: None, subprocess.PIPE, subprocess.DEVNULL, an existing file
+      descriptor, or an existing file object. See subprocess.Popen() docs.
+    stderr: None, subprocess.PIPE, subprocess.DEVNULL, an existing file
+      descriptor, or an existing file object. See subprocess.Popen() docs.
 
   Returns:
     The subprocess that was started.
@@ -531,8 +541,8 @@ def start_standing_subprocess(cmd, shell=False, env=None):
   proc = subprocess.Popen(
       cmd,
       stdin=subprocess.PIPE,
-      stdout=subprocess.PIPE,
-      stderr=subprocess.PIPE,
+      stdout=stdout,
+      stderr=stderr,
       shell=shell,
       env=env,
   )

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -393,6 +393,7 @@ class AndroidDeviceTest(unittest.TestCase):
     self.assertEqual(ad.space, 'the final frontier')
     self.assertEqual(ad.number, 1)
     self.assertEqual(ad.debug_tag, 'my_tag')
+    self.assertEqual(ad.device_info['user_added_info']['debug_tag'], 'my_tag')
 
   @mock.patch(
       'mobly.controllers.android_device_lib.adb.AdbProxy',

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -153,6 +153,29 @@ class AndroidDeviceTest(unittest.TestCase):
     with self.assertRaisesRegex(android_device.Error, expected_msg):
       android_device.create([1])
 
+  @mock.patch(
+      'mobly.controllers.android_device_lib.adb.AdbProxy',
+      return_value=mock_android_device.MockAdbProxy(1),
+  )
+  @mock.patch(
+      'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+      return_value=mock_android_device.MockFastbootProxy(1),
+  )
+  @mock.patch('mobly.utils.create_dir')
+  def test_get_info(self, create_dir_mock, FastbootProxy, MockAdbProxy):
+    mock_serial = '1'
+    ad = android_device.AndroidDevice(serial=mock_serial)
+    example_user_object = mock_android_device.MockAdbProxy('magic')
+    # Add an arbitrary object as a device info
+    ad.add_device_info('user_stuff', example_user_object)
+    info = android_device.get_info([ad])[0]
+    self.assertEqual(info['serial'], mock_serial)
+    self.assertTrue(info['build_info'])
+    # User added values should be normalized to strings.
+    self.assertEqual(
+        info['user_added_info']['user_stuff'], str(example_user_object)
+    )
+
   @mock.patch('mobly.controllers.android_device.list_fastboot_devices')
   @mock.patch('mobly.controllers.android_device.list_adb_devices')
   @mock.patch('mobly.controllers.android_device.list_adb_devices_by_usb_id')

--- a/tests/mobly/utils_test.py
+++ b/tests/mobly/utils_test.py
@@ -406,6 +406,36 @@ class UtilsTest(unittest.TestCase):
         env=mock_env,
     )
 
+  @mock.patch('subprocess.Popen')
+  def test_start_standing_subproc_with_custom_stdout(self, mock_popen):
+    mock_stdout = mock.MagicMock(spec=io.TextIOWrapper)
+
+    utils.start_standing_subprocess(self.sleep_cmd(0.01), stdout=mock_stdout)
+
+    mock_popen.assert_called_with(
+        self.sleep_cmd(0.01),
+        stdin=subprocess.PIPE,
+        stdout=mock_stdout,
+        stderr=subprocess.PIPE,
+        shell=False,
+        env=None,
+    )
+
+  @mock.patch('subprocess.Popen')
+  def test_start_standing_subproc_with_custom_stderr(self, mock_popen):
+    mock_stderr = mock.MagicMock(spec=io.TextIOWrapper)
+
+    utils.start_standing_subprocess(self.sleep_cmd(0.01), stderr=mock_stderr)
+
+    mock_popen.assert_called_with(
+        self.sleep_cmd(0.01),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=mock_stderr,
+        shell=False,
+        env=None,
+    )
+
   def test_stop_standing_subproc(self):
     p = utils.start_standing_subprocess(self.sleep_cmd(4))
     utils.stop_standing_subprocess(p)


### PR DESCRIPTION
Since these k-v pairs are added by users through the device config, by definition these are `user_added_info`. So they should be part of the `user_added_info` field of `device_info`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/935)
<!-- Reviewable:end -->
