### PR TITLE
Support selecting test cases in a class with regex

### DIFF
--- a/mobly/base_suite.py
+++ b/mobly/base_suite.py
@@ -47,8 +47,10 @@ class BaseSuite(abc.ABC):
       config: config_parser.TestRunConfig, the config to run the class with. If
         not specified, the default config passed from google3 infra is used.
       tests: list of strings, names of the tests to run in this test class, in
-        the execution order. If not specified, all tests in the class are
-        executed.
+        the execution order. Or a string with prefix `re:` for full regex match
+        of test cases; all matched test cases will be executed; an error is
+        raised if no match is found.
+        If not specified, all tests in the class are executed.
       name_suffix: string, suffix to append to the class name for reporting.
         This is used for differentiating the same class executed with different
         parameters in a suite.

--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -1044,10 +1044,10 @@ class BaseTestClass:
   ):
     matching_name_tuples = []
     for name in current_valid_names:
-      if re.match(test_name_regex, name):
+      if re.fullmatch(test_name_regex, name):
         matching_name_tuples.append((name, getattr(self, name)))
     for name in self._generated_test_table.keys():
-      if re.match(test_name_regex, name):
+      if re.fullmatch(test_name_regex, name):
         self._assert_valid_test_name(name)
         matching_name_tuples.append((name, self._generated_test_table[name]))
     if not matching_name_tuples:

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -126,8 +126,12 @@ def parse_mobly_cli_args(argv):
       '--test_case',
       nargs='+',
       type=str,
-      metavar='[test_a test_b...]',
-      help='A list of tests in the test class to execute.',
+      metavar='[test_a test_b re:test_(c|d)...]',
+      help=(
+          'A list of tests in the test class to execute. Each value can be a '
+          'test name string or a `re:` prefixed string for full regex match of'
+          ' test names.'
+      ),
   )
   parser.add_argument(
       '-tb',

--- a/tests/mobly/base_test_test.py
+++ b/tests/mobly/base_test_test.py
@@ -208,6 +208,15 @@ class BaseTestTest(unittest.TestCase):
         super().__init__(controllers)
         self.tests = ('test_never',)
 
+      def test_foo(self):
+        pass
+
+      def test_a(self):
+        pass
+
+      def test_b(self):
+        pass
+
       def test_something_1(self):
         pass
 
@@ -218,15 +227,18 @@ class BaseTestTest(unittest.TestCase):
         pass
 
       def test_never(self):
-        # This should not execute it's not selected by cmd line input.
+        # This should not execute since it's not selected by cmd line input.
         never_call()
 
     bt_cls = MockBaseTest(self.mock_test_cls_configs)
-    bt_cls.run(test_names=['re:test_something*'])
-    self.assertEqual(len(bt_cls.results.passed), 3)
+    bt_cls.run(test_names=['re:test_something_.*', 'test_foo', 're:test_(a|b)'])
+    self.assertEqual(len(bt_cls.results.passed), 6)
     self.assertEqual(bt_cls.results.passed[0].test_name, 'test_something_1')
     self.assertEqual(bt_cls.results.passed[1].test_name, 'test_something_2')
     self.assertEqual(bt_cls.results.passed[2].test_name, 'test_something_3')
+    self.assertEqual(bt_cls.results.passed[3].test_name, 'test_foo')
+    self.assertEqual(bt_cls.results.passed[4].test_name, 'test_a')
+    self.assertEqual(bt_cls.results.passed[5].test_name, 'test_b')
 
   def test_cli_test_selection_with_regex_fail_by_convention(self):
     class MockBaseTest(base_test.BaseTestClass):


### PR DESCRIPTION
Now users can enter regex strings with prefix `re:` in the `test_cases` field to select with regex. Only full matches apply.

Fixes #887

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/938)
<!-- Reviewable:end -->
