### PR TITLE
Add `get_service_alias_by_class` in Android service manager.

### DIFF
--- a/mobly/controllers/android_device_lib/service_manager.py
+++ b/mobly/controllers/android_device_lib/service_manager.py
@@ -122,6 +122,24 @@ class ServiceManager:
       ):
         func(self._service_objects[alias])
 
+  def get_service_alias_by_class(self, service_class):
+    """Gets the aslias name of a registered service.
+
+    Note the same class can be registered multiple times with different alias
+    names. So this returnes a list.
+
+    Args:
+      service_class: class, the class of a service type.
+
+    Returns:
+      list of strings, the aliases the service is registered with.
+    """
+    aliases = []
+    for alias, service_object in self._service_objects.items():
+      if isinstance(service_object, service_class):
+        aliases.append(alias)
+    return aliases
+
   def list_live_services(self):
     """Lists the aliases of all the services that are alive.
 

--- a/mobly/controllers/android_device_lib/service_manager.py
+++ b/mobly/controllers/android_device_lib/service_manager.py
@@ -125,8 +125,9 @@ class ServiceManager:
   def get_service_alias_by_class(self, service_class):
     """Gets the aslias name of a registered service.
 
-    Note the same class can be registered multiple times with different alias
-    names. So this returnes a list.
+    The same service class can be registered multiple times with different
+    aliases. When not well managed, duplication and race conditions can arise.
+    One can use this API to de-duplicate as needed.
 
     Args:
       service_class: class, the class of a service type.

--- a/tests/mobly/controllers/android_device_lib/service_manager_test.py
+++ b/tests/mobly/controllers/android_device_lib/service_manager_test.py
@@ -469,6 +469,14 @@ class ServiceManagerTest(unittest.TestCase):
     with self.assertRaisesRegex(service_manager.Error, msg):
       manager.resume_services(['mock_service'])
 
+  def test_get_alias_by_class(self):
+    manager = service_manager.ServiceManager(mock.MagicMock())
+    manager.register('mock_service1', MockService, start_service=False)
+    manager.register('mock_service2', MockService, start_service=False)
+    manager.start_services(['mock_service2'])
+    aliases = manager.get_service_alias_by_class(MockService)
+    self.assertEqual(aliases, ['mock_service1', 'mock_service2'])
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This is useful for looking up how many instances of a service has been registered, and find out their aliases.

Util functions may depend on services like `uiautomator`. Users tend to follow the anti-pattern of attempting to register the service again under the name the util expects. This causes duplication. This API can be used to clean things up.

This is derived from the discussion in #919

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/942)
<!-- Reviewable:end -->
