### PR TITLE
Force serialization of added device info values from config

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -897,7 +897,7 @@ class AndroidDevice:
             % (k, getattr(self, k)),
         )
       setattr(self, k, v)
-      self.add_device_info(k, v)
+      self.add_device_info(k, str(v)) # Ensure that v is serializable
 
   def root_adb(self):
     """Change adb to root mode for this device if allowed.

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -410,13 +410,16 @@ class AndroidDeviceTest(unittest.TestCase):
       self, create_dir_mock, FastbootProxy, MockAdbProxy
   ):
     mock_serial = '1'
-    config = {'space': 'the final frontier', 'number': 1, 'debug_tag': 'my_tag'}
+    config = {'space': 'the final frontier', 'number': 1, 'debug_tag': 'my_tag', "force_serialize": (1, (2, 3))}
     ad = android_device.AndroidDevice(serial=mock_serial)
     ad.load_config(config)
     self.assertEqual(ad.space, 'the final frontier')
-    self.assertEqual(ad.number, 1)
+    self.assertEqual(ad.number, '1')
     self.assertEqual(ad.debug_tag, 'my_tag')
     self.assertEqual(ad.device_info['user_added_info']['debug_tag'], 'my_tag')
+    self.assertEqual(
+        ad.device_info['user_added_info']['debug_tag'], '(1, (2, 3))'
+    )
 
   @mock.patch(
       'mobly.controllers.android_device_lib.adb.AdbProxy',


### PR DESCRIPTION
Now device info captured from loaded config will forced to be serialized, by explicitly convering them to a string

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/943)
<!-- Reviewable:end -->
