### PR TITLE
Force serialization of device info values from configuration

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -897,7 +897,7 @@ class AndroidDevice:
             % (k, getattr(self, k)),
         )
       setattr(self, k, v)
-      self.add_device_info(k, v)
+      self.add_device_info(k, str(v)) # Force v to be serializable
 
   def root_adb(self):
     """Change adb to root mode for this device if allowed.

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -410,13 +410,20 @@ class AndroidDeviceTest(unittest.TestCase):
       self, create_dir_mock, FastbootProxy, MockAdbProxy
   ):
     mock_serial = '1'
-    config = {'space': 'the final frontier', 'number': 1, 'debug_tag': 'my_tag'}
+    config = {
+        'space': 'the final frontier',
+        'number': 1,
+        'debug_tag': 'my_tag',
+        'force_serialize': (1, (1, 2))}
     ad = android_device.AndroidDevice(serial=mock_serial)
     ad.load_config(config)
     self.assertEqual(ad.space, 'the final frontier')
     self.assertEqual(ad.number, 1)
     self.assertEqual(ad.debug_tag, 'my_tag')
     self.assertEqual(ad.device_info['user_added_info']['debug_tag'], 'my_tag')
+    self.assertEqual(
+        ad.device_info['user_added_info']['force_serialize'], '(1, (1, 2))'
+    )
 
   @mock.patch(
       'mobly.controllers.android_device_lib.adb.AdbProxy',


### PR DESCRIPTION
Force device info from config to be serializiable by explicitly converting to a string before passing. This will ensure that the value meets the requirements of `add_device_info`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/944)
<!-- Reviewable:end -->
