### PR TITLE
Use updated serial when running fastboot command

### DIFF
--- a/mobly/controllers/android_device_lib/fastboot.py
+++ b/mobly/controllers/android_device_lib/fastboot.py
@@ -60,16 +60,17 @@ class FastbootProxy:
 
   def __init__(self, serial=''):
     self.serial = serial
-    if serial:
-      self.fastboot_str = 'fastboot -s {}'.format(serial)
-    else:
-      self.fastboot_str = 'fastboot'
+
+  def fastboot_str(self):
+    if self.serial:
+      return 'fastboot -s {}'.format(self.serial)
+    return 'fastboot'
 
   def _exec_fastboot_cmd(self, name, arg_str):
-    return exe_cmd(' '.join((self.fastboot_str, name, arg_str)))
+    return exe_cmd(' '.join((self.fastboot_str(), name, arg_str)))
 
   def args(self, *args):
-    return exe_cmd(' '.join((self.fastboot_str,) + args))
+    return exe_cmd(' '.join((self.fastboot_str(),) + args))
 
   def __getattr__(self, name):
     def fastboot_call(*args):

--- a/tests/mobly/controllers/android_device_lib/fastboot_test.py
+++ b/tests/mobly/controllers/android_device_lib/fastboot_test.py
@@ -44,9 +44,7 @@ class FastbootTest(unittest.TestCase):
     )
 
   @mock.patch('mobly.controllers.android_device_lib.fastboot.Popen')
-  def test_fastboot_without_serial(
-      self, mock_popen
-  ):
+  def test_fastboot_without_serial(self, mock_popen):
     expected_stdout = 'stdout'
     expected_stderr = b'stderr'
     mock_popen.return_value.communicate = mock.Mock(
@@ -56,12 +54,15 @@ class FastbootTest(unittest.TestCase):
 
     fastboot.FastbootProxy().fake_command('extra', 'flags')
 
-    mock_popen.assert_called_with("fastboot fake-command extra flags", stdout=mock.ANY, stderr=mock.ANY, shell=True)
+    mock_popen.assert_called_with(
+        'fastboot fake-command extra flags',
+        stdout=mock.ANY,
+        stderr=mock.ANY,
+        shell=True,
+    )
 
   @mock.patch('mobly.controllers.android_device_lib.fastboot.Popen')
-  def test_fastboot_with_serial(
-      self, mock_popen
-  ):
+  def test_fastboot_with_serial(self, mock_popen):
     expected_stdout = 'stdout'
     expected_stderr = b'stderr'
     mock_popen.return_value.communicate = mock.Mock(
@@ -71,12 +72,15 @@ class FastbootTest(unittest.TestCase):
 
     fastboot.FastbootProxy('ABC').fake_command('extra', 'flags')
 
-    mock_popen.assert_called_with("fastboot -s ABC fake-command extra flags", stdout=mock.ANY, stderr=mock.ANY, shell=True)
+    mock_popen.assert_called_with(
+        'fastboot -s ABC fake-command extra flags',
+        stdout=mock.ANY,
+        stderr=mock.ANY,
+        shell=True,
+    )
 
   @mock.patch('mobly.controllers.android_device_lib.fastboot.Popen')
-  def test_fastboot_update_serial(
-      self, mock_popen
-  ):
+  def test_fastboot_update_serial(self, mock_popen):
     expected_stdout = 'stdout'
     expected_stderr = b'stderr'
     mock_popen.return_value.communicate = mock.Mock(
@@ -89,7 +93,13 @@ class FastbootTest(unittest.TestCase):
     fut.serial = 'XYZ'
     fut.fake_command('extra', 'flags')
 
-    mock_popen.assert_called_with("fastboot -s XYZ fake-command extra flags", stdout=mock.ANY, stderr=mock.ANY, shell=True)
+    mock_popen.assert_called_with(
+        'fastboot -s XYZ fake-command extra flags',
+        stdout=mock.ANY,
+        stderr=mock.ANY,
+        shell=True,
+    )
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/mobly/controllers/android_device_lib/fastboot_test.py
+++ b/tests/mobly/controllers/android_device_lib/fastboot_test.py
@@ -84,11 +84,11 @@ class FastbootTest(unittest.TestCase):
     )
     mock_popen.return_value.returncode = 123
 
-    fut = fastboot.FastbootProxy('ABC') 
+    fut = fastboot.FastbootProxy('ABC')
     fut.fake_command('extra', 'flags')
     fut.serial = 'XYZ'
     fut.fake_command('extra', 'flags')
-    
+
     mock_popen.assert_called_with("fastboot -s XYZ fake-command extra flags", stdout=mock.ANY, stderr=mock.ANY, shell=True)
 
 if __name__ == '__main__':

--- a/tests/mobly/controllers/android_device_lib/fastboot_test.py
+++ b/tests/mobly/controllers/android_device_lib/fastboot_test.py
@@ -43,6 +43,53 @@ class FastbootTest(unittest.TestCase):
         123,
     )
 
+  @mock.patch('mobly.controllers.android_device_lib.fastboot.Popen')
+  def test_fastboot_without_serial(
+      self, mock_popen
+  ):
+    expected_stdout = 'stdout'
+    expected_stderr = b'stderr'
+    mock_popen.return_value.communicate = mock.Mock(
+        return_value=(expected_stdout, expected_stderr)
+    )
+    mock_popen.return_value.returncode = 123
+
+    fastboot.FastbootProxy().fake_command('extra', 'flags')
+
+    mock_popen.assert_called_with("fastboot fake-command extra flags", stdout=mock.ANY, stderr=mock.ANY, shell=True)
+
+  @mock.patch('mobly.controllers.android_device_lib.fastboot.Popen')
+  def test_fastboot_with_serial(
+      self, mock_popen
+  ):
+    expected_stdout = 'stdout'
+    expected_stderr = b'stderr'
+    mock_popen.return_value.communicate = mock.Mock(
+        return_value=(expected_stdout, expected_stderr)
+    )
+    mock_popen.return_value.returncode = 123
+
+    fastboot.FastbootProxy('ABC').fake_command('extra', 'flags')
+
+    mock_popen.assert_called_with("fastboot -s ABC fake-command extra flags", stdout=mock.ANY, stderr=mock.ANY, shell=True)
+
+  @mock.patch('mobly.controllers.android_device_lib.fastboot.Popen')
+  def test_fastboot_update_serial(
+      self, mock_popen
+  ):
+    expected_stdout = 'stdout'
+    expected_stderr = b'stderr'
+    mock_popen.return_value.communicate = mock.Mock(
+        return_value=(expected_stdout, expected_stderr)
+    )
+    mock_popen.return_value.returncode = 123
+
+    fut = fastboot.FastbootProxy('ABC') 
+    fut.fake_command('extra', 'flags')
+    fut.serial = 'XYZ'
+    fut.fake_command('extra', 'flags')
+    
+    mock_popen.assert_called_with("fastboot -s XYZ fake-command extra flags", stdout=mock.ANY, stderr=mock.ANY, shell=True)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Make fastboot use the updated serial from [AndroidDevice.update_serial](https://github.com/google/mobly/blob/de93e1e9cb5766d95fa85a9870f16f01c4c38d20/mobly/controllers/android_device.py#L665) .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/945)
<!-- Reviewable:end -->
