### PR TITLE
Support finding suite class that is not defined in the main module.

### DIFF
--- a/mobly/suite_runner.py
+++ b/mobly/suite_runner.py
@@ -183,7 +183,7 @@ def _find_suite_class():
     if len(stacks) < 2:
       logging.debug(
           f'Failed to get the caller stack of run_suite_class. Got stacks: %s',
-          stacks
+          stacks,
       )
     else:
       run_suite_class_caller_frame_info = inspect.stack()[2]

--- a/mobly/suite_runner.py
+++ b/mobly/suite_runner.py
@@ -137,21 +137,63 @@ def _parse_cli_args(argv):
   return parser.parse_known_args(argv)[0]
 
 
+def _find_suite_classes_in_module(module):
+  """Finds all test suite classes in the given module.
+
+  Walk through module members and find all classes that is a subclass of
+  BaseSuite.
+
+  Args:
+    module: types.ModuleType, the module object to find test suite classes.
+
+  Returns:
+    A list of test suite classes.
+  """
+  test_suites = []
+  for _, module_member in module.__dict__.items():
+    if inspect.isclass(module_member):
+      if issubclass(module_member, base_suite.BaseSuite):
+        test_suites.append(module_member)
+  return test_suites
+
+
 def _find_suite_class():
-  """Finds the test suite class in the current module.
+  """Finds the test suite class.
+
+  First search for test suite classes in the __main__ module. If no test suite
+  class is found, search in the module that is calling
+  `suite_runner.run_suite_class`.
 
   Walk through module members and find the subclass of BaseSuite. Only
-  one subclass is allowed in a module.
+  one subclass is allowed.
 
   Returns:
       The test suite class in the test module.
   """
-  test_suites = []
-  main_module_members = sys.modules['__main__']
-  for _, module_member in main_module_members.__dict__.items():
-    if inspect.isclass(module_member):
-      if issubclass(module_member, base_suite.BaseSuite):
-        test_suites.append(module_member)
+  # Try to find test suites in __main__ module first.
+  test_suites = _find_suite_classes_in_module(sys.modules['__main__'])
+
+  # Try to find test suites in the module of the caller of `run_suite_class`.
+  if len(test_suites) == 0:
+    logging.debug(
+        'No suite class found in the __main__ module, trying to find it in the '
+        'module of the caller of suite_runner.run_suite_class method.'
+    )
+    stacks = inspect.stack()
+    if len(stacks) < 2:
+      logging.debug(
+          f'Failed to get the caller stack of run_suite_class. Got stacks: %s',
+          stacks
+      )
+    else:
+      run_suite_class_caller_frame_info = inspect.stack()[2]
+      caller_frame = run_suite_class_caller_frame_info.frame
+      module = inspect.getmodule(caller_frame)
+      if module is None:
+        logging.debug('Failed to find module for frame %s', caller_frame)
+      else:
+        test_suites = _find_suite_classes_in_module(module)
+
   if len(test_suites) != 1:
     logging.error(
         'Expected 1 test class per file, found %s.',

--- a/tests/lib/integration_test_suite.py
+++ b/tests/lib/integration_test_suite.py
@@ -1,0 +1,31 @@
+# Copyright 2024 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mobly import base_suite
+from mobly import suite_runner
+from tests.lib import integration_test
+
+
+class IntegrationTestSuite(base_suite.BaseSuite):
+
+  def setup_suite(self, config):
+    self.add_test_class(integration_test.IntegrationTest)
+
+
+def main():
+  suite_runner.run_suite_class()
+
+if __name__ == "__main__":
+  main()
+

--- a/tests/lib/integration_test_suite.py
+++ b/tests/lib/integration_test_suite.py
@@ -26,6 +26,6 @@ class IntegrationTestSuite(base_suite.BaseSuite):
 def main():
   suite_runner.run_suite_class()
 
+
 if __name__ == "__main__":
   main()
-

--- a/tests/mobly/suite_runner_test.py
+++ b/tests/mobly/suite_runner_test.py
@@ -168,12 +168,11 @@ class SuiteRunnerTest(unittest.TestCase):
 
   @mock.patch('sys.exit')
   @mock.patch.object(test_runner, 'TestRunner')
-  @mock.patch.object(integration_test_suite.IntegrationTestSuite, 'setup_suite', autospec=True)
+  @mock.patch.object(
+      integration_test_suite.IntegrationTestSuite, 'setup_suite', autospec=True
+  )
   def test_run_suite_class_finds_suite_class_when_not_in_main_module(
-      self,
-      mock_setup_suite,
-      mock_test_runner_class,
-      mock_exit
+      self, mock_setup_suite, mock_test_runner_class, mock_exit
   ):
     mock_test_runner = mock_test_runner_class.return_value
     mock_test_runner.results.is_all_pass = True


### PR DESCRIPTION
**Background**: Current implementation only searches for the test suite class in the `__main__` module. But projects like BeToCQ are running in a different approach, which causes that test suite class is not in the `__main__` module.

**Change**: When suite class is not found in the main module, search for it in the module of the caller of `suite_runner.run_suite_class`.