### PR TITLE
Support using the customized fastboot binary

### DIFF
--- a/mobly/controllers/android_device_lib/fastboot.py
+++ b/mobly/controllers/android_device_lib/fastboot.py
@@ -17,6 +17,9 @@ from subprocess import Popen, PIPE
 
 from mobly import utils
 
+# Command to use for running fastboot commands.
+FASTBOOT = 'fastboot'
+
 
 def exe_cmd(*cmds):
   """Executes commands in a new shell. Directing stderr to PIPE.
@@ -63,8 +66,8 @@ class FastbootProxy:
 
   def fastboot_str(self):
     if self.serial:
-      return 'fastboot -s {}'.format(self.serial)
-    return 'fastboot'
+      return '{} -s {}'.format(FASTBOOT, self.serial)
+    return FASTBOOT
 
   def _exec_fastboot_cmd(self, name, arg_str):
     return exe_cmd(' '.join((self.fastboot_str(), name, arg_str)))

--- a/tests/mobly/controllers/android_device_lib/fastboot_test.py
+++ b/tests/mobly/controllers/android_device_lib/fastboot_test.py
@@ -21,6 +21,9 @@ from mobly.controllers.android_device_lib import fastboot
 class FastbootTest(unittest.TestCase):
   """Unit tests for mobly.controllers.android_device_lib.adb."""
 
+  def setUp(self):
+    fastboot.FASTBOOT = 'fastboot'
+
   @mock.patch('mobly.controllers.android_device_lib.fastboot.Popen')
   @mock.patch('logging.debug')
   def test_fastboot_commands_and_results_are_logged_to_debug_log(
@@ -95,6 +98,25 @@ class FastbootTest(unittest.TestCase):
 
     mock_popen.assert_called_with(
         'fastboot -s XYZ fake-command extra flags',
+        stdout=mock.ANY,
+        stderr=mock.ANY,
+        shell=True,
+    )
+
+  @mock.patch('mobly.controllers.android_device_lib.fastboot.Popen')
+  def test_fastboot_use_customized_fastboot(self, mock_popen):
+    expected_stdout = 'stdout'
+    expected_stderr = b'stderr'
+    mock_popen.return_value.communicate = mock.Mock(
+        return_value=(expected_stdout, expected_stderr)
+    )
+    mock_popen.return_value.returncode = 123
+    fastboot.FASTBOOT = 'my_fastboot'
+
+    fastboot.FastbootProxy('ABC').fake_command('extra', 'flags')
+
+    mock_popen.assert_called_with(
+        'my_fastboot -s ABC fake-command extra flags',
         stdout=mock.ANY,
         stderr=mock.ANY,
         shell=True,


### PR DESCRIPTION
This CL aims to allow users to use their customized fastboot binary, like ADB.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/954)
<!-- Reviewable:end -->
