### PR TITLE
Check whether adb forwarding takes effect when hit socket connection failure

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -457,10 +457,16 @@ class SnippetClientV2(client_base.ClientBase):
         if not stdout:
           raise errors.Error(
               self._device,
-              'The Adb forward command execution does not take effect. Please'
-              ' check if there are other processes occupying adb forward on the'
+              'The Adb forward command execution did not take effect. Please'
+              ' check if there are other processes affecting adb forward on the'
               ' host.',
           ) from err2
+
+        raise errors.Error(
+            self._device,
+            'Failed to establish socket connection from host to snippet server'
+            ' running on Android device.'
+        ) from err2
 
     self._conn.settimeout(_SOCKET_READ_TIMEOUT)
     self._client = self._conn.makefile(mode='brw')

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -465,7 +465,7 @@ class SnippetClientV2(client_base.ClientBase):
         raise errors.Error(
             self._device,
             'Failed to establish socket connection from host to snippet server'
-            ' running on Android device.'
+            ' running on Android device.',
         ) from err2
 
     self._conn.settimeout(_SOCKET_READ_TIMEOUT)

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -459,7 +459,7 @@ class SnippetClientV2(client_base.ClientBase):
               self._device,
               'The Adb forward command execution does not take effect. Please'
               ' check if there are other processes occupying adb forward on the'
-              ' host.'
+              ' host.',
           ) from err2
 
     self._conn.settimeout(_SOCKET_READ_TIMEOUT)

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -452,7 +452,7 @@ class SnippetClientV2(client_base.ClientBase):
         )
       except ConnectionRefusedError as err2:
         _, stdout, _ = utils.run_command(
-            f'netstat tulpn | grep ":{self.host_port}"', shell=True
+            f'netstat -tulpn | grep ":{self.host_port}"', shell=True
         )
         if not stdout:
           raise errors.Error(

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -451,10 +451,10 @@ class SnippetClientV2(client_base.ClientBase):
             ('127.0.0.1', self.host_port), _SOCKET_CONNECTION_TIMEOUT
         )
       except ConnectionRefusedError as err2:
-        _, stdout, _ = utils.run_command(
+        ret, _, _ = utils.run_command(
             f'netstat -tulpn | grep ":{self.host_port}"', shell=True
         )
-        if not stdout:
+        if ret != 0:
           raise errors.Error(
               self._device,
               'The Adb forward command execution did not take effect. Please'

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -1476,7 +1476,37 @@ class SnippetClientV2Test(unittest.TestCase):
         f'[Errno 111] Connection refused.'
     )
     mock_run_cmd.return_value = (1, b'', b'')
-    with self.assertRaises(errors.Error):
+    error_msg = 'The Adb forward command execution did not take effect'
+    with self.assertRaisesRegex(errors.Error, error_msg):
+      self._make_client()
+      self.client.device_port = 123
+      self.client.make_connection()
+
+  @mock.patch(
+      'mobly.controllers.android_device_lib.snippet_client_v2.'
+      'adb.list_occupied_adb_ports',
+      return_value=[],
+  )
+  @mock.patch(
+      'mobly.controllers.android_device_lib.snippet_client_v2.'
+      'utils.run_command'
+  )
+  @mock.patch('socket.create_connection')
+  def test_make_connection_raise_when_host_port_is_in_listening_state_(
+      self, mock_socket_create_conn, mock_run_cmd, _
+  ):
+    """Tests IOError occurred trying to create a socket connection."""
+    mock_socket_create_conn.side_effect = ConnectionRefusedError(
+        f'[Errno 111] Connection refused.'
+    )
+    mock_run_cmd.return_value = (
+        1, f'127.0.0.1:{MOCK_HOST_PORT}'.encode(), b''
+    )
+    error_msg = (
+        'Failed to establish socket connection from host to snippet server'
+        ' running on Android device.'
+    )
+    with self.assertRaisesRegex(errors.Error, error_msg):
       self._make_client()
       self.client.device_port = 123
       self.client.make_connection()

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -1472,7 +1472,9 @@ class SnippetClientV2Test(unittest.TestCase):
       self, mock_socket_create_conn, mock_run_cmd, _
   ):
     """Tests IOError occurred trying to create a socket connection."""
-    mock_socket_create_conn.side_effect = ConnectionRefusedError(f'[Errno 111] Connection refused.')
+    mock_socket_create_conn.side_effect = ConnectionRefusedError(
+        f'[Errno 111] Connection refused.'
+    )
     mock_run_cmd.return_value = (1, b'', b'')
     with self.assertRaises(errors.Error):
       self._make_client()

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -1463,6 +1463,27 @@ class SnippetClientV2Test(unittest.TestCase):
       'adb.list_occupied_adb_ports',
       return_value=[],
   )
+  @mock.patch(
+      'mobly.controllers.android_device_lib.snippet_client_v2.'
+      'utils.run_command'
+  )
+  @mock.patch('socket.create_connection')
+  def test_make_connection_when_host_port_is_not_in_listening_state_(
+      self, mock_socket_create_conn, mock_run_cmd, _
+  ):
+    """Tests IOError occurred trying to create a socket connection."""
+    mock_socket_create_conn.side_effect = ConnectionRefusedError(f'[Errno 111] Connection refused.')
+    mock_run_cmd.return_value = (1, b'', b'')
+    with self.assertRaises(errors.Error):
+      self._make_client()
+      self.client.device_port = 123
+      self.client.make_connection()
+
+  @mock.patch(
+      'mobly.controllers.android_device_lib.snippet_client_v2.'
+      'adb.list_occupied_adb_ports',
+      return_value=[],
+  )
   @mock.patch('socket.create_connection')
   def test_make_connection_io_error(self, mock_socket_create_conn, _):
     """Tests IOError occurred trying to create a socket connection."""

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -1499,9 +1499,7 @@ class SnippetClientV2Test(unittest.TestCase):
     mock_socket_create_conn.side_effect = ConnectionRefusedError(
         f'[Errno 111] Connection refused.'
     )
-    mock_run_cmd.return_value = (
-        1, f'127.0.0.1:{MOCK_HOST_PORT}'.encode(), b''
-    )
+    mock_run_cmd.return_value = (1, f'127.0.0.1:{MOCK_HOST_PORT}'.encode(), b'')
     error_msg = (
         'Failed to establish socket connection from host to snippet server'
         ' running on Android device.'

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -1503,7 +1503,7 @@ class SnippetClientV2Test(unittest.TestCase):
     mock_socket_create_conn.side_effect = ConnectionRefusedError(
         f'[Errno 111] Connection refused.'
     )
-    mock_run_cmd.return_value = (1, f'127.0.0.1:{MOCK_HOST_PORT}'.encode(), b'')
+    mock_run_cmd.return_value = (0, f'127.0.0.1:{MOCK_HOST_PORT}'.encode(), b'')
     error_msg = (
         'Failed to establish socket connection from host to snippet server'
         ' running on Android device.'

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -1482,6 +1482,10 @@ class SnippetClientV2Test(unittest.TestCase):
       self.client.device_port = 123
       self.client.make_connection()
 
+    mock_run_cmd.assert_any_call(
+        f'netstat -tulpn | grep ":{MOCK_HOST_PORT}"', shell=True
+    )
+
   @mock.patch(
       'mobly.controllers.android_device_lib.snippet_client_v2.'
       'adb.list_occupied_adb_ports',
@@ -1508,6 +1512,10 @@ class SnippetClientV2Test(unittest.TestCase):
       self._make_client()
       self.client.device_port = 123
       self.client.make_connection()
+
+    mock_run_cmd.assert_any_call(
+        f'netstat -tulpn | grep ":{MOCK_HOST_PORT}"', shell=True
+    )
 
   @mock.patch(
       'mobly.controllers.android_device_lib.snippet_client_v2.'


### PR DESCRIPTION
Check whether adb forwarding takes effect when hit socket connection failure.

Tested E2E locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/957)
<!-- Reviewable:end -->
