### PR TITLE
Set default timeout for fastboot command

### DIFF
--- a/mobly/controllers/android_device_lib/fastboot.py
+++ b/mobly/controllers/android_device_lib/fastboot.py
@@ -24,7 +24,7 @@ DEFAULT_TIMEOUT_SEC = 180
 FASTBOOT = 'fastboot'
 
 
-def exe_cmd(*cmds, timeout):
+def exe_cmd(*cmds, timeout=DEFAULT_TIMEOUT_SEC):
   """Executes commands in a new shell. Directing stderr to PIPE, with timeout.
 
   This is fastboot's own exe_cmd because of its peculiar way of writing
@@ -78,7 +78,7 @@ class FastbootProxy:
       return '{} -s {}'.format(FASTBOOT, self.serial)
     return FASTBOOT
 
-  def _exec_fastboot_cmd(self, name, arg_str, timeout):
+  def _exec_fastboot_cmd(self, name, arg_str, timeout=DEFAULT_TIMEOUT_SEC):
     return exe_cmd(
         ' '.join((self.fastboot_str(), name, arg_str)), timeout=timeout
     )

--- a/tests/mobly/controllers/android_device_lib/fastboot_test.py
+++ b/tests/mobly/controllers/android_device_lib/fastboot_test.py
@@ -161,6 +161,38 @@ class FastbootTest(unittest.TestCase):
         timeout=20,
     )
 
+  @mock.patch('mobly.utils.run_command')
+  def test_fastboot_exe_cmd_without_timeout_arg(self, mock_run_command):
+    expected_stdout = 'stdout'
+    expected_stderr = b'stderr'
+    mock_run_command.return_value = (123, expected_stdout, expected_stderr)
+
+    fastboot.exe_cmd('fastboot -w')
+
+    mock_run_command.assert_called_with(
+        cmd='fastboot -w',
+        stdout=PIPE,
+        stderr=PIPE,
+        shell=True,
+        timeout=180,
+    )
+
+  @mock.patch('mobly.utils.run_command')
+  def test_fastboot_exec_fastboot_cmd_without_timeout_arg(self, mock_run_command):
+    expected_stdout = 'stdout'
+    expected_stderr = b'stderr'
+    mock_run_command.return_value = (123, expected_stdout, expected_stderr)
+
+    fastboot.FastbootProxy()._exec_fastboot_cmd(name='', arg_str='-w')
+
+    mock_run_command.assert_called_with(
+        cmd='fastboot  -w',
+        stdout=PIPE,
+        stderr=PIPE,
+        shell=True,
+        timeout=180,
+    )
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/mobly/controllers/android_device_lib/fastboot_test.py
+++ b/tests/mobly/controllers/android_device_lib/fastboot_test.py
@@ -178,7 +178,9 @@ class FastbootTest(unittest.TestCase):
     )
 
   @mock.patch('mobly.utils.run_command')
-  def test_fastboot_exec_fastboot_cmd_without_timeout_arg(self, mock_run_command):
+  def test_fastboot_exec_fastboot_cmd_without_timeout_arg(
+      self, mock_run_command
+  ):
     expected_stdout = 'stdout'
     expected_stderr = b'stderr'
     mock_run_command.return_value = (123, expected_stdout, expected_stderr)

--- a/tests/mobly/controllers/android_device_lib/fastboot_test.py
+++ b/tests/mobly/controllers/android_device_lib/fastboot_test.py
@@ -177,24 +177,6 @@ class FastbootTest(unittest.TestCase):
         timeout=180,
     )
 
-  @mock.patch('mobly.utils.run_command')
-  def test_fastboot_exec_fastboot_cmd_without_timeout_arg(
-      self, mock_run_command
-  ):
-    expected_stdout = 'stdout'
-    expected_stderr = b'stderr'
-    mock_run_command.return_value = (123, expected_stdout, expected_stderr)
-
-    fastboot.FastbootProxy()._exec_fastboot_cmd(name='', arg_str='-w')
-
-    mock_run_command.assert_called_with(
-        cmd='fastboot  -w',
-        stdout=PIPE,
-        stderr=PIPE,
-        shell=True,
-        timeout=180,
-    )
-
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This is a follow-up fix for [PR952](https://github.com/google/mobly/pull/952). Without setting up the default values, existing tests from other users may break since their tests are missing `timeout` arg.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/959)
<!-- Reviewable:end -->
