### PR TITLE
Add test class name into the test case starting log info in base_test.py

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -788,7 +788,7 @@ class BaseTestClass:
         test_name, self.log_path, tr_record
     )
     expects.recorder.reset_internal_states(tr_record)
-    logging.info('%s %s', TEST_CASE_TOKEN, test_name)
+    logging.info('%s %s#%s', TEST_CASE_TOKEN, self.TAG, test_name)
     # Did teardown_test throw an error.
     teardown_test_failed = False
     try:


### PR DESCRIPTION
To better distinguish test cases in Mobly main log, when logging test case starting point, also add test class name into the log.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/963)
<!-- Reviewable:end -->
