### PR TITLE
Include snippet server process stdout in server start error message

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -40,12 +40,13 @@ _LAUNCH_CMD = (
 )
 
 _SNIPPET_SERVER_START_ERROR_DEBUG_TIP = """
-Got invalid snippet sever start instrumentation result: {instrumentation_result}
+Invalid instrumentation result log received during snippet server start:
+{instrumentation_result}
 
-Please check following logs for debugging:
+For debugging, please check the following:
 1. Check the server process stdout attached below.
-2. Check the snippet server logs on device in the logcat file. Search for
-   "SNIPPET START" to find the snippet server process ID.
+2. The snippet server logs within the device's logcat file. Search for
+   "SNIPPET START" to locate the relevant process ID.
 
 Server process stdout:
 {server_start_stdout}

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -310,9 +310,7 @@ class SnippetClientV2(client_base.ClientBase):
     if not match:
       message = _SNIPPET_SERVER_START_ERROR_DEBUG_TIP.format(
           instrumentation_result=line,
-          server_start_stdout='\n'.join(
-              self._server_start_stdout
-          ),
+          server_start_stdout='\n'.join(self._server_start_stdout),
       )
       raise errors.ServerStartProtocolError(self._device, message)
     self.device_port = int(match.group(1))

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -758,7 +758,9 @@ class SnippetClientV2Test(unittest.TestCase):
       'mobly.controllers.android_device_lib.snippet_client_v2.'
       'utils.start_standing_subprocess'
   )
-  def test_start_server_error_message_include_discarded_output(self, mock_start_standing_subprocess):
+  def test_start_server_error_message_include_discarded_output(
+      self, mock_start_standing_subprocess
+  ):
     """Tests that starting server process reports known protocol with junk."""
     self._make_client()
     discarded_output = 'java.lang.RuntimeException: Failed to start server'
@@ -767,11 +769,12 @@ class SnippetClientV2Test(unittest.TestCase):
         resp_lines=[
             b'SNIPPET START, PROTOCOL 1 0\n',
             discarded_output.encode('utf-8'),
-            b'INSTRUMENTATION_RESULT: shortMsg=Process crashed.'
+            b'INSTRUMENTATION_RESULT: shortMsg=Process crashed.',
         ],
     )
     with self.assertRaisesRegex(
-        errors.ServerStartProtocolError, discarded_output,
+        errors.ServerStartProtocolError,
+        discarded_output,
     ):
       self.client.start_server()
 

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -758,6 +758,27 @@ class SnippetClientV2Test(unittest.TestCase):
       'mobly.controllers.android_device_lib.snippet_client_v2.'
       'utils.start_standing_subprocess'
   )
+  def test_start_server_error_message_include_discarded_output(self, mock_start_standing_subprocess):
+    """Tests that starting server process reports known protocol with junk."""
+    self._make_client()
+    discarded_output = 'java.lang.RuntimeException: Failed to start server'
+    self._mock_server_process_starting_response(
+        mock_start_standing_subprocess,
+        resp_lines=[
+            b'SNIPPET START, PROTOCOL 1 0\n',
+            discarded_output.encode('utf-8'),
+            b'INSTRUMENTATION_RESULT: shortMsg=Process crashed.'
+        ],
+    )
+    with self.assertRaisesRegex(
+        errors.ServerStartProtocolError, discarded_output,
+    ):
+      self.client.start_server()
+
+  @mock.patch(
+      'mobly.controllers.android_device_lib.snippet_client_v2.'
+      'utils.start_standing_subprocess'
+  )
   def test_start_server_no_valid_line(self, mock_start_standing_subprocess):
     """Tests that starting server process reports unknown protocol message."""
     self._make_client()


### PR DESCRIPTION
This PR includes the stdout because it contains error stacktrace if the snippet server crashes. Thus users can get some useful debugging information without checking logcat.

Here's an example error message with this PR:

```
File ".../mobly/controllers/android_device_lib/snippet_client_v2.py", line 317, in start_server
    raise errors.ServerStartProtocolError(self._device, message)
mobly.snippet.errors.ServerStartProtocolError: <AndroidDevice|38060DLJG002LF> 
Invalid instrumentation result log received during snippet server start:
INSTRUMENTATION_RESULT: shortMsg=Process crashed.

For debugging, please check the following:
1. Check the server process stdout attached below.
2. The snippet server logs within the device's logcat file. Search for
   "SNIPPET START" to locate the relevant process ID.

Server process stdout:

Process crashed before executing the test(s):
java.lang.RuntimeException: Failed to start server
at com.google.android.mobly.snippet.SnippetRunner.startServer(SnippetRunner.java:169)
at com.google.android.mobly.snippet.SnippetRunner.onStart(SnippetRunner.java:101)
at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2598)
Caused by: java.net.SocketException: socket failed: EPERM (Operation not permitted)
at java.net.ServerSocket.createImpl(ServerSocket.java:331)
at java.net.ServerSocket.getImpl(ServerSocket.java:281)
at java.net.ServerSocket.bind(ServerSocket.java:399)
at java.net.ServerSocket.<init>(ServerSocket.java:259)
at com.google.android.mobly.snippet.rpc.SimpleServer.startLocal(SimpleServer.java:102)
at com.google.android.mobly.snippet.manager.SnippetObjectConverterManager.startLocal$ar$objectUnboxing(SnippetObjectConverterManager.java:1)
at com.google.android.mobly.snippet.SnippetRunner.startServer(SnippetRunner.java:12)
... 2 more
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/964)
<!-- Reviewable:end -->
