### PR TITLE
Enable certain "serial" ids

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -526,7 +526,9 @@ class AndroidDevice:
     self._log_path = os.path.join(
         _log_path_base, 'AndroidDevice%s' % self._normalized_serial
     )
-    self._debug_tag = self._serial
+    # Some "serial" addresses actually contain a % character that interferes
+    # with the Python logger's %-operator string interpolation. Escape it.
+    self._debug_tag = self._serial.replace('%', '%%')
     self.log = AndroidDeviceLoggerAdapter(
         logging.getLogger(), {'tag': self.debug_tag}
     )


### PR DESCRIPTION
Some serial IDs contain %, such as serial-over-networking. This patch enables these kinds of serial IDs to
survive the python logger, which employs the %-operator for string interpolation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/965)
<!-- Reviewable:end -->
