### PR TITLE
Allow ipv6 scope syntax in a serial ID

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -526,7 +526,7 @@ class AndroidDevice:
     self._log_path = os.path.join(
         _log_path_base, 'AndroidDevice%s' % self._normalized_serial
     )
-    self._debug_tag = self._serial
+    self._debug_tag = self._serial.replace('%', '%%')
     self.log = AndroidDeviceLoggerAdapter(
         logging.getLogger(), {'tag': self.debug_tag}
     )

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -1605,6 +1605,15 @@ class AndroidDeviceTest(unittest.TestCase):
     ):
       raise Exception(ad, 'Something')
 
+  def test_AndroidDevice_debug_tag_of_ipv6_serial(self):
+    ad = android_device.AndroidDevice(serial='[fe80::1234%42]:5555')
+    self.assertEqual(ad.debug_tag, '[fe80::1234%%42]:5555')
+    try:
+      msg = '{} and %s'.format(ad.debug_tag)
+      ad.log.error(msg % 'happened')
+    except ValueError as e:
+      raise Exception(f'Error occurred: {e}')
+
   @mock.patch(
       'mobly.controllers.android_device_lib.adb.AdbProxy',
       return_value=mock_android_device.MockAdbProxy('1'),


### PR DESCRIPTION
Without escaping, the test simulates the logger logic and issues this error:
E         Exception: Error occurred: unsupported format character ']' (0x5d) at index 14

With escaping, tox passes all tests. It's a bit unfortunate that the debug_tag_ is escaped directly, instead of at its injection point into the custom logger's tag field.