### PR TITLE
android_device: update take_screenshot to support multiple displays

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -1053,22 +1053,52 @@ class AndroidDevice:
     self.log.debug('Bugreport taken at %s.', full_out_path)
     return full_out_path
 
-  def take_screenshot(self, destination, prefix='screenshot'):
+  def take_screenshot(
+      self, destination, prefix='screenshot', all_displays=False
+  ):
     """Takes a screenshot of the device.
 
     Args:
       destination: string, full path to the directory to save in.
       prefix: string, prefix file name of the screenshot.
+      all_displays: bool, if true will take a screenshot on all connnected
+        displays, if false will take a screenshot on the default display.
 
     Returns:
-      string, full path to the screenshot file on the host.
+      string, full path to the screenshot file on the host, or
+      list[str], when all_displays is True, the full paths to the screenshot
+        files on the host.
     """
     filename = self.generate_filename(prefix, extension_name='png')
+    filename_no_extension, _ = os.path.splitext(filename)
     device_path = os.path.join('/storage/emulated/0/', filename)
     self.adb.shell(
-        ['screencap', '-p', device_path], timeout=TAKE_SCREENSHOT_TIMEOUT_SECOND
+        ['screencap', '-p', '-a' if all_displays else '', device_path],
+        timeout=TAKE_SCREENSHOT_TIMEOUT_SECOND,
     )
     utils.create_dir(destination)
+    if all_displays:
+      pic_paths = []
+      png_files = [device_path]
+      # iterate over all files that match the filename, if all_displays is true
+      # then filename will get a suffix of display number eg filenmame.png ->
+      # filename_0.png, filename_1.png
+      png_files = (
+          self.adb.shell('ls /storage/emulated/0/*.png')
+          .decode('utf-8')
+          .split('\n')
+      )
+      for device_path in png_files:
+        if device_path.find(filename_no_extension) < 0:
+          continue
+        self.adb.pull([device_path, destination])
+        pic_paths.append(
+            os.path.join(destination, os.path.basename(device_path))
+        )
+        self.log.debug('Screenshot taken, saved on the host: %s', pic_paths[-1])
+        self.adb.shell(['rm', device_path])
+      return pic_paths
+    # handle single screenshot when all_displays=False
     self.adb.pull([device_path, destination])
     pic_path = os.path.join(destination, filename)
     self.log.debug('Screenshot taken, saved on the host: %s', pic_path)

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -1169,6 +1169,148 @@ class AndroidDeviceTest(unittest.TestCase):
   )
   @mock.patch('mobly.utils.create_dir')
   @mock.patch('mobly.logger.get_log_file_timestamp')
+  def test_AndroidDevice_take_screenshot_all_displays(
+      self,
+      get_log_file_timestamp_mock,
+      create_dir_mock,
+      FastbootProxy,
+      MockAdbProxy,
+  ):
+    test_adb_proxy = MockAdbProxy.return_value
+    original_mock_adb_instance_shell = MockAdbProxy.shell
+
+    def custom_shell_for_screenshot(params, timeout=None):
+      if f'ls /storage/emulated/0/*.png' in params:
+        return (
+            b'/storage/emulated/0/screenshot,1,fakemodel,07-22-2019_17-53-34-450_0.png\n'
+            + b'/storage/emulated/0/screenshot,1,fakemodel,07-22-2019_17-53-34-450_1.png\n'
+        )
+      return original_mock_adb_instance_shell(params, timeout)
+
+    test_adb_proxy.shell = custom_shell_for_screenshot
+
+    get_log_file_timestamp_mock.return_value = '07-22-2019_17-53-34-450'
+    mock_serial = '1'
+    ad = android_device.AndroidDevice(serial=mock_serial)
+    full_pic_paths = ad.take_screenshot(self.tmp_dir, all_displays=True)
+    self.assertEqual(
+        full_pic_paths,
+        [
+            os.path.join(
+                self.tmp_dir,
+                'screenshot,1,fakemodel,07-22-2019_17-53-34-450_0.png',
+            ),
+            os.path.join(
+                self.tmp_dir,
+                'screenshot,1,fakemodel,07-22-2019_17-53-34-450_1.png',
+            ),
+        ],
+    )
+
+  @mock.patch(
+      'mobly.controllers.android_device_lib.adb.AdbProxy',
+      return_value=mock_android_device.MockAdbProxy('1'),
+  )
+  @mock.patch(
+      'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+      return_value=mock_android_device.MockFastbootProxy('1'),
+  )
+  @mock.patch('mobly.utils.create_dir')
+  @mock.patch('mobly.logger.get_log_file_timestamp')
+  def test_AndroidDevice_take_screenshot_all_displays_with_additional_files(
+      self,
+      get_log_file_timestamp_mock,
+      create_dir_mock,
+      FastbootProxy,
+      MockAdbProxy,
+  ):
+    test_adb_proxy = MockAdbProxy.return_value
+    original_mock_adb_instance_shell = MockAdbProxy.shell
+
+    def custom_shell_for_screenshot(params, timeout=None):
+      if f'ls /storage/emulated/0/*.png' in params:
+        return (
+            b'/storage/emulated/0/screenshot,1,fakemodel,07-22-2019_17-53-34-450_0.png\n'
+            + b'/storage/emulated/0/screenshot,1,fakemodel,07-22-2019_17-53-34-450_1.png\n'
+            b'/storage/emulated/0/screenshot,1,fakemodel,07-22-2019_16-53-34-450_0.png\n'
+            + b'/storage/emulated/0/screenshot,1,fakemodel,07-22-2019_16-53-34-450_1.png\n'
+        )
+      return original_mock_adb_instance_shell(params, timeout)
+
+    test_adb_proxy.shell = custom_shell_for_screenshot
+
+    get_log_file_timestamp_mock.return_value = '07-22-2019_17-53-34-450'
+    mock_serial = '1'
+    ad = android_device.AndroidDevice(serial=mock_serial)
+    full_pic_paths = ad.take_screenshot(self.tmp_dir, all_displays=True)
+    self.assertEqual(
+        full_pic_paths,
+        [
+            os.path.join(
+                self.tmp_dir,
+                'screenshot,1,fakemodel,07-22-2019_17-53-34-450_0.png',
+            ),
+            os.path.join(
+                self.tmp_dir,
+                'screenshot,1,fakemodel,07-22-2019_17-53-34-450_1.png',
+            ),
+        ],
+    )
+
+  @mock.patch(
+      'mobly.controllers.android_device_lib.adb.AdbProxy',
+      return_value=mock_android_device.MockAdbProxy('1'),
+  )
+  @mock.patch(
+      'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+      return_value=mock_android_device.MockFastbootProxy('1'),
+  )
+  @mock.patch('mobly.utils.create_dir')
+  @mock.patch('mobly.logger.get_log_file_timestamp')
+  def test_AndroidDevice_take_screenshot_all_displays_with_single_display(
+      self,
+      get_log_file_timestamp_mock,
+      create_dir_mock,
+      FastbootProxy,
+      MockAdbProxy,
+  ):
+    test_adb_proxy = MockAdbProxy.return_value
+    original_mock_adb_instance_shell = MockAdbProxy.shell
+
+    def custom_shell_for_screenshot(params, timeout=None):
+      if f'ls /storage/emulated/0/*.png' in params:
+        return (
+            # when there is a single display there is no suffix on the png filename
+            b'/storage/emulated/0/screenshot,1,fakemodel,07-22-2019_17-53-34-450.png\n'
+        )
+      return original_mock_adb_instance_shell(params, timeout)
+
+    test_adb_proxy.shell = custom_shell_for_screenshot
+
+    get_log_file_timestamp_mock.return_value = '07-22-2019_17-53-34-450'
+    mock_serial = '1'
+    ad = android_device.AndroidDevice(serial=mock_serial)
+    full_pic_paths = ad.take_screenshot(self.tmp_dir, all_displays=True)
+    self.assertEqual(
+        full_pic_paths,
+        [
+            os.path.join(
+                self.tmp_dir,
+                'screenshot,1,fakemodel,07-22-2019_17-53-34-450.png',
+            ),
+        ],
+    )
+
+  @mock.patch(
+      'mobly.controllers.android_device_lib.adb.AdbProxy',
+      return_value=mock_android_device.MockAdbProxy('1'),
+  )
+  @mock.patch(
+      'mobly.controllers.android_device_lib.fastboot.FastbootProxy',
+      return_value=mock_android_device.MockFastbootProxy('1'),
+  )
+  @mock.patch('mobly.utils.create_dir')
+  @mock.patch('mobly.logger.get_log_file_timestamp')
   def test_AndroidDevice_take_screenshot_with_prefix(
       self,
       get_log_file_timestamp_mock,


### PR DESCRIPTION
new all_displays arg to take_screenshot allows capturing a screenshot on all connected displays including internal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/970)
<!-- Reviewable:end -->
