### PR TITLE
Skip adb port removal when port not forwarded (Fixes #971)

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -718,9 +718,12 @@ class SnippetClientV2(client_base.ClientBase):
       self._stop_port_forwarding()
 
   def _stop_port_forwarding(self):
-    """
-    Stops the adb port forwarding used by this client.
-    Will skip removal if the port is not currently forwarded.
+    """Stops the adb port forwarding used by this client.
+
+    Although we explicitly forward and track the host port, it can be unforwarded
+    unexpectedly due to flaky USB connections, adb restarts, or external tools
+    (e.g., `adb forward --remove-all`). To prevent unnecessary errors, this method
+    checks if the host port is still forwarded before attempting to remove it.
     """
     if self.host_port:
       occupied_ports = adb.list_occupied_adb_ports()

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -718,8 +718,19 @@ class SnippetClientV2(client_base.ClientBase):
       self._stop_port_forwarding()
 
   def _stop_port_forwarding(self):
-    """Stops the adb port forwarding used by this client."""
+    """
+    Stops the adb port forwarding used by this client.
+    Will skip removal if the port is not currently forwarded.
+    """
     if self.host_port:
+      occupied_ports = adb.list_occupied_adb_ports()
+      if self.host_port not in occupied_ports:
+        self.log.debug(
+            'Host port %s is not currently forwarded by adb, skipping removal.',
+            self.host_port,
+        )
+        self.host_port = None
+        return
       self._device.adb.forward(['--remove', f'tcp:{self.host_port}'])
       self.host_port = None
 


### PR DESCRIPTION
Fixes #971

This PR improves the robustness of `_stop_port_forwarding()` in `SnippetClientV2`.

### Summary of Changes
- Before attempting `adb forward --remove`, the code now checks if the `host_port` is in `list_occupied_adb_ports()`.
- Skips the removal and logs a debug message if the port isn't found.
- Prevents unnecessary ADB errors when stopping a client that has already cleaned up ports.
- Updates related unit tests to reflect this logic.
- All `tox` tests pass and code is formatted using `pyink==24.3.0`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/972)
<!-- Reviewable:end -->
