### PR TITLE
Keep the consistent newline format when creating excerpts of adb logcat.

### DIFF
--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import io
 import logging
 import os
 import time
@@ -121,8 +120,13 @@ class Logcat(base_service.BaseService):
         self.OUTPUT_FILE_TYPE, test_info, 'txt'
     )
     excerpt_file_path = os.path.join(dest_path, filename)
-    with io.open(
-        excerpt_file_path, 'w', encoding='utf-8', errors='replace'
+    with open(
+        excerpt_file_path,
+        'w',
+        encoding='utf-8',
+        errors='replace',
+        # When newline is '', line endings are written without conversion.
+        newline='',
     ) as out:
       # Devices may accidentally go offline during test,
       # check not None before readline().
@@ -195,8 +199,13 @@ class Logcat(base_service.BaseService):
               self._ad, 'Timeout while waiting for logcat file to be created.'
           )
         time.sleep(1)
-      self._adb_logcat_file_obj = io.open(
-          self.adb_logcat_file_path, 'r', encoding='utf-8', errors='replace'
+      self._adb_logcat_file_obj = open(
+          self.adb_logcat_file_path,
+          'r',
+          encoding='utf-8',
+          errors='replace',
+          # When newline is '', line endings are read without conversion.
+          newline='',
       )
       self._adb_logcat_file_obj.seek(0, os.SEEK_END)
 

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -83,12 +83,12 @@ class LogcatTest(unittest.TestCase):
     shutil.rmtree(self.tmp_dir)
 
   def AssertFileContains(self, content, file_path):
-    with open(file_path, 'r') as f:
+    with open(file_path, 'r', newline='') as f:
       output = f.read()
     self.assertIn(content, output)
 
   def AssertFileDoesNotContain(self, content, file_path):
-    with open(file_path, 'r') as f:
+    with open(file_path, 'r', newline='') as f:
       output = f.read()
     self.assertNotIn(content, output)
 
@@ -320,7 +320,7 @@ class LogcatTest(unittest.TestCase):
     def _write_logcat_file_and_assert_excerpts_exists(
         logcat_file_content, test_begin_time, test_name
     ):
-      with open(logcat_service.adb_logcat_file_path, 'a') as f:
+      with open(logcat_service.adb_logcat_file_path, 'a', newline='') as f:
         f.write(logcat_file_content)
       test_output_dir = os.path.join(self.tmp_dir, test_name)
       mock_record = records.TestResultRecord(test_name)
@@ -348,11 +348,12 @@ class LogcatTest(unittest.TestCase):
     # Generate logs before the file pointer is created.
     # This message will not be captured in the excerpt.
     NOT_IN_EXCERPT = 'Not in excerpt.\n'
-    with open(logcat_service.adb_logcat_file_path, 'a') as f:
+    with open(logcat_service.adb_logcat_file_path, 'a', newline='') as f:
       f.write(NOT_IN_EXCERPT)
     # With the file pointer created, generate logs and make an excerpt.
     logcat_service._open_logcat_file()
-    FILE_CONTENT = 'Some log.\n'
+    # Both CR and LF should be preserved no matter the operating system.
+    FILE_CONTENT = 'Some log.\r\nAnother log.\n'
     expected_path1 = _write_logcat_file_and_assert_excerpts_exists(
         logcat_file_content=FILE_CONTENT,
         test_begin_time=123,


### PR DESCRIPTION
The result of `adb logcat` may contain lines ending with `\r\n`. This change will keep the original newline format when creating excerpts.

Use `newline=''` when opening the log file to prevent line endings from being converted on both read and write. See: https://docs.python.org/3/library/functions.html#open

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/973)
<!-- Reviewable:end -->
