### PR TITLE
Fix pytype error when using adb_logcat_file_path in open

### DIFF
--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -199,6 +199,8 @@ class Logcat(base_service.BaseService):
               self._ad, 'Timeout while waiting for logcat file to be created.'
           )
         time.sleep(1)
+      if self.adb_logcat_file_path is None:
+        raise Error(self._ad, 'Logcat file path is not initialized.')
       self._adb_logcat_file_obj = open(
           self.adb_logcat_file_path,
           'r',


### PR DESCRIPTION
```
Built-in function open was called with the wrong arguments [wrong-arg-types]

       Expected: (file: Union[_PathLike, bytes, int, str], ...)
Actually passed: (file: None, ...)
Attributes of protocol _PathLike are not implemented on None: __fspath__
```