### PR TITLE
Improve controller error message when DUT isn't found

### DIFF
--- a/mobly/controller_manager.py
+++ b/mobly/controller_manager.py
@@ -141,7 +141,8 @@ class ControllerManager:
     if actual_number < min_number:
       module.destroy(objects)
       raise signals.ControllerError(
-          'Expected to get at least %d controller objects, got %d.'
+          'Expected to get at least %d controller objects, got %d. '
+          'Verify that the DUT is connected via ADB'
           % (min_number, actual_number)
       )
     # Save a shallow copy of the list for internal usage, so tests can't


### PR DESCRIPTION
Improve the error messaging to indicate that an expected DUT might not be connected via ADB.

Test: atest UCD with ADB disconnected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/976)
<!-- Reviewable:end -->
