### PR TITLE
android_device: add BUILD_VERSION_SDK_FULL to AndroidProperties

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -481,8 +481,10 @@ class BuildInfoConstants(enum.Enum):
       'build_version_incremental',
       'ro.build.version.incremental',
   )
+  # Refer to android.os.Build.VERSION#SDK_INT
   BUILD_VERSION_SDK = 'build_version_sdk', 'ro.build.version.sdk'
-  BUILD_VERSION_SDK_FULL = 'build_version_sdk_full', 'ro.build.version.sdk_full'  
+  # Refer to android.os.Build.VERSION#SDK_INT_FULL (Available on `SDK_INT > 36` devices)
+  BUILD_VERSION_SDK_FULL = 'build_version_sdk_full', 'ro.build.version.sdk_full'
   BUILD_PRODUCT = 'build_product', 'ro.build.product'
   BUILD_CHARACTERISTICS = 'build_characteristics', 'ro.build.characteristics'
   DEBUGGABLE = 'debuggable', 'ro.debuggable'


### PR DESCRIPTION
This is the new versioning variable for minor API bumps

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/977)
<!-- Reviewable:end -->
