### PR TITLE
Add iteration tracking to test execution

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -209,6 +209,7 @@ class BaseTestClass:
     self.testbed_name = configs.testbed_name
     self.user_params = configs.user_params
     self.results = records.TestResult()
+    self._iteration = 0
     self.summary_writer = configs.summary_writer
     self._generated_test_table = collections.OrderedDict()
     self._controller_manager = controller_manager.ControllerManager(
@@ -365,7 +366,7 @@ class BaseTestClass:
     record = records.TestResultRecord(stage_name, self.TAG)
     record.test_begin()
     self.current_test_info = runtime_test_info.RuntimeTestInfo(
-        stage_name, self.log_path, record
+        stage_name, self.log_path, record, self._iteration
     )
     try:
       with self._log_test_stage(stage_name):
@@ -403,7 +404,7 @@ class BaseTestClass:
     class_record = records.TestResultRecord(STAGE_NAME_SETUP_CLASS, self.TAG)
     class_record.test_begin()
     self.current_test_info = runtime_test_info.RuntimeTestInfo(
-        STAGE_NAME_SETUP_CLASS, self.log_path, class_record
+        STAGE_NAME_SETUP_CLASS, self.log_path, class_record, self._iteration
     )
     expects.recorder.reset_internal_states(class_record)
     try:
@@ -455,7 +456,7 @@ class BaseTestClass:
     record = records.TestResultRecord(stage_name, self.TAG)
     record.test_begin()
     self.current_test_info = runtime_test_info.RuntimeTestInfo(
-        stage_name, self.log_path, record
+        stage_name, self.log_path, record, self._iteration
     )
     expects.recorder.reset_internal_states(record)
     try:
@@ -784,8 +785,9 @@ class BaseTestClass:
     tr_record = record or records.TestResultRecord(test_name, self.TAG)
     tr_record.uid = getattr(test_method, 'uid', None)
     tr_record.test_begin()
+    self._iteration = self._iteration + 1
     self.current_test_info = runtime_test_info.RuntimeTestInfo(
-        test_name, self.log_path, tr_record
+        test_name, self.log_path, tr_record, self._iteration
     )
     expects.recorder.reset_internal_states(tr_record)
     logging.info('%s %s', TEST_CASE_TOKEN, test_name)
@@ -1081,6 +1083,7 @@ class BaseTestClass:
       The test results object of this class.
     """
     logging.log_path = self.log_path
+    self._iteration = 0
     # Executes pre-setup procedures, like generating test methods.
     if not self._pre_run():
       return self.results
@@ -1118,6 +1121,7 @@ class BaseTestClass:
           )
         else:
           self.exec_one_test(test_name, test_method)
+        self._iteration = 0
       return self.results
     except signals.TestAbortClass as e:
       e.details = 'Test class aborted due to: %s' % e.details
@@ -1142,7 +1146,7 @@ class BaseTestClass:
     record = records.TestResultRecord(stage_name, self.TAG)
     record.test_begin()
     self.current_test_info = runtime_test_info.RuntimeTestInfo(
-        stage_name, self.log_path, record
+        stage_name, self.log_path, record, self._iteration
     )
     expects.recorder.reset_internal_states(record)
     with self._log_test_stage(stage_name):

--- a/mobly/runtime_test_info.py
+++ b/mobly/runtime_test_info.py
@@ -34,14 +34,16 @@ class RuntimeTestInfo:
       as the test's execution progresses.
     output_path: string, path to the test's output directory. It's created
       upon accessing.
+    iteration: int, the current iteration of the test.
   """
 
-  def __init__(self, test_name, log_path, record):
+  def __init__(self, test_name, log_path, record, iteration=1):
     self._name = test_name
     self._record = record
     self._output_dir_path = utils.abs_path(
         os.path.join(log_path, self._record.signature)
     )
+    self._iteration = iteration
 
   @property
   def name(self):
@@ -59,3 +61,7 @@ class RuntimeTestInfo:
   def output_path(self):
     utils.create_dir(self._output_dir_path)
     return self._output_dir_path
+
+  @property
+  def iteration(self):
+    return self._iteration


### PR DESCRIPTION
Introduces `_iteration` counter to track the current iteration of a test case, especially useful for repeated or retried tests.
* The `_iteration` variable is incremented before each test execution.
* The `current_test_info` now includes the current iteration number by introducing an `iteration` property to the `RuntimeTestInfo` class.

This allows clients to easily access the current iteration without needing to manage a separate counter.