### PR TITLE
AndroidDevice controller should use a timeout for `adb root`

### DIFF
--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -556,7 +556,7 @@ class AdbProxy:
               'Retry the command "%s" since %s.'
               % (
                   utils.cli_cmd_to_string(e.cmd),
-                  ('Error %s occurred' % e.stderr.decode('utf-8').strip())
+                  ('Error "%s" occurred' % e.stderr.decode('utf-8').strip())
                   if isinstance(e, AdbError)
                   else ('it timed out after %d seconds' % e.timeout),
               )

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -31,7 +31,7 @@ ADB_PORT_LOCK = threading.Lock()
 # the timeout of this command.
 ADB_ROOT_RETRY_ATTEMPTS = 3
 ADB_ROOT_RETRY_ATTEMPT_INTERVAL_SEC = 10
-ADB_ROOT_ATTEMPT_TIMEOUT_SEC = 10
+ADB_ROOT_ATTEMPT_TIMEOUT_SEC = 5
 
 # Qualified class name of the default instrumentation test runner.
 DEFAULT_INSTRUMENTATION_RUNNER = (

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -552,13 +552,15 @@ class AdbProxy:
         )
       except (AdbError, AdbTimeoutError) as e:
         if attempt + 1 < ADB_ROOT_RETRY_ATTEMPTS:
+          retry_reason = (
+              f'Error "{e.stderr.decode("utf-8").strip()}" occurred'
+              if isinstance(e, AdbError)
+              else f'it timed out after {e.timeout} seconds'
+          )
           logging.debug(
-              f'Retry the command "{utils.cli_cmd_to_string(e.cmd)}" since '
-              + (
-                  f'Error "{e.stderr.decode("utf-8").strip()}" occurred.'
-                  if isinstance(e, AdbError)
-                  else f'it timed out after {e.timeout} seconds.'
-              )
+              'Retry the command "%s" since %s.',
+              utils.cli_cmd_to_string(e.cmd),
+              retry_reason,
           )
 
           # Buffer between "adb root" commands.

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -554,9 +554,11 @@ class AdbProxy:
         if attempt + 1 < ADB_ROOT_RETRY_ATTEMPTS:
           logging.debug(
               f'Retry the command "{utils.cli_cmd_to_string(e.cmd)}" since '
-              + (f'Error "{e.stderr.decode("utf-8").strip()}" occurred.'
-              if isinstance(e, AdbError)
-              else f'it timed out after {e.timeout} seconds.')
+              + (
+                  f'Error "{e.stderr.decode("utf-8").strip()}" occurred.'
+                  if isinstance(e, AdbError)
+                  else f'it timed out after {e.timeout} seconds.'
+              )
           )
 
           # Buffer between "adb root" commands.

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -27,10 +27,11 @@ ADB = 'adb'
 # do with port forwarding must happen under this lock.
 ADB_PORT_LOCK = threading.Lock()
 
-# Number of attempts to execute "adb root", and seconds for interval time of
-# this commands.
+# Number of attempts to execute "adb root", and seconds for interval time and
+# the timeout of this command.
 ADB_ROOT_RETRY_ATTEMPTS = 3
 ADB_ROOT_RETRY_ATTEMPT_INTERVAL_SEC = 10
+ADB_ROOT_ATTEMPT_TIMEOUT_SEC = 10
 
 # Qualified class name of the default instrumentation test runner.
 DEFAULT_INSTRUMENTATION_RUNNER = (
@@ -537,22 +538,21 @@ class AdbProxy:
 
     Raises:
       AdbError: If the command exit code is not 0.
+      AdbTimeoutError: If the command timed out.
     """
     retry_interval = ADB_ROOT_RETRY_ATTEMPT_INTERVAL_SEC
     for attempt in range(ADB_ROOT_RETRY_ATTEMPTS):
       try:
         return self._exec_adb_cmd(
-            'root', args=None, shell=False, timeout=None, stderr=None
+            'root',
+            args=None,
+            shell=False,
+            timeout=ADB_ROOT_ATTEMPT_TIMEOUT_SEC,
+            stderr=None,
         )
-      except AdbError as e:
+      except (AdbError, AdbTimeoutError) as e:
         if attempt + 1 < ADB_ROOT_RETRY_ATTEMPTS:
-          logging.debug(
-              'Retry the command "%s" since Error "%s" occurred.'
-              % (
-                  utils.cli_cmd_to_string(e.cmd),
-                  e.stderr.decode('utf-8').strip(),
-              )
-          )
+          logging.debug('Retry root() since Error "%s" occurred.', e)
           # Buffer between "adb root" commands.
           time.sleep(retry_interval)
           retry_interval *= 2

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -552,7 +552,16 @@ class AdbProxy:
         )
       except (AdbError, AdbTimeoutError) as e:
         if attempt + 1 < ADB_ROOT_RETRY_ATTEMPTS:
-          logging.debug('Retry root() since Error "%s" occurred.', e)
+          logging.debug(
+              'Retry the command "%s" since %s.'
+              % (
+                  utils.cli_cmd_to_string(e.cmd),
+                  ('Error %s occurred' % e.stderr.decode('utf-8').strip())
+                  if isinstance(e, AdbError)
+                  else ('it timed out after %d seconds' % e.timeout),
+              )
+          )
+
           # Buffer between "adb root" commands.
           time.sleep(retry_interval)
           retry_interval *= 2

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -553,13 +553,10 @@ class AdbProxy:
       except (AdbError, AdbTimeoutError) as e:
         if attempt + 1 < ADB_ROOT_RETRY_ATTEMPTS:
           logging.debug(
-              'Retry the command "%s" since %s.'
-              % (
-                  utils.cli_cmd_to_string(e.cmd),
-                  ('Error "%s" occurred' % e.stderr.decode('utf-8').strip())
-                  if isinstance(e, AdbError)
-                  else ('it timed out after %d seconds' % e.timeout),
-              )
+              f'Retry the command "{utils.cli_cmd_to_string(e.cmd)}" since '
+              + (f'Error "{e.stderr.decode("utf-8").strip()}" occurred.'
+              if isinstance(e, AdbError)
+              else f'it timed out after {e.timeout} seconds.')
           )
 
           # Buffer between "adb root" commands.

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -550,14 +550,26 @@ class AdbProxy:
             timeout=ADB_ROOT_ATTEMPT_TIMEOUT_SEC,
             stderr=None,
         )
-      except (AdbError, AdbTimeoutError) as e:
+      except AdbError as e:
         if attempt + 1 < ADB_ROOT_RETRY_ATTEMPTS:
-          logging.debug('Retry root() since Error "%s" occurred.', e)
-          # Buffer between "adb root" commands.
-          time.sleep(retry_interval)
-          retry_interval *= 2
+          logging.debug(
+              'Retry the command "%s" since Error "%s" occurred.'
+              % (
+                  utils.cli_cmd_to_string(e.cmd),
+                  e.stderr.decode('utf-8').strip(),
+              )
+          )
         else:
           raise e
+      except AdbTimeoutError as e:
+        if attempt + 1 < ADB_ROOT_RETRY_ATTEMPTS:
+          logging.debug('Retry root() since Error "%s" occurred.', e)
+        else:
+          raise e
+
+      # Buffer between "adb root" commands.
+      time.sleep(retry_interval)
+      retry_interval *= 2
 
   def __getattr__(self, name):
     def adb_call(args=None, shell=False, timeout=None, stderr=None) -> bytes:

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -842,7 +842,7 @@ class AdbTest(unittest.TestCase):
     mock_exec_cmd.return_value = MOCK_ROOT_SUCCESS_OUTPUT
     output = adb.AdbProxy().root()
     mock_exec_cmd.assert_called_once_with(
-        ['adb', 'root'], shell=False, timeout=10, stderr=None
+        ['adb', 'root'], shell=False, timeout=5, stderr=None
     )
     self.assertEqual(output, MOCK_ROOT_SUCCESS_OUTPUT)
 
@@ -855,7 +855,7 @@ class AdbTest(unittest.TestCase):
     ]
     output = adb.AdbProxy().root()
     mock_exec_cmd.assert_called_with(
-        ['adb', 'root'], shell=False, timeout=10, stderr=None
+        ['adb', 'root'], shell=False, timeout=5, stderr=None
     )
     self.assertEqual(output, MOCK_ROOT_SUCCESS_OUTPUT)
     self.assertEqual(mock_sleep.call_count, 1)
@@ -876,7 +876,7 @@ class AdbTest(unittest.TestCase):
     with self.assertRaisesRegex(adb.AdbError, expected_msg):
       adb.AdbProxy().root()
       mock_exec_cmd.assert_called_with(
-          ['adb', 'root'], shell=False, timeout=10, stderr=None
+          ['adb', 'root'], shell=False, timeout=5, stderr=None
       )
     self.assertEqual(mock_sleep.call_count, adb.ADB_ROOT_RETRY_ATTEMPTS - 1)
     mock_sleep.assert_has_calls([mock.call(10), mock.call(20)])
@@ -892,7 +892,7 @@ class AdbTest(unittest.TestCase):
     ]
     output = adb.AdbProxy().root()
     mock_exec_cmd.assert_called_with(
-        ['adb', 'root'], shell=False, timeout=10, stderr=None
+        ['adb', 'root'], shell=False, timeout=5, stderr=None
     )
     self.assertEqual(output, MOCK_ROOT_SUCCESS_OUTPUT)
     self.assertEqual(mock_sleep.call_count, 1)

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -842,7 +842,7 @@ class AdbTest(unittest.TestCase):
     mock_exec_cmd.return_value = MOCK_ROOT_SUCCESS_OUTPUT
     output = adb.AdbProxy().root()
     mock_exec_cmd.assert_called_once_with(
-        ['adb', 'root'], shell=False, timeout=None, stderr=None
+        ['adb', 'root'], shell=False, timeout=10, stderr=None
     )
     self.assertEqual(output, MOCK_ROOT_SUCCESS_OUTPUT)
 
@@ -855,7 +855,7 @@ class AdbTest(unittest.TestCase):
     ]
     output = adb.AdbProxy().root()
     mock_exec_cmd.assert_called_with(
-        ['adb', 'root'], shell=False, timeout=None, stderr=None
+        ['adb', 'root'], shell=False, timeout=10, stderr=None
     )
     self.assertEqual(output, MOCK_ROOT_SUCCESS_OUTPUT)
     self.assertEqual(mock_sleep.call_count, 1)
@@ -876,10 +876,27 @@ class AdbTest(unittest.TestCase):
     with self.assertRaisesRegex(adb.AdbError, expected_msg):
       adb.AdbProxy().root()
       mock_exec_cmd.assert_called_with(
-          ['adb', 'root'], shell=False, timeout=None, stderr=None
+          ['adb', 'root'], shell=False, timeout=10, stderr=None
       )
     self.assertEqual(mock_sleep.call_count, adb.ADB_ROOT_RETRY_ATTEMPTS - 1)
     mock_sleep.assert_has_calls([mock.call(10), mock.call(20)])
+
+  @mock.patch('time.sleep', return_value=mock.MagicMock())
+  @mock.patch.object(adb.AdbProxy, '_exec_cmd')
+  def test_root_success_with_retry_after_timeout(
+      self, mock_exec_cmd, mock_sleep
+  ):
+    mock_exec_cmd.side_effect = [
+        adb.AdbTimeoutError('adb root', 10, 'S3RIAL'),
+        MOCK_ROOT_SUCCESS_OUTPUT,
+    ]
+    output = adb.AdbProxy().root()
+    mock_exec_cmd.assert_called_with(
+        ['adb', 'root'], shell=False, timeout=10, stderr=None
+    )
+    self.assertEqual(output, MOCK_ROOT_SUCCESS_OUTPUT)
+    self.assertEqual(mock_sleep.call_count, 1)
+    mock_sleep.assert_called_with(10)
 
   def test_has_shell_command_called_correctly(self):
     with mock.patch.object(adb.AdbProxy, '_exec_cmd') as mock_exec_cmd:

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -853,7 +853,15 @@ class AdbTest(unittest.TestCase):
         adb.AdbError('adb root', '', MOCK_ROOT_ERROR_OUTPUT, 1),
         MOCK_ROOT_SUCCESS_OUTPUT,
     ]
-    output = adb.AdbProxy().root()
+    with self.assertLogs(level='DEBUG') as logs:
+      output = adb.AdbProxy().root()
+    self.assertEqual(
+        logs.output,
+        [
+            'DEBUG:root:Retry the command "adb root" since Error "adb: unable to connect for root: closed" occurred.'
+        ],
+    )
+
     mock_exec_cmd.assert_called_with(
         ['adb', 'root'], shell=False, timeout=5, stderr=None
     )
@@ -905,7 +913,15 @@ class AdbTest(unittest.TestCase):
         adb.AdbTimeoutError('adb root', 5, 'S3RIAL'),
         MOCK_ROOT_SUCCESS_OUTPUT,
     ]
-    output = adb.AdbProxy().root()
+    with self.assertLogs(level='DEBUG') as logs:
+      output = adb.AdbProxy().root()
+    self.assertEqual(
+        logs.output,
+        [
+            'DEBUG:root:Retry the command "adb root" since it timed out after 5 seconds.'
+        ],
+    )
+
     mock_exec_cmd.assert_called_with(
         ['adb', 'root'], shell=False, timeout=5, stderr=None
     )

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -887,9 +887,7 @@ class AdbTest(unittest.TestCase):
       self, mock_exec_cmd, mock_sleep
   ):
     mock_exec_cmd.side_effect = adb.AdbTimeoutError('adb root', 5, 'S3RIAL')
-    expected_msg = (
-        'Timed out executing command "adb root" after 5s'
-    )
+    expected_msg = 'Timed out executing command "adb root" after 5s'
     with self.assertRaisesRegex(adb.AdbTimeoutError, expected_msg):
       adb.AdbProxy().root()
       mock_exec_cmd.assert_called_with(

--- a/tests/mobly/controllers/android_device_lib/adb_test.py
+++ b/tests/mobly/controllers/android_device_lib/adb_test.py
@@ -858,7 +858,8 @@ class AdbTest(unittest.TestCase):
     self.assertEqual(
         logs.output,
         [
-            'DEBUG:root:Retry the command "adb root" since Error "adb: unable to connect for root: closed" occurred.'
+            'DEBUG:root:Retry the command "adb root" since Error "%s" occurred.'
+            % MOCK_ROOT_ERROR_OUTPUT.decode()
         ],
     )
 


### PR DESCRIPTION
When using a remote proxied device, `adb root` can destabilize the connection and cause ADB to hang. Retrying the command usually works. We should use a timeout instead of allowing the call to hang indefinitely with no feedback to the user.

Test: mobly test using a remote proxied device no longer hangs indefinitely

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/982)
<!-- Reviewable:end -->
