### PR TITLE
Provide accurate command to fetch device information

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -228,7 +228,9 @@ class SnippetClientV2(client_base.ClientBase):
         for the current user.
     """
     # Validate that the Mobly Snippet app is installed for the current user.
-    out = self._adb.shell(f'pm list package --user {self.user_id}')
+    out = self._adb.shell(
+        f'pm list packages --user {self.user_id} {self.package}'
+    )
     if not utils.grep(f'^package:{self.package}$', out):
       raise errors.ServerStartPreCheckError(
           self._device,
@@ -236,7 +238,7 @@ class SnippetClientV2(client_base.ClientBase):
       )
 
     # Validate that the app is instrumented.
-    out = self._adb.shell('pm list instrumentation')
+    out = self._adb.shell(f'pm list instrumentation {self.package}')
     matched_out = utils.grep(
         f'^instrumentation:{self.package}/{_INSTRUMENTATION_RUNNER_PACKAGE}',
         out,


### PR DESCRIPTION
A long adb command output usually results in large log files (at DEBUG verbosity) and slows down test and upload process. This CL contains small improvements to specify the package name in `pm list packages`/`instrumentation` to suppress all packages being printed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly/983)
<!-- Reviewable:end -->
