### PR TITLE
Allow loading snippets with the same package but different user IDs

### DIFF
--- a/mobly/controllers/android_device_lib/services/snippet_management_service.py
+++ b/mobly/controllers/android_device_lib/services/snippet_management_service.py
@@ -87,7 +87,7 @@ class SnippetManagementService(base_service.BaseService):
       if package == client.package and new_snippet_user_id == client.user_id:
         raise Error(
             self,
-            f'Snippet package "{package}" (user id {client.user_id}) has'
+            f'Snippet package "{package}" (under user ID {client.user_id}) has'
             f' already been loaded under name "{snippet_name}".',
         )
 

--- a/tests/mobly/controllers/android_device_test.py
+++ b/tests/mobly/controllers/android_device_test.py
@@ -1556,9 +1556,12 @@ class AndroidDeviceTest(unittest.TestCase):
       self, MockGetPort, MockSnippetClient, MockFastboot, MockAdbProxy
   ):
     ad = android_device.AndroidDevice(serial='1')
+    ad.adb.current_user_id = 1
+    MockSnippetClient.return_value.user_id = 1
     ad.load_snippet('snippet', MOCK_SNIPPET_PACKAGE_NAME)
     expected_msg = (
-        'Snippet package "%s" has already been loaded under name "snippet".'
+        'Snippet package "%s" \(under user ID 1\) has already been loaded under'
+        ' name "snippet".'
     ) % MOCK_SNIPPET_PACKAGE_NAME
     with self.assertRaisesRegex(android_device.Error, expected_msg):
       ad.load_snippet('snippet2', MOCK_SNIPPET_PACKAGE_NAME)


### PR DESCRIPTION
This is to relax the check in snippet_management_service to allow loading same snippet package with different user IDs.

With this CL, I verified that the same snippet app installed to different users can be loaded and used at the same time.