### PR TITLE
fix: ensure non-zero exit code on TestAbortAll (#960)

### DIFF
--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -79,9 +79,10 @@ def main(argv=None):
         runner.run()
         ok = runner.results.is_all_pass and ok
       except signals.TestAbortAll:
-        pass
+        ok = False
+        logging.error('Test run aborted by TestAbortAll.')
       except Exception:
-        logging.exception('Exception when executing %s.', config.testbed_name)
+        logging.exception('Exception when executing %s.', config.test_bed_name)
         ok = False
   if not ok:
     sys.exit(1)

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -79,8 +79,8 @@ def main(argv=None):
         runner.run()
         ok = runner.results.is_all_pass and ok
       except signals.TestAbortAll:
-        ok = False
         logging.error('Test run aborted by TestAbortAll.')
+        ok = False
       except Exception:
         logging.exception('Exception when executing %s.', config.testbed_name)
         ok = False

--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -82,7 +82,7 @@ def main(argv=None):
         ok = False
         logging.error('Test run aborted by TestAbortAll.')
       except Exception:
-        logging.exception('Exception when executing %s.', config.test_bed_name)
+        logging.exception('Exception when executing %s.', config.testbed_name)
         ok = False
   if not ok:
     sys.exit(1)

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -67,14 +67,19 @@ class TestRunnerTest(unittest.TestCase):
 
   def test_main_exits_with_error_on_test_abort_all(self):
     """Verifies that main exits with 1 when TestAbortAll is raised."""
-    with mock.patch('mobly.test_runner.TestRunner') as mock_test_runner:
-      mock_test_runner.return_value.run.side_effect = signals.TestAbortAll('Abort!')
+    tmp_config_path = os.path.join(tempfile.gettempdir(), 'dummy_config.yaml')
+    with open(tmp_config_path, 'w') as f:
+      f.write('TestBeds: [{Name: "dummy"}]')
 
-      with self.assertRaises(SystemExit) as cm:
-        # Using a dummy config path as the runner is mocked
-        test_runner.main(['-c', '/tmp/nonexistent_config.yaml'])
-
-      self.assertEqual(cm.exception.code, 1)
+    try:
+      with mock.patch('mobly.test_runner.TestRunner', autospec=True) as mock_tr:
+        mock_tr.return_value.run.side_effect = signals.TestAbortAll('Abort!')
+        with self.assertRaises(SystemExit) as cm:
+          test_runner.main(['-c', tmp_config_path])
+        self.assertEqual(cm.exception.code, 1)
+    finally:
+      if os.path.exists(tmp_config_path):
+        os.remove(tmp_config_path)
 
   def test_run_twice(self):
     """Verifies that:

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -65,6 +65,17 @@ class TestRunnerTest(unittest.TestCase):
         expected_info_dict['Controller Info'], info.controller_info
     )
 
+  def test_main_exits_with_error_on_test_abort_all(self):
+    """Verifies that main exits with 1 when TestAbortAll is raised."""
+    with mock.patch('mobly.test_runner.TestRunner') as mock_test_runner:
+      mock_test_runner.return_value.run.side_effect = signals.TestAbortAll('Abort!')
+
+      with self.assertRaises(SystemExit) as cm:
+        # Using a dummy config path as the runner is mocked
+        test_runner.main(['-c', '/tmp/nonexistent_config.yaml'])
+
+      self.assertEqual(cm.exception.code, 1)
+
   def test_run_twice(self):
     """Verifies that:
     1. Repeated run works properly.


### PR DESCRIPTION
Ensures that Mobly returns a non-zero exit code when `TestAbortAll` is raised, 
preventing CI/CD systems from incorrectly reporting success.

Fixes #960