### PR TITLE
Fix incorrect timing of the "RPC request sent" log.

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -588,6 +588,7 @@ class SnippetClientV2(client_base.ClientBase):
     try:
       self._client.write(f'{message}\n'.encode('utf8'))
       self._client.flush()
+      self.log.debug('RPC request sent.')
     except socket.error as e:
       raise errors.Error(
           self._device,

--- a/mobly/snippet/client_base.py
+++ b/mobly/snippet/client_base.py
@@ -289,7 +289,6 @@ class ClientBase(abc.ABC):
 
       self.log.debug('Sending RPC request %s.', request)
       response = self.send_rpc_request(request)
-      self.log.debug('RPC request sent.')
 
       if self.verbose_logging or _MAX_RPC_RESP_LOGGING_LENGTH >= len(response):
         self.log.debug('Snippet received: %s', response)


### PR DESCRIPTION
Before this PR, the log message was printed after receiving the RPC response, which is incorrect.