### PR TITLE
Fix type warning for invalid escape in string

### DIFF
--- a/mobly/controllers/attenuator_lib/telnet_scpi_client.py
+++ b/mobly/controllers/attenuator_lib/telnet_scpi_client.py
@@ -70,7 +70,7 @@ class TelnetScpiClient:
       return None
 
     match_idx, match_val, ret_text = self._tn.expect(
-        [_ascii_string("\S+" + self.rx_cmd_separator)], 1
+        [_ascii_string(r"\S+" + self.rx_cmd_separator)], 1
     )
 
     if match_idx == -1:


### PR DESCRIPTION
This change will fix the following type checker warning:

```
mobly/controllers/attenuator_lib/telnet_scpi_client.py:73: SyntaxWarning: invalid escape sequence '\S'
  [_ascii_string("\S+" + self.rx_cmd_separator)], 1
```