### PR TITLE
fix: remove accidental debug print(ok) from run_suite_class

### DIFF
--- a/mobly/suite_runner.py
+++ b/mobly/suite_runner.py
@@ -366,7 +366,6 @@ def run_suite_class(argv=None):
         suite_record.suite_begin()
         runner.run()
         ok = runner.results.is_all_pass
-        print(ok)
       except signals.TestAbortAll:
         pass
     finally:


### PR DESCRIPTION
Related to #950

In `run_suite_class()` in `suite_runner.py`, there is an accidental debug `print(ok)` statement at line 369 that prints `True` or `False` to the console after every test run.

This was reported in issue #950 where the user noticed the output:
```
Test results: Error 0, Executed 3, Failed 0, Passed 3, Requested 3, Skipped 0
True
```

The `True` on the last line is from `print(ok)` and should not be there. This PR removes it.