### PR TITLE
fix: set ok=False when TestAbortAll is raised in run_suite_class

### DIFF
--- a/mobly/suite_runner.py
+++ b/mobly/suite_runner.py
@@ -368,7 +368,7 @@ def run_suite_class(argv=None):
         ok = runner.results.is_all_pass
         print(ok)
       except signals.TestAbortAll:
-        pass
+        ok = False
     finally:
       suite.teardown_suite()
       suite_record.suite_end()


### PR DESCRIPTION
Related to #950 and #960

## Problem

In `run_suite_class()` in `suite_runner.py`, when `signals.TestAbortAll` is raised, the `except` block only has `pass` and does not set `ok = False`. This means if a test aborts before any failures, the suite exits with code 0 instead of 1.

This is the same issue that was fixed in `test_runner.py` by PR #997 for issue #960, but `run_suite_class()` in `suite_runner.py` was missed.

## Fix

Change `pass` to `ok = False` in the `except signals.TestAbortAll` block so that aborting a test suite always results in a non-zero exit code.