### PR TITLE
fix: remove accidental debug print(ok) from run_suite_class (fixes #1005)

### DIFF
--- a/mobly/suite_runner.py
+++ b/mobly/suite_runner.py
@@ -366,7 +366,6 @@ def run_suite_class(argv=None):
         suite_record.suite_begin()
         runner.run()
         ok = runner.results.is_all_pass
-        print(ok)
       except signals.TestAbortAll:
         pass
     finally:


### PR DESCRIPTION
Fixes #1005

## Problem
There is an accidental debug `print(ok)` statement at line 369 of `suite_runner.py` that prints `True` or `False` to stdout after every test run.

Users see unexpected output like:
```
Test results: Error 0, Executed 3, Failed 0, Passed 3, Requested 3, Skipped 0
True
```

The `True` on the last line is from `print(ok)` and should not be there.

## Fix
Remove the `print(ok)` debug statement from `run_suite_class()`.