### PR TITLE
Adopt Python 3.8-3.9 language & typing features

### DIFF
--- a/mobly/base_test.py
+++ b/mobly/base_test.py
@@ -640,7 +640,7 @@ class BaseTestClass:
         executed.
     """
     func_name = func.__name__
-    procedure_name = func_name[1:] if func_name[0] == '_' else func_name
+    procedure_name = func_name.removeprefix('_')
     with self._log_test_stage(procedure_name):
       try:
         # Pass a copy of the record instead of the actual object so that it

--- a/mobly/controllers/android_device_lib/adb.py
+++ b/mobly/controllers/android_device_lib/adb.py
@@ -333,8 +333,7 @@ class AdbProxy:
         continue
       name = name.strip()[1:-1]
       # Remove any square bracket from either end of the value string.
-      if value and value[0] == '[':
-        value = value[1:]
+      value = value.removeprefix('[')
       results[name] = value
     return results
 

--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -18,7 +18,6 @@ import enum
 import json
 import re
 import socket
-from typing import Dict, Union
 
 from mobly import utils
 from mobly.controllers.android_device_lib import adb
@@ -114,10 +113,10 @@ class Config:
     user_id: The user id under which to launch the snippet process.
   """
 
-  am_instrument_options: Dict[str, str] = dataclasses.field(
+  am_instrument_options: dict[str, str] = dataclasses.field(
       default_factory=dict
   )
-  user_id: Union[int, None] = None
+  user_id: int | None = None
 
 
 class ConnectionHandshakeCommand(enum.Enum):

--- a/mobly/logger.py
+++ b/mobly/logger.py
@@ -17,7 +17,7 @@ import logging
 import os
 import re
 import sys
-from typing import Any, MutableMapping, Tuple
+from typing import Any, MutableMapping
 
 from mobly import records
 from mobly import utils
@@ -393,7 +393,7 @@ class PrefixLoggerAdapter(logging.LoggerAdapter):
   """
 
   _KWARGS_TYPE = MutableMapping[str, Any]
-  _PROCESS_RETURN_TYPE = Tuple[str, _KWARGS_TYPE]
+  _PROCESS_RETURN_TYPE = tuple[str, _KWARGS_TYPE]
 
   # The key of log_preifx item in the dict self.extra
   EXTRA_KEY_LOG_PREFIX: str = 'log_prefix'

--- a/mobly/utils.py
+++ b/mobly/utils.py
@@ -29,7 +29,7 @@ import string
 import subprocess
 import time
 import traceback
-from typing import Literal, Tuple, overload
+from typing import Literal, overload
 
 import portpicker
 
@@ -398,7 +398,7 @@ def run_command(
     cwd=...,
     env=...,
     universal_newlines: Literal[False] = ...,
-) -> Tuple[int, bytes, bytes]:
+) -> tuple[int, bytes, bytes]:
   ...
 
 
@@ -412,7 +412,7 @@ def run_command(
     cwd=...,
     env=...,
     universal_newlines: Literal[True] = ...,
-) -> Tuple[int, str, str]:
+) -> tuple[int, str, str]:
   ...
 
 

--- a/tests/lib/mock_android_device.py
+++ b/tests/lib/mock_android_device.py
@@ -169,7 +169,7 @@ class MockAdbProxy:
 
     def adb_call(*args, **kwargs):
       arg_str = ' '.join(str(elem) for elem in args)
-      return arg_str
+      return bytes(arg_str, 'utf-8')
 
     return adb_call
 


### PR DESCRIPTION
- Use built-in generic collections (tuple, dict) and union operators (PEP 585 / PEP 604) in mobly/utils.py, mobly/logger.py, and mobly/controllers/android_device_lib/snippet_client_v2.py, removing legacy imports from typing.
- Replace string slicing with str.removeprefix() (PEP 616) in mobly/base_test.py and mobly/controllers/android_device_lib/adb.py.
- Adopt walrus operator := (PEP 572) for regex pattern matching in mobly/controllers/android_device_lib/snippet_client_v2.py and snippet_client.py.
- Fix string decoding bug in adb.list_occupied_adb_ports when out is already a string.