### PR TITLE
Exit with status code 1 when a test aborts all tests

### DIFF
--- a/mobly/test_runner.py
+++ b/mobly/test_runner.py
@@ -79,7 +79,7 @@ def main(argv=None):
         runner.run()
         ok = runner.results.is_all_pass and ok
       except signals.TestAbortAll:
-        pass
+        ok = False
       except Exception:
         logging.exception('Exception when executing %s.', config.testbed_name)
         ok = False

--- a/tests/mobly/test_runner_test.py
+++ b/tests/mobly/test_runner_test.py
@@ -337,6 +337,25 @@ class TestRunnerTest(unittest.TestCase):
 
   @mock.patch(
       'mobly.test_runner._find_test_class',
+      return_value=type('SampleTest', (), {}),
+  )
+  @mock.patch(
+      'mobly.test_runner.config_parser.load_test_config_file',
+      return_value=[config_parser.TestRunConfig()],
+  )
+  @mock.patch('mobly.test_runner.TestRunner')
+  @mock.patch('sys.exit')
+  def test_main_with_abort_all(
+      self, mock_exit, mock_test_runner_class, mock_config, mock_find_test
+  ):
+    mock_runner = mock.MagicMock()
+    mock_runner.run.side_effect = signals.TestAbortAll('Aborting all tests.')
+    mock_test_runner_class.return_value = mock_runner
+    test_runner.main(['-c', 'some/path/foo.yaml'])
+    mock_exit.assert_called_once_with(1)
+
+  @mock.patch(
+      'mobly.test_runner._find_test_class',
       return_value=integration_test.IntegrationTest,
   )
   @mock.patch('sys.exit')


### PR DESCRIPTION
Fixes #960

`test_runner.main()` caught `signals.TestAbortAll` and did nothing, leaving `ok` unchanged, so a run that aborted before any failure or error was recorded exited with status code 0. If a failure occurred before the abort, the exit code was 1 — inconsistent for the same abort. The handler now sets `ok = False`, so an abort always exits 1.

Added `test_main_with_abort_all` to `tests/mobly/test_runner_test.py`; it fails on the current code (`sys.exit` never called) and passes with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
