### PR TITLE
Fix logcat pause/resume timestamp format and state cleanup

### DIFF
--- a/mobly/controllers/android_device_lib/services/logcat.py
+++ b/mobly/controllers/android_device_lib/services/logcat.py
@@ -250,6 +250,7 @@ class Logcat(base_service.BaseService):
     # Add spaces at beginning and at last to fix this issue.
     if self._last_connection_time is not None:
       t_argument_value = self._last_connection_time
+      self._last_connection_time = None
     else:
       t_argument_value = '1'
     cmd = ' "%s" -s %s logcat -v threadtime -T "%s" %s >> "%s" ' % (
@@ -287,11 +288,11 @@ class Logcat(base_service.BaseService):
     """
     self._stop()
     try:
-      response = self._ad.adb.shell(['date', '-Is', r'+%Y-%m-%d\ %H:%M:%S.%N'])
+      response = self._ad.adb.shell(['date', r'+%Y-%m-%d\ %H:%M:%S.%3N'])
       if response:
         self._last_connection_time = response.decode('utf-8').strip()
-    except adb.AdbError as e:
-      self._ad.log.exception('Failed to get host time.')
+    except adb.AdbError:
+      self._ad.log.exception('Failed to get device time.')
 
   def resume(self):
     """Resumes a paused logcat service."""

--- a/tests/mobly/controllers/android_device_lib/services/logcat_test.py
+++ b/tests/mobly/controllers/android_device_lib/services/logcat_test.py
@@ -67,7 +67,7 @@ MOCK_LOGPERSIST_START_MISSING_ADB_ERROR = adb.AdbError(
     0,
 )
 
-_DATE_COMMAND = ['date', '-Is', r'+%Y-%m-%d\ %H:%M:%S.%N']
+_DATE_COMMAND = ['date', r'+%Y-%m-%d\ %H:%M:%S.%3N']
 
 
 class LogcatTest(unittest.TestCase):
@@ -287,6 +287,7 @@ class LogcatTest(unittest.TestCase):
     start_proc_mock.assert_called_with(
         adb_cmd % (ad_serial, '"%s" ' % expected_log_path), shell=True
     )
+    self.assertIsNone(logcat_service._last_connection_time)
 
   @mock.patch(
       'mobly.controllers.android_device_lib.adb.AdbProxy',


### PR DESCRIPTION
Follow up minor fixes to the logcat pause timestamp PR.
- Remove conflicting -Is flag from adb shell date command in Logcat.pause().
- Use %3N instead of %N to output 3-digit milliseconds (YYYY-MM-DD HH:MM:SS.mmm), matching the timestamp format expected by adb logcat -T <time>.
- Reset self._last_connection_time to None in Logcat._start() after consuming it to prevent stale timestamp reuse.
- Fix inaccurate exception log message from "host time" to "device time".