### PR TITLE
Support setting prefix args in Android snippet's `am` cmd

### DIFF
--- a/mobly/controllers/android_device_lib/snippet_client_v2.py
+++ b/mobly/controllers/android_device_lib/snippet_client_v2.py
@@ -111,12 +111,15 @@ class Config:
       is because Mobly snippet runner changes the subsequent instrumentation
       process.
     user_id: The user id under which to launch the snippet process.
+    am_cmd_prefix: An optional prefix string prepended directly before the `am`
+      command (e.g. `'CLASSPATH=/data/local/tmp/app.apk'` or `'env ...'`).
   """
 
   am_instrument_options: dict[str, str] = dataclasses.field(
       default_factory=dict
   )
   user_id: int | None = None
+  am_cmd_prefix: str | None = None
 
 
 class ConnectionHandshakeCommand(enum.Enum):
@@ -313,6 +316,8 @@ class SnippetClientV2(client_base.ClientBase):
         snippet_package=self.package,
         instrument_options=option_str,
     )
+    if self._config.am_cmd_prefix:
+      cmd = f'{self._config.am_cmd_prefix.strip()} {cmd}'
     self._proc = self._run_adb_cmd(cmd)
 
     # Check protocol version and get the device port

--- a/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
+++ b/tests/mobly/controllers/android_device_lib/snippet_client_v2_test.py
@@ -700,6 +700,35 @@ class SnippetClientV2Test(unittest.TestCase):
       'mobly.controllers.android_device_lib.snippet_client_v2.'
       'utils.start_standing_subprocess'
   )
+  def test_start_server_with_am_cmd_prefix(self, mock_start_subprocess):
+    """Checks the starting server command with custom am command prefix."""
+    config = snippet_client_v2.Config(
+        am_cmd_prefix='CLASSPATH=/data/local/tmp/app.apk',
+    )
+    self._make_client(config=config)
+    self._mock_server_process_starting_response(mock_start_subprocess)
+
+    self.client.start_server()
+
+    start_cmd_list = [
+        'adb',
+        'shell',
+        (
+            'CLASSPATH=/data/local/tmp/app.apk'
+            f'  am instrument --user {MOCK_USER_ID} -w -e action start  '
+            f'{MOCK_SERVER_PATH}'
+        ),
+    ]
+    self.assertListEqual(
+        mock_start_subprocess.call_args_list,
+        [mock.call(start_cmd_list, shell=False)],
+    )
+    self.assertEqual(self.client.device_port, 1234)
+
+  @mock.patch(
+      'mobly.controllers.android_device_lib.snippet_client_v2.'
+      'utils.start_standing_subprocess'
+  )
   def test_start_server_server_crash(self, mock_start_standing_subprocess):
     """Tests that starting server process crashes."""
     self._make_client()


### PR DESCRIPTION
When launching snippet servers via `am instrument`, users sometimes need to prefix the `am` command with environment variables or wrappers like `CLASSPATH=/path/to/extra.apk` or `env ...`