### PR TITLE
Fix sphinx-apidoc CLI argument order in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,13 +223,13 @@ def run_apidoc(_):
 
   apidoc.main(
       [
-          '-o',
-          output_dir,
-          module_dir,
           '--force',
           '--separate',
           '--module-first',
           '--no-toc',
+          '-o',
+          output_dir,
+          module_dir,
       ]
       + excludes
   )


### PR DESCRIPTION
Move option flags before positional module_dir and excludes arguments in apidoc.main() call to prevent argparse from rejecting exclude patterns as unrecognized arguments.