### PR TITLE
Fix millisecond zero-padding in epoch_to_log_line_timestamp

### DIFF
--- a/mobly/logger.py
+++ b/mobly/logger.py
@@ -125,7 +125,7 @@ def epoch_to_log_line_timestamp(epoch_time, time_zone=None):
   """
   s, ms = divmod(epoch_time, 1000)
   d = datetime.datetime.fromtimestamp(s, tz=time_zone)
-  return d.strftime('%m-%d %H:%M:%S.') + str(ms)
+  return d.strftime('%m-%d %H:%M:%S.') + f'{ms:03d}'
 
 
 def get_log_line_timestamp(delta=None):

--- a/tests/mobly/logger_test.py
+++ b/tests/mobly/logger_test.py
@@ -38,6 +38,19 @@ class LoggerTest(unittest.TestCase):
     )
     self.assertEqual('07-21 20:51:02.116', actual_stamp)
 
+  def test_epoch_to_log_line_timestamp_pads_milliseconds(self):
+    for epoch_time, expected_stamp in [
+        (1469134262000, '07-21 20:51:02.000'),
+        (1469134262005, '07-21 20:51:02.005'),
+        (1469134262050, '07-21 20:51:02.050'),
+        (1469134262099, '07-21 20:51:02.099'),
+    ]:
+      actual_stamp = logger.epoch_to_log_line_timestamp(
+          epoch_time, time_zone=datetime.timezone.utc
+      )
+      self.assertEqual(expected_stamp, actual_stamp)
+      self.assertTrue(logger.is_valid_logline_timestamp(actual_stamp))
+
   def test_is_valid_logline_timestamp(self):
     self.assertTrue(logger.is_valid_logline_timestamp('06-21 17:44:42.336'))
 


### PR DESCRIPTION
## Problem

`mobly.logger.epoch_to_log_line_timestamp` produced a non-zero-padded millisecond component:

```python
return d.strftime('%m-%d %H:%M:%S.') + str(ms)
```

For epoch values whose millisecond remainder is below 100, `str(ms)` drops the leading zeros. For example `epoch_to_log_line_timestamp(1469134262005, time_zone=datetime.timezone.utc)` returned `'07-21 20:51:02.5'` instead of `'07-21 20:51:02.005'`.

This is inconsistent with the canonical log line timestamp format used everywhere else in the module: `get_log_line_timestamp` returns exactly three millisecond digits, `logline_timestamp_re` matches `\d\d\d` after the dot, and `is_valid_logline_timestamp` rejects anything else. Such malformed timestamps also compare incorrectly with `logline_timestamp_comparator`, which relies on fixed-width fields.

## Fix

Zero-pad the millisecond component to three digits:

```python
return d.strftime('%m-%d %H:%M:%S.') + f'{ms:03d}'
```

## Test

Added `test_epoch_to_log_line_timestamp_pads_milliseconds` covering millisecond remainders of 0, 5, 50 and 99, asserting both the exact output and that `is_valid_logline_timestamp` accepts it.

`python -m pytest tests/mobly/logger_test.py` passes (27 passed).